### PR TITLE
feat: ncurses terminal UI (receiver-tui)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ GST_LIBDIR = /usr/lib/x86_64-linux-gnu/gstreamer-1.0
 GST_SCANNER = /usr/lib/x86_64-linux-gnu/gstreamer1.0/gstreamer-1.0/gst-plugin-scanner
 VERSION = $(shell grep "version:" meson.build | head -1 | sed "s/.*'\(.*\)'.*/\1/")
 
-.PHONY: build install clean deb run appimage \
+.PHONY: build install clean deb run run-tui appimage \
         flatpak-build flatpak-run flatpak-lint-manifest flatpak-lint-repo flatpak-submit \
         translations-check translations-update
 
@@ -31,6 +31,13 @@ run: build
 	XDG_DATA_DIRS=$(CURDIR)/data:/usr/share \
 	LOCALEDIR=$(CURDIR)/builddir/po \
 	./builddir/receiver
+
+run-tui: build
+	glib-compile-schemas data/
+	GSETTINGS_SCHEMA_DIR=$(CURDIR)/data \
+	XDG_DATA_DIRS=$(CURDIR)/data:/usr/share \
+	LOCALEDIR=$(CURDIR)/builddir/po \
+	./builddir/receiver-tui
 
 deb:
 	dpkg-buildpackage -us -uc -b

--- a/meson.build
+++ b/meson.build
@@ -43,6 +43,7 @@ core_sources = files(
   'src/services/lastfm.vala',
   'src/services/scrobbler.vala',
   'src/services/history_store.vala',
+  'src/services/mpris.vala',
 )
 
 core_deps = [
@@ -60,7 +61,6 @@ core_deps = [
 gui_sources = files(
   'src/main.vala',
   'src/application.vala',
-  'src/services/mpris.vala',
   'src/services/image_loader.vala',
   'src/services/song_downloader.vala',
   'src/widgets/window.vala',

--- a/meson.build
+++ b/meson.build
@@ -75,6 +75,7 @@ gui_sources = files(
 # Vala compiler arguments
 add_project_arguments([
   '--target-glib=2.76',
+  '--vapidir', meson.current_source_dir() / 'vapi',
 ], language: 'vala')
 
 add_project_arguments('-DRECEIVER_APP_VERSION="' + meson.project_version() + '"', language: 'c')
@@ -104,6 +105,22 @@ executable('receiver',
   ],
   install: true
 )
+
+# Build ncurses terminal UI (optional, second frontend over the core)
+if get_option('tui')
+  ncursesw_dep = dependency('ncursesw')
+  executable('receiver-tui',
+    files(
+      'src/tui/main.vala',
+      'vapi/posix-extras.vapi',
+    ),
+    dependencies: [
+      receiver_core_dep,
+      ncursesw_dep,
+    ],
+    install: true
+  )
+endif
 
 # GSettings schema
 gnome.compile_schemas(

--- a/meson.build
+++ b/meson.build
@@ -9,12 +9,18 @@ i18n = import('i18n')
 gnome = import('gnome')
 
 # Dependencies (with Vala bindings)
-gtk4_dep = dependency('gtk4', version: '>= 4.10')
-adw_dep = dependency('libadwaita-1', version: '>= 1.4')
+# Core (GUI-independent) dependencies
+glib_dep = dependency('glib-2.0')
+gobject_dep = dependency('gobject-2.0')
+gio_dep = dependency('gio-2.0')
 gst_dep = dependency('gstreamer-1.0')
 soup_dep = dependency('libsoup-3.0')
 json_dep = dependency('json-glib-1.0')
 sqlite_dep = dependency('sqlite3')
+
+# GUI (GTK frontend) dependencies
+gtk4_dep = dependency('gtk4', version: '>= 4.10')
+adw_dep = dependency('libadwaita-1', version: '>= 1.4')
 
 # ytdl subproject
 ytdl_subproject = subproject('ytdl')
@@ -24,10 +30,9 @@ ytdl_dep = ytdl_subproject.get_variable('ytdl_dep')
 add_project_arguments('-DGETTEXT_PACKAGE="' + meson.project_name() + '"', language: 'c')
 add_project_arguments('-DG_LOG_DOMAIN="receiver"', language: 'c')
 
-# Source files
-sources = files(
-  'src/main.vala',
-  'src/application.vala',
+# Core library: GUI-independent logic (models, utils, services).
+# Shared by the GTK frontend and any future frontend (e.g. a curses TUI).
+core_sources = files(
   'src/models/station.vala',
   'src/utils/metadata_parser.vala',
   'src/utils/metadata_extractor.vala',
@@ -35,12 +40,29 @@ sources = files(
   'src/services/app_state.vala',
   'src/services/station_store.vala',
   'src/services/player.vala',
-  'src/services/mpris.vala',
-  'src/services/image_loader.vala',
-  'src/services/song_downloader.vala',
   'src/services/lastfm.vala',
   'src/services/scrobbler.vala',
   'src/services/history_store.vala',
+)
+
+core_deps = [
+  glib_dep,
+  gobject_dep,
+  gio_dep,
+  gst_dep,
+  soup_dep,
+  json_dep,
+  sqlite_dep,
+]
+
+# GTK frontend sources. The three services below still depend on GTK/Adw/Gdk
+# (image_loader, mpris, song_downloader) and stay here until they are decoupled.
+gui_sources = files(
+  'src/main.vala',
+  'src/application.vala',
+  'src/services/mpris.vala',
+  'src/services/image_loader.vala',
+  'src/services/song_downloader.vala',
   'src/widgets/window.vala',
   'src/widgets/favourites_page.vala',
   'src/widgets/station_list.vala',
@@ -58,16 +80,26 @@ add_project_arguments([
 add_project_arguments('-DRECEIVER_APP_VERSION="' + meson.project_version() + '"', language: 'c')
 add_project_arguments('-DLOCALEDIR="' + get_option('prefix') / get_option('localedir') + '"', language: 'c')
 
-# Build executable
+# Build core static library
+libreceiver_core = static_library('receiver-core',
+  core_sources,
+  dependencies: core_deps,
+  install: false,
+)
+
+receiver_core_dep = declare_dependency(
+  link_with: libreceiver_core,
+  include_directories: include_directories('.'),
+  dependencies: core_deps,
+)
+
+# Build GTK executable
 executable('receiver',
-  sources,
+  gui_sources,
   dependencies: [
+    receiver_core_dep,
     gtk4_dep,
     adw_dep,
-    gst_dep,
-    soup_dep,
-    json_dep,
-    sqlite_dep,
     ytdl_dep,
   ],
   install: true

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,2 @@
+option('tui', type: 'boolean', value: true,
+  description: 'Build the ncurses terminal UI (receiver-tui)')

--- a/src/application.vala
+++ b/src/application.vala
@@ -1,7 +1,7 @@
 // Main application class
 namespace Receiver {
 
-    public class Application : Adw.Application {
+    public class Application : Adw.Application, MprisHost {
         public StationStore store { get; private set; }
         public Player player { get; private set; }
         public Scrobbler scrobbler { get; private set; }
@@ -12,6 +12,14 @@ namespace Receiver {
                 application_id: "io.github.meehow.Receiver",
                 flags: ApplicationFlags.DEFAULT_FLAGS | ApplicationFlags.NON_UNIQUE
             );
+        }
+
+        // MprisHost
+        public void raise() {
+            var win = active_window;
+            if (win != null) {
+                win.present();
+            }
         }
 
         protected override void startup() {

--- a/src/models/station.vala
+++ b/src/models/station.vala
@@ -5,6 +5,8 @@ namespace Receiver {
     public const int SOURCE_SOMAFM = 2;
 
     public class Station : Object {
+        public const string IMAGE_BASE_URL = "https://receiver.808bits.com/images/";
+
         public int64 id { get; set; }
         public int source { get; set; }
         public string name { get; set; }

--- a/src/services/image_loader.vala
+++ b/src/services/image_loader.vala
@@ -6,7 +6,6 @@ namespace Receiver {
         private static ImageLoader? _instance;
         private Soup.Session session;
         private string cache_dir;
-        public const string IMAGE_BASE_URL = "https://receiver.808bits.com/images/";
 
         public static ImageLoader get_default() {
             if (_instance == null) {
@@ -54,7 +53,7 @@ namespace Receiver {
             loading.set(image_hash, true);
 
             try {
-                var url = IMAGE_BASE_URL + image_hash.to_string();
+                var url = Station.IMAGE_BASE_URL + image_hash.to_string();
                 var msg = new Soup.Message("GET", url);
                 var stream = yield session.send_async(msg, Priority.DEFAULT, null);
 

--- a/src/services/mpris.vala
+++ b/src/services/mpris.vala
@@ -1,12 +1,19 @@
 // MPRIS2 D-Bus integration for desktop media controls
 namespace Receiver {
 
+    // Frontend hooks the MPRIS layer needs but that differ per UI: raising the
+    // app and quitting. Implemented by the GTK app and the TUI.
+    public interface MprisHost : Object {
+        public abstract void raise();
+        public abstract void quit();
+    }
+
     [DBus(name = "org.mpris.MediaPlayer2")]
     public class MprisRoot : Object {
-        private Gtk.Application app;
+        private MprisHost host;
 
-        public MprisRoot(Gtk.Application app) {
-            this.app = app;
+        public MprisRoot(MprisHost host) {
+            this.host = host;
         }
 
         public bool can_quit { get { return true; } }
@@ -18,14 +25,11 @@ namespace Receiver {
         public string[] supported_mime_types { owned get { return {}; } }
 
         public void raise() throws GLib.Error {
-            var win = app.active_window;
-            if (win != null) {
-                win.present();
-            }
+            host.raise();
         }
 
         public void quit() throws GLib.Error {
-            app.quit();
+            host.quit();
         }
     }
 
@@ -91,7 +95,7 @@ namespace Receiver {
                     meta.insert("xesam:artist", new Variant.strv({station.name}));
 
                     if (station.image_hash != 0) {
-                        meta.insert("mpris:artUrl", ImageLoader.IMAGE_BASE_URL + station.image_hash.to_string());
+                        meta.insert("mpris:artUrl", Station.IMAGE_BASE_URL + station.image_hash.to_string());
                     }
                 }
 
@@ -231,7 +235,7 @@ namespace Receiver {
     public class MprisService : Object {
         private uint owner_id;
 
-        public MprisService(Gtk.Application app, Player player) {
+        public MprisService(MprisHost host, Player player) {
             // Snap only allows simple names; Flatpak requires reverse-DNS
             var snap = Environment.get_variable("SNAP_NAME");
             var bus_name = snap != null
@@ -244,7 +248,7 @@ namespace Receiver {
                 BusNameOwnerFlags.NONE,
                 (conn) => {
                     try {
-                        conn.register_object("/org/mpris/MediaPlayer2", new MprisRoot(app));
+                        conn.register_object("/org/mpris/MediaPlayer2", new MprisRoot(host));
                         conn.register_object("/org/mpris/MediaPlayer2", new MprisPlayer(player, conn));
                         message("MPRIS D-Bus registered");
                     } catch (IOError e) {

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -1,16 +1,16 @@
 /*
  * Receiver TUI — ncurses frontend over libreceiver-core.
  *
- * This skeleton establishes the runtime: curses runs as a guest of the GLib
- * main loop (so the core's GStreamer/Soup work keeps ticking), stdin is read
- * non-blocking via a GLib fd watch, repaints are coalesced, and the terminal
- * is always restored on exit. The actual station/player UI is layered on top
- * of this in the next step.
+ * Browse + play MVP: a scrollable station list backed by StationStore with
+ * incremental search, driving the shared Player. Curses runs as a guest of the
+ * GLib main loop so the core's async GStreamer/Soup work keeps ticking; stdin
+ * is read non-blocking, repaints are coalesced, and the terminal is always
+ * restored on exit.
  */
 namespace Receiver {
 
     public class Tui : Object {
-        // Signal numbers (GLib profile has no Posix.Signal binding).
+        // Signal numbers (the GLib profile has no Posix.Signal binding).
         private const int SIGNAL_INT = 2;
         private const int SIGNAL_TERM = 15;
 
@@ -18,10 +18,20 @@ namespace Receiver {
         private const int PAIR_HEADER = 1;
         private const int PAIR_STATUS = 2;
 
+        private const double VOLUME_STEP = 0.05;
+
         private MainLoop loop = new MainLoop ();
         private unowned Curses.Window scr;
         private IOChannel stdin_channel;
         private bool needs_redraw = true;
+
+        private StationStore store = new StationStore ();
+        private Player player = new Player ();
+
+        private int selected = 0;
+        private int scroll = 0;
+        private bool search_active = false;
+        private string search_text = "";
 
         public int run () {
             Intl.setlocale (LocaleCategory.ALL, "");
@@ -31,17 +41,20 @@ namespace Receiver {
                 return 1;
             }
 
+            // Skip language/country filtering ("all" bypasses those clauses).
+            store.language_filter = "all";
+            store.country_filter = "all";
+            wire_core ();
+            load_database ();
+
             init_screen ();
 
-            // Restore the terminal no matter how we are asked to stop.
             Unix.signal_add (SIGNAL_INT, () => { loop.quit (); return Source.REMOVE; });
             Unix.signal_add (SIGNAL_TERM, () => { loop.quit (); return Source.REMOVE; });
 
-            // Non-blocking stdin driven by the main loop, so async core work runs.
             stdin_channel = new IOChannel.unix_new (0);
             stdin_channel.add_watch (IOCondition.IN, on_input);
 
-            // Paint once up front, then coalesce later repaints (~30 fps cap).
             render ();
             needs_redraw = false;
             Timeout.add (33, () => {
@@ -54,8 +67,41 @@ namespace Receiver {
 
             loop.run ();
 
+            AppState.get_default ().flush ();
             Curses.endwin ();
             return 0;
+        }
+
+        private void wire_core () {
+            store.items_changed.connect (() => {
+                clamp_selection ();
+                needs_redraw = true;
+            });
+            player.state_changed.connect (() => { needs_redraw = true; });
+            player.metadata_changed.connect (() => { needs_redraw = true; });
+            player.stream_info_changed.connect (() => { needs_redraw = true; });
+        }
+
+        // Mirror the GTK app: look through XDG data dirs, then fall back to the
+        // in-tree data dir so the binary runs straight from the build tree.
+        private void load_database () {
+            foreach (var dir in Environment.get_system_data_dirs ()) {
+                if (try_open_db (Path.build_filename (dir, "receiver", "receiver.db"))) {
+                    return;
+                }
+            }
+            if (try_open_db (Path.build_filename (Environment.get_current_dir (),
+                                                  "data", "receiver", "receiver.db"))) {
+                return;
+            }
+        }
+
+        private bool try_open_db (string path) {
+            if (FileUtils.test (path, FileTest.EXISTS)) {
+                store.open (path);
+                return true;
+            }
+            return false;
         }
 
         private void init_screen () {
@@ -74,19 +120,76 @@ namespace Receiver {
             }
         }
 
+        // --- Input -----------------------------------------------------------
+
         private bool on_input (IOChannel source, IOCondition condition) {
             int ch;
             while ((ch = scr.getch ()) != Curses.ERR) {
-                dispatch (ch);
+                if (search_active) {
+                    handle_search_key (ch);
+                } else {
+                    handle_key (ch);
+                }
             }
             return Source.CONTINUE;
         }
 
-        private void dispatch (int ch) {
+        private void handle_key (int ch) {
             switch (ch) {
                 case 'q':
                 case 'Q':
                     loop.quit ();
+                    break;
+                case Curses.KEY_UP:
+                case 'k':
+                    move_selection (-1);
+                    break;
+                case Curses.KEY_DOWN:
+                case 'j':
+                    move_selection (1);
+                    break;
+                case Curses.KEY_PPAGE:
+                    move_selection (-list_height ());
+                    break;
+                case Curses.KEY_NPAGE:
+                    move_selection (list_height ());
+                    break;
+                case Curses.KEY_HOME:
+                case 'g':
+                    selected = 0;
+                    clamp_selection ();
+                    needs_redraw = true;
+                    break;
+                case Curses.KEY_END:
+                case 'G':
+                    selected = (int) store.get_n_items () - 1;
+                    clamp_selection ();
+                    needs_redraw = true;
+                    break;
+                case '\n':
+                case '\r':
+                case Curses.KEY_ENTER:
+                    play_selected ();
+                    break;
+                case ' ':
+                    player.toggle_pause ();
+                    break;
+                case '+':
+                case '=':
+                    player.volume = player.volume + VOLUME_STEP;
+                    needs_redraw = true;
+                    break;
+                case '-':
+                case '_':
+                    player.volume = player.volume - VOLUME_STEP;
+                    needs_redraw = true;
+                    break;
+                case 'f':
+                    toggle_favourite_selected ();
+                    break;
+                case '/':
+                    search_active = true;
+                    needs_redraw = true;
                     break;
                 case Curses.KEY_RESIZE:
                     needs_redraw = true;
@@ -96,25 +199,171 @@ namespace Receiver {
             }
         }
 
+        private void handle_search_key (int ch) {
+            switch (ch) {
+                case '\n':
+                case '\r':
+                case Curses.KEY_ENTER:
+                case 27: // Esc — confirm and leave search mode, keeping results
+                    search_active = false;
+                    needs_redraw = true;
+                    break;
+                case Curses.KEY_BACKSPACE:
+                case 127:
+                case 8:
+                    if (search_text.length > 0) {
+                        search_text = search_text[0 : search_text.index_of_nth_char (
+                            search_text.char_count () - 1)];
+                        store.search_query = search_text;
+                    }
+                    needs_redraw = true;
+                    break;
+                case Curses.KEY_RESIZE:
+                    needs_redraw = true;
+                    break;
+                default:
+                    if (ch >= 32 && ch < 127) {
+                        search_text += ((char) ch).to_string ();
+                        store.search_query = search_text;
+                        needs_redraw = true;
+                    }
+                    break;
+            }
+        }
+
+        private void move_selection (int delta) {
+            selected += delta;
+            clamp_selection ();
+            needs_redraw = true;
+        }
+
+        private void play_selected () {
+            var station = current_station_at_cursor ();
+            if (station != null) {
+                player.play (station);
+            }
+        }
+
+        private void toggle_favourite_selected () {
+            var station = current_station_at_cursor ();
+            if (station != null) {
+                store.toggle_favourite (station);
+                needs_redraw = true;
+            }
+        }
+
+        private Station? current_station_at_cursor () {
+            if (selected < 0 || selected >= (int) store.get_n_items ()) {
+                return null;
+            }
+            return store.get_item (selected) as Station;
+        }
+
+        private void clamp_selection () {
+            int n = (int) store.get_n_items ();
+            if (n == 0) {
+                selected = 0;
+                scroll = 0;
+                return;
+            }
+            selected = selected.clamp (0, n - 1);
+
+            int lh = list_height ();
+            if (selected < scroll) {
+                scroll = selected;
+            } else if (selected >= scroll + lh) {
+                scroll = selected - lh + 1;
+            }
+            scroll = scroll.clamp (0, int.max (0, n - 1));
+        }
+
+        private int list_height () {
+            return int.max (1, Curses.LINES - 2);
+        }
+
+        // --- Rendering -------------------------------------------------------
+
         private void render () {
             int h = Curses.LINES;
             int w = Curses.COLS;
             scr.erase ();
 
-            draw_bar (0, w, PAIR_HEADER, " Receiver — TUI (skeleton)");
-
-            if (h > 4) {
-                scr.mvaddstr (2, 2, "libreceiver-core is linked; station UI comes next.");
-                scr.mvaddstr (3, 2, "Press 'q' to quit.");
-            }
-
-            draw_bar (h - 1, w, PAIR_STATUS, " q: quit");
+            draw_header (w);
+            draw_list (h, w);
+            draw_player_bar (h, w);
 
             scr.noutrefresh ();
             Curses.doupdate ();
         }
 
-        // Draw a full-width coloured bar with left-aligned text.
+        private void draw_header (int width) {
+            string text;
+            if (search_active) {
+                text = " Search: %s".printf (search_text);
+            } else {
+                text = " Receiver   %u/%d stations   [/] search  [enter] play  [space] pause  [f] fav  [q] quit"
+                    .printf (store.get_n_items (), store.total_count);
+            }
+            draw_bar (0, width, PAIR_HEADER, text);
+        }
+
+        private void draw_list (int h, int width) {
+            int lh = list_height ();
+            uint n = store.get_n_items ();
+            for (int i = 0; i < lh; i++) {
+                int idx = scroll + i;
+                if (idx >= (int) n) {
+                    break;
+                }
+                var station = store.get_item (idx) as Station;
+                if (station != null) {
+                    draw_row (1 + i, width, station, idx == selected);
+                }
+            }
+        }
+
+        private void draw_row (int row, int width, Station station, bool is_selected) {
+            bool playing = player.current_station != null
+                && player.current_station.id == station.id;
+            string marker = playing ? "▶" : " ";
+            string star = store.is_favourite (station.id) ? "★" : " ";
+            string subtitle = station.get_subtitle ();
+            string line = "%s %s %s".printf (marker, star, station.name);
+            if (subtitle != "") {
+                line += "   —   " + subtitle;
+            }
+
+            int attr = is_selected ? Curses.A_REVERSE : Curses.A_NORMAL;
+            scr.attron (attr);
+            scr.mvaddstr (row, 0, fit (line, width));
+            scr.attroff (attr);
+        }
+
+        private void draw_player_bar (int h, int width) {
+            string left;
+            var station = player.current_station;
+            if (station == null) {
+                left = " Stopped";
+            } else {
+                string icon;
+                if (player.state == PlayerState.PLAYING) {
+                    icon = player.is_buffering ? "…" : "▶";
+                } else if (player.state == PlayerState.PAUSED) {
+                    icon = "⏸";
+                } else {
+                    icon = "■";
+                }
+                left = " %s %s".printf (icon, station.name);
+                if (player.now_playing != "") {
+                    left += " — " + player.now_playing;
+                }
+            }
+            string right = "vol %d%% ".printf ((int) (player.volume * 100 + 0.5));
+            draw_bar (h - 1, width, PAIR_STATUS, compose (left, right, width));
+        }
+
+        // --- Drawing helpers -------------------------------------------------
+
         private void draw_bar (int row, int width, int pair, string text) {
             if (row < 0 || width <= 0) {
                 return;
@@ -125,8 +374,23 @@ namespace Receiver {
             scr.attroff (attr);
         }
 
-        // Pad or truncate to exactly `width` display columns (1 column per
-        // character; good enough for the ASCII chrome drawn here).
+        // Left-aligned text with right-aligned suffix, padded to width.
+        private string compose (string left, string right, int width) {
+            int lw = left.char_count ();
+            int rw = right.char_count ();
+            if (lw + rw >= width) {
+                return fit (left, width);
+            }
+            var sb = new StringBuilder (left);
+            for (int i = lw; i < width - rw; i++) {
+                sb.append_c (' ');
+            }
+            sb.append (right);
+            return sb.str;
+        }
+
+        // Pad or truncate to exactly `width` display columns (assumes one
+        // column per character; adequate for the Latin chrome drawn here).
         private string fit (string text, int width) {
             int len = text.char_count ();
             if (len > width) {

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -173,6 +173,7 @@ namespace Receiver {
             Curses.curs_set (0);
             scr.keypad (true);
             scr.nodelay (true);
+            Curses.mousemask (Curses.ALL_MOUSE_EVENTS);
 
             if (Curses.has_colors ()) {
                 Curses.start_color ();
@@ -330,11 +331,42 @@ namespace Receiver {
                         open_language_picker ();
                     }
                     break;
+                case Curses.KEY_MOUSE:
+                    handle_mouse ();
+                    break;
                 case Curses.KEY_RESIZE:
                     needs_redraw = true;
                     break;
                 default:
                     break;
+            }
+        }
+
+        // Wheel scrolls the list; a left click on a row selects and plays it.
+        private void handle_mouse () {
+            Curses.MEvent ev;
+            if (Curses.getmouse (out ev) == Curses.ERR) {
+                return;
+            }
+            if ((ev.bstate & Curses.BUTTON4_PRESSED) != 0) {
+                move_selection (-3);
+                return;
+            }
+            if ((ev.bstate & Curses.BUTTON5_PRESSED) != 0) {
+                move_selection (3);
+                return;
+            }
+            if ((ev.bstate & (Curses.BUTTON1_CLICKED | Curses.BUTTON1_PRESSED)) != 0) {
+                int row = ev.y;
+                // List rows occupy screen rows 1 .. list_height.
+                if (row >= 1 && row <= list_height ()) {
+                    int idx = scroll + (row - 1);
+                    if (idx >= 0 && idx < item_count ()) {
+                        selected = idx;
+                        play_selected ();
+                        needs_redraw = true;
+                    }
+                }
             }
         }
 

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -777,7 +777,7 @@ namespace Receiver {
                 // Fixed action hints first so their click targets never move;
                 // the variable count and active filters follow.
                 var sb = new StringBuilder ();
-                sb.append (" ");
+                sb.append (" Receiver   ");
                 add_zone (sb, "[Tab]view", ACT_VIEW);
                 sb.append ("  ");
                 add_zone (sb, "[c]country", ACT_COUNTRY);
@@ -803,7 +803,7 @@ namespace Receiver {
                 text = sb.str;
             } else {
                 var sb = new StringBuilder ();
-                sb.append (" ");
+                sb.append (" Receiver   ");
                 add_zone (sb, "[Tab]view", ACT_VIEW);
                 sb.append ("  ");
                 add_zone (sb, "[q]quit", ACT_QUIT);

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -1,0 +1,146 @@
+/*
+ * Receiver TUI — ncurses frontend over libreceiver-core.
+ *
+ * This skeleton establishes the runtime: curses runs as a guest of the GLib
+ * main loop (so the core's GStreamer/Soup work keeps ticking), stdin is read
+ * non-blocking via a GLib fd watch, repaints are coalesced, and the terminal
+ * is always restored on exit. The actual station/player UI is layered on top
+ * of this in the next step.
+ */
+namespace Receiver {
+
+    public class Tui : Object {
+        // Signal numbers (GLib profile has no Posix.Signal binding).
+        private const int SIGNAL_INT = 2;
+        private const int SIGNAL_TERM = 15;
+
+        // Colour pair ids.
+        private const int PAIR_HEADER = 1;
+        private const int PAIR_STATUS = 2;
+
+        private MainLoop loop = new MainLoop ();
+        private unowned Curses.Window scr;
+        private IOChannel stdin_channel;
+        private bool needs_redraw = true;
+
+        public int run () {
+            Intl.setlocale (LocaleCategory.ALL, "");
+
+            if (PosixExtras.isatty (0) == 0 || PosixExtras.isatty (1) == 0) {
+                stderr.printf ("receiver-tui requires an interactive terminal.\n");
+                return 1;
+            }
+
+            init_screen ();
+
+            // Restore the terminal no matter how we are asked to stop.
+            Unix.signal_add (SIGNAL_INT, () => { loop.quit (); return Source.REMOVE; });
+            Unix.signal_add (SIGNAL_TERM, () => { loop.quit (); return Source.REMOVE; });
+
+            // Non-blocking stdin driven by the main loop, so async core work runs.
+            stdin_channel = new IOChannel.unix_new (0);
+            stdin_channel.add_watch (IOCondition.IN, on_input);
+
+            // Paint once up front, then coalesce later repaints (~30 fps cap).
+            render ();
+            needs_redraw = false;
+            Timeout.add (33, () => {
+                if (needs_redraw) {
+                    render ();
+                    needs_redraw = false;
+                }
+                return Source.CONTINUE;
+            });
+
+            loop.run ();
+
+            Curses.endwin ();
+            return 0;
+        }
+
+        private void init_screen () {
+            scr = Curses.Window.initscr ();
+            Curses.cbreak ();
+            Curses.noecho ();
+            Curses.curs_set (0);
+            scr.keypad (true);
+            scr.nodelay (true);
+
+            if (Curses.has_colors ()) {
+                Curses.start_color ();
+                Curses.use_default_colors ();
+                Curses.init_pair (PAIR_HEADER, Curses.COLOR_BLACK, Curses.COLOR_CYAN);
+                Curses.init_pair (PAIR_STATUS, Curses.COLOR_WHITE, Curses.COLOR_BLUE);
+            }
+        }
+
+        private bool on_input (IOChannel source, IOCondition condition) {
+            int ch;
+            while ((ch = scr.getch ()) != Curses.ERR) {
+                dispatch (ch);
+            }
+            return Source.CONTINUE;
+        }
+
+        private void dispatch (int ch) {
+            switch (ch) {
+                case 'q':
+                case 'Q':
+                    loop.quit ();
+                    break;
+                case Curses.KEY_RESIZE:
+                    needs_redraw = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        private void render () {
+            int h = Curses.LINES;
+            int w = Curses.COLS;
+            scr.erase ();
+
+            draw_bar (0, w, PAIR_HEADER, " Receiver — TUI (skeleton)");
+
+            if (h > 4) {
+                scr.mvaddstr (2, 2, "libreceiver-core is linked; station UI comes next.");
+                scr.mvaddstr (3, 2, "Press 'q' to quit.");
+            }
+
+            draw_bar (h - 1, w, PAIR_STATUS, " q: quit");
+
+            scr.noutrefresh ();
+            Curses.doupdate ();
+        }
+
+        // Draw a full-width coloured bar with left-aligned text.
+        private void draw_bar (int row, int width, int pair, string text) {
+            if (row < 0 || width <= 0) {
+                return;
+            }
+            int attr = Curses.has_colors () ? Curses.color_pair (pair) : Curses.A_REVERSE;
+            scr.attron (attr);
+            scr.mvaddstr (row, 0, fit (text, width));
+            scr.attroff (attr);
+        }
+
+        // Pad or truncate to exactly `width` display columns (1 column per
+        // character; good enough for the ASCII chrome drawn here).
+        private string fit (string text, int width) {
+            int len = text.char_count ();
+            if (len > width) {
+                return text[0 : (int) text.index_of_nth_char (width)];
+            }
+            var sb = new StringBuilder (text);
+            for (int i = len; i < width; i++) {
+                sb.append_c (' ');
+            }
+            return sb.str;
+        }
+    }
+
+    public static int main (string[] args) {
+        return new Tui ().run ();
+    }
+}

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -1,13 +1,28 @@
 /*
  * Receiver TUI — ncurses frontend over libreceiver-core.
  *
- * Browse + play MVP: a scrollable station list backed by StationStore with
- * incremental search, driving the shared Player. Curses runs as a guest of the
- * GLib main loop so the core's async GStreamer/Soup work keeps ticking; stdin
- * is read non-blocking, repaints are coalesced, and the terminal is always
- * restored on exit.
+ * Three views (Browse / Favourites / History) over the shared StationStore,
+ * AppState favourites and HistoryStore, driving the shared Player. Curses runs
+ * as a guest of the GLib main loop so the core's async GStreamer/Soup work keeps
+ * ticking; stdin is read non-blocking, repaints are coalesced, and the terminal
+ * is always restored on exit.
  */
 namespace Receiver {
+
+    public enum View {
+        BROWSE, FAVOURITES, HISTORY;
+
+        public const int COUNT = 3;
+
+        public string label () {
+            switch (this) {
+                case BROWSE: return "Browse";
+                case FAVOURITES: return "Favourites";
+                case HISTORY: return "History";
+                default: return "";
+            }
+        }
+    }
 
     public class Tui : Object {
         // Signal numbers (the GLib profile has no Posix.Signal binding).
@@ -31,8 +46,13 @@ namespace Receiver {
         private StationStore store = new StationStore ();
         private Player player = new Player ();
 
+        private View view = View.BROWSE;
+        // Cursor and scroll position, remembered per view.
         private int selected = 0;
         private int scroll = 0;
+        private int[] saved_sel = { 0, 0, 0 };
+        private int[] saved_off = { 0, 0, 0 };
+
         private bool search_active = false;
         private string search_text = "";
 
@@ -80,9 +100,23 @@ namespace Receiver {
                 clamp_selection ();
                 needs_redraw = true;
             });
+            AppState.get_default ().favourites_changed.connect (() => {
+                clamp_selection ();
+                needs_redraw = true;
+            });
+            HistoryStore.get_default ().items_changed.connect (() => {
+                clamp_selection ();
+                needs_redraw = true;
+            });
             player.state_changed.connect (() => { needs_redraw = true; });
-            player.metadata_changed.connect (() => { needs_redraw = true; });
             player.stream_info_changed.connect (() => { needs_redraw = true; });
+            player.metadata_changed.connect ((title) => {
+                // Record songs to history (same guard as the GTK frontend).
+                if (player.current_station != null && player.state == PlayerState.PLAYING) {
+                    HistoryStore.get_default ().add (player.current_station, title);
+                }
+                needs_redraw = true;
+            });
         }
 
         // Mirror the GTK app: look through XDG data dirs, then fall back to the
@@ -93,10 +127,8 @@ namespace Receiver {
                     return;
                 }
             }
-            if (try_open_db (Path.build_filename (Environment.get_current_dir (),
-                                                  "data", "receiver", "receiver.db"))) {
-                return;
-            }
+            try_open_db (Path.build_filename (Environment.get_current_dir (),
+                                              "data", "receiver", "receiver.db"));
         }
 
         private bool try_open_db (string path) {
@@ -123,6 +155,52 @@ namespace Receiver {
             }
         }
 
+        // --- View-aware data access -----------------------------------------
+
+        private int item_count () {
+            switch (view) {
+                case View.BROWSE:
+                    return (int) store.get_n_items ();
+                case View.FAVOURITES:
+                    return (int) AppState.get_default ().get_favourite_stations ().length;
+                case View.HISTORY:
+                    return (int) HistoryStore.get_default ().get_n_items ();
+                default:
+                    return 0;
+            }
+        }
+
+        // The station shown at a list row (Browse/Favourites only).
+        private Station? station_at (int idx) {
+            if (idx < 0) {
+                return null;
+            }
+            if (view == View.BROWSE) {
+                return idx < (int) store.get_n_items () ? store.get_item (idx) as Station : null;
+            }
+            if (view == View.FAVOURITES) {
+                var favs = AppState.get_default ().get_favourite_stations ();
+                return idx < (int) favs.length ? favs[idx] : null;
+            }
+            return null;
+        }
+
+        private HistoryEntry? history_at (int idx) {
+            var h = HistoryStore.get_default ();
+            return idx >= 0 && idx < (int) h.get_n_items ()
+                ? h.get_item (idx) as HistoryEntry : null;
+        }
+
+        // The playable station for the current selection, resolving history
+        // entries back to a full station (with a stream URL) via the database.
+        private Station? selected_station () {
+            if (view == View.HISTORY) {
+                var e = history_at (selected);
+                return e != null ? store.get_station_by_id (e.station_id) : null;
+            }
+            return station_at (selected);
+        }
+
         // --- Input -----------------------------------------------------------
 
         private bool on_input (IOChannel source, IOCondition condition) {
@@ -142,6 +220,12 @@ namespace Receiver {
                 case 'q':
                 case 'Q':
                     loop.quit ();
+                    break;
+                case '\t':
+                    cycle_view (1);
+                    break;
+                case Curses.KEY_BTAB:
+                    cycle_view (-1);
                     break;
                 case Curses.KEY_UP:
                 case 'k':
@@ -165,7 +249,7 @@ namespace Receiver {
                     break;
                 case Curses.KEY_END:
                 case 'G':
-                    selected = (int) store.get_n_items () - 1;
+                    selected = item_count () - 1;
                     clamp_selection ();
                     needs_redraw = true;
                     break;
@@ -191,8 +275,10 @@ namespace Receiver {
                     toggle_favourite_selected ();
                     break;
                 case '/':
-                    search_active = true;
-                    needs_redraw = true;
+                    if (view == View.BROWSE) {
+                        search_active = true;
+                        needs_redraw = true;
+                    }
                     break;
                 case Curses.KEY_RESIZE:
                     needs_redraw = true;
@@ -234,6 +320,17 @@ namespace Receiver {
             }
         }
 
+        private void cycle_view (int dir) {
+            saved_sel[(int) view] = selected;
+            saved_off[(int) view] = scroll;
+            view = (View) (((int) view + dir + View.COUNT) % View.COUNT);
+            selected = saved_sel[(int) view];
+            scroll = saved_off[(int) view];
+            search_active = false;
+            clamp_selection ();
+            needs_redraw = true;
+        }
+
         private void move_selection (int delta) {
             selected += delta;
             clamp_selection ();
@@ -241,29 +338,23 @@ namespace Receiver {
         }
 
         private void play_selected () {
-            var station = current_station_at_cursor ();
+            var station = selected_station ();
             if (station != null) {
                 player.play (station);
             }
         }
 
         private void toggle_favourite_selected () {
-            var station = current_station_at_cursor ();
+            // Only meaningful for station rows; a no-op in History.
+            var station = station_at (selected);
             if (station != null) {
                 store.toggle_favourite (station);
                 needs_redraw = true;
             }
         }
 
-        private Station? current_station_at_cursor () {
-            if (selected < 0 || selected >= (int) store.get_n_items ()) {
-                return null;
-            }
-            return store.get_item (selected) as Station;
-        }
-
         private void clamp_selection () {
-            int n = (int) store.get_n_items ();
+            int n = item_count ();
             if (n == 0) {
                 selected = 0;
                 scroll = 0;
@@ -304,28 +395,52 @@ namespace Receiver {
             if (search_active) {
                 text = " Search: %s".printf (search_text);
             } else {
-                text = " Receiver   %u/%d stations   [/] search  [enter] play  [space] pause  [f] fav  [q] quit"
-                    .printf (store.get_n_items (), store.total_count);
+                text = " Receiver · %s (%d)   [Tab] view  [↵] play  [space] pause  [+/-] vol  [f] fav  [/] search  [q] quit"
+                    .printf (view.label (), item_count ());
             }
             draw_bar (0, width, PAIR_HEADER, text);
         }
 
         private void draw_list (int h, int width) {
             int lh = list_height ();
-            uint n = store.get_n_items ();
+            int n = item_count ();
+            if (n == 0) {
+                scr.mvaddstr (1, 2, empty_message ());
+                return;
+            }
             for (int i = 0; i < lh; i++) {
                 int idx = scroll + i;
-                if (idx >= (int) n) {
+                if (idx >= n) {
                     break;
                 }
-                var station = store.get_item (idx) as Station;
-                if (station != null) {
-                    draw_row (1 + i, width, station, idx == selected);
+                int row = 1 + i;
+                bool is_selected = (idx == selected);
+                if (view == View.HISTORY) {
+                    var e = history_at (idx);
+                    if (e != null) {
+                        draw_history_row (row, width, e, is_selected);
+                    }
+                } else {
+                    var station = station_at (idx);
+                    if (station != null) {
+                        draw_station_row (row, width, station, is_selected);
+                    }
                 }
             }
         }
 
-        private void draw_row (int row, int width, Station station, bool is_selected) {
+        private string empty_message () {
+            switch (view) {
+                case View.FAVOURITES:
+                    return "No favourites yet — press 'f' on a station in Browse.";
+                case View.HISTORY:
+                    return "No song history yet — play a station for a while.";
+                default:
+                    return "No stations match your search.";
+            }
+        }
+
+        private void draw_station_row (int row, int width, Station station, bool is_selected) {
             bool playing = player.current_station != null
                 && player.current_station.id == station.id;
             string marker = playing ? "▶" : " ";
@@ -335,7 +450,16 @@ namespace Receiver {
             if (subtitle != "") {
                 line += "   —   " + subtitle;
             }
+            draw_line (row, width, line, is_selected);
+        }
 
+        private void draw_history_row (int row, int width, HistoryEntry entry, bool is_selected) {
+            string time = format_time (entry.played_at);
+            string line = "%s   %s   —   %s".printf (time, entry.song_title, entry.station_name);
+            draw_line (row, width, line, is_selected);
+        }
+
+        private void draw_line (int row, int width, string line, bool is_selected) {
             int attr = is_selected ? Curses.A_REVERSE : Curses.A_NORMAL;
             scr.attron (attr);
             scr.mvaddstr (row, 0, fit (line, width));
@@ -404,6 +528,14 @@ namespace Receiver {
                 sb.append_c (' ');
             }
             return sb.str;
+        }
+
+        private string format_time (string iso) {
+            if (iso == "") {
+                return "--:--";
+            }
+            var dt = new DateTime.from_iso8601 (iso, null);
+            return dt != null ? dt.format ("%H:%M") : iso;
         }
 
         // Redirect GLib log messages (from the core services) to a file so they

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -644,10 +644,13 @@ namespace Receiver {
         private void draw_header (int width) {
             string text;
             if (search_active) {
-                text = " Search: %s".printf (search_text);
+                text = " Search: %s▏".printf (search_text);
             } else if (view == View.BROWSE) {
                 var sb = new StringBuilder ();
                 sb.append (" Receiver · Browse (%d)".printf (item_count ()));
+                if (search_text != "") {
+                    sb.append ("  search:\"%s\"".printf (search_text));
+                }
                 if (country_label != "") {
                     sb.append ("  country:" + country_label);
                 }

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -28,6 +28,13 @@ namespace Receiver {
         NONE, COUNTRY, LANGUAGE
     }
 
+    // A clickable span in the header bar: columns [start, end) trigger `action`.
+    public struct HeaderZone {
+        int start;
+        int end;
+        int action;
+    }
+
     public class Tui : Object, MprisHost {
         // Signal numbers (the GLib profile has no Posix.Signal binding).
         private const int SIGNAL_INT = 2;
@@ -38,6 +45,16 @@ namespace Receiver {
         private const int PAIR_STATUS = 2;
 
         private const double VOLUME_STEP = 0.05;
+
+        // Header click actions.
+        private const int ACT_COUNTRY = 1;
+        private const int ACT_LANGUAGE = 2;
+        private const int ACT_SEARCH = 3;
+        private const int ACT_CLEAR = 4;
+        private const int ACT_VIEW = 5;
+        private const int ACT_QUIT = 6;
+
+        private HeaderZone[] header_zones = {};
 
         // Keeps core log messages from corrupting the curses screen.
         private static FileStream? log_stream;
@@ -242,7 +259,9 @@ namespace Receiver {
         private bool on_input (IOChannel source, IOCondition condition) {
             int ch;
             while ((ch = scr.getch ()) != Curses.ERR) {
-                if (picker != PickerMode.NONE) {
+                if (ch == Curses.KEY_MOUSE) {
+                    handle_mouse ();
+                } else if (picker != PickerMode.NONE) {
                     handle_picker_key (ch);
                 } else if (search_active) {
                     handle_search_key (ch);
@@ -331,9 +350,6 @@ namespace Receiver {
                         open_language_picker ();
                     }
                     break;
-                case Curses.KEY_MOUSE:
-                    handle_mouse ();
-                    break;
                 case Curses.KEY_RESIZE:
                     needs_redraw = true;
                     break;
@@ -342,12 +358,21 @@ namespace Receiver {
             }
         }
 
-        // Wheel scrolls the list; a left click on a row selects and plays it.
         private void handle_mouse () {
             Curses.MEvent ev;
             if (Curses.getmouse (out ev) == Curses.ERR) {
                 return;
             }
+            if (picker != PickerMode.NONE) {
+                handle_picker_mouse (ev);
+            } else if (!search_active) {
+                handle_view_mouse (ev);
+            }
+        }
+
+        // Wheel scrolls; left click on the header runs a hint, on a row plays
+        // it; right click on a row toggles its favourite.
+        private void handle_view_mouse (Curses.MEvent ev) {
             if ((ev.bstate & Curses.BUTTON4_PRESSED) != 0) {
                 move_selection (-3);
                 return;
@@ -356,17 +381,68 @@ namespace Receiver {
                 move_selection (3);
                 return;
             }
+            bool left = (ev.bstate & (Curses.BUTTON1_CLICKED | Curses.BUTTON1_PRESSED)) != 0;
+            bool right = (ev.bstate & (Curses.BUTTON3_CLICKED | Curses.BUTTON3_PRESSED)) != 0;
+
+            if (ev.y == 0) {
+                if (left) {
+                    header_click (ev.x);
+                }
+                return;
+            }
+            if (ev.y >= 1 && ev.y <= list_height ()) {
+                int idx = scroll + (ev.y - 1);
+                if (idx < 0 || idx >= item_count ()) {
+                    return;
+                }
+                selected = idx;
+                if (right) {
+                    toggle_favourite_selected ();
+                } else if (left) {
+                    play_selected ();
+                }
+                needs_redraw = true;
+            }
+        }
+
+        private void handle_picker_mouse (Curses.MEvent ev) {
+            if ((ev.bstate & Curses.BUTTON4_PRESSED) != 0) {
+                picker_move (-3);
+                return;
+            }
+            if ((ev.bstate & Curses.BUTTON5_PRESSED) != 0) {
+                picker_move (3);
+                return;
+            }
             if ((ev.bstate & (Curses.BUTTON1_CLICKED | Curses.BUTTON1_PRESSED)) != 0) {
-                int row = ev.y;
-                // List rows occupy screen rows 1 .. list_height.
-                if (row >= 1 && row <= list_height ()) {
-                    int idx = scroll + (row - 1);
-                    if (idx >= 0 && idx < item_count ()) {
-                        selected = idx;
-                        play_selected ();
-                        needs_redraw = true;
+                if (ev.y >= 1 && ev.y <= list_height ()) {
+                    int i = picker_off + (ev.y - 1);
+                    if (i >= 0 && i < picker_matches ().length) {
+                        picker_sel = i;
+                        picker_select ();
                     }
                 }
+            }
+        }
+
+        private void header_click (int x) {
+            foreach (var z in header_zones) {
+                if (x >= z.start && x < z.end) {
+                    run_header_action (z.action);
+                    return;
+                }
+            }
+        }
+
+        private void run_header_action (int action) {
+            switch (action) {
+                case ACT_COUNTRY:  open_country_picker ();  break;
+                case ACT_LANGUAGE: open_language_picker (); break;
+                case ACT_SEARCH:   search_active = true; needs_redraw = true; break;
+                case ACT_CLEAR:    clear_search ();         break;
+                case ACT_VIEW:     cycle_view (1);          break;
+                case ACT_QUIT:     loop.quit ();            break;
+                default: break;
             }
         }
 
@@ -693,32 +769,55 @@ namespace Receiver {
         }
 
         private void draw_header (int width) {
+            header_zones = {};
             string text;
             if (search_active) {
                 text = " Search: %s▏   [↵] apply  [Esc] clear".printf (search_text);
             } else if (view == View.BROWSE) {
                 var sb = new StringBuilder ();
                 sb.append (" Receiver · Browse (%d)".printf (item_count ()));
+                // Active filters double as clickable shortcuts to change them.
                 if (search_text != "") {
-                    sb.append ("  search:\"%s\"".printf (search_text));
+                    add_zone (sb, "  search:\"%s\"".printf (search_text), ACT_SEARCH);
                 }
                 if (country_label != "") {
-                    sb.append ("  country:" + country_label);
+                    add_zone (sb, "  country:" + country_label, ACT_COUNTRY);
                 }
                 if (language_label != "") {
-                    sb.append ("  lang:" + language_label);
+                    add_zone (sb, "  lang:" + language_label, ACT_LANGUAGE);
                 }
-                sb.append ("   [c]/[l] filter  [/] search");
+                sb.append ("   ");
+                add_zone (sb, "[c]country", ACT_COUNTRY);
+                sb.append ("  ");
+                add_zone (sb, "[l]lang", ACT_LANGUAGE);
+                sb.append ("  ");
+                add_zone (sb, "[/]search", ACT_SEARCH);
                 if (search_text != "") {
-                    sb.append ("  [Esc] clear");
+                    sb.append ("  ");
+                    add_zone (sb, "[Esc]clear", ACT_CLEAR);
                 }
-                sb.append ("  [Tab] view  [q] quit");
+                sb.append ("  ");
+                add_zone (sb, "[Tab]view", ACT_VIEW);
+                sb.append ("  ");
+                add_zone (sb, "[q]quit", ACT_QUIT);
                 text = sb.str;
             } else {
-                text = " Receiver · %s (%d)   [Tab] view  [↵] play  [space] pause  [f] fav  [q] quit"
-                    .printf (view.label (), item_count ());
+                var sb = new StringBuilder ();
+                sb.append (" Receiver · %s (%d)   ".printf (view.label (), item_count ()));
+                add_zone (sb, "[Tab]view", ACT_VIEW);
+                sb.append ("  ");
+                add_zone (sb, "[q]quit", ACT_QUIT);
+                text = sb.str;
             }
             draw_bar (0, width, PAIR_HEADER, text);
+        }
+
+        // Append a clickable token to the header, recording its column span.
+        private void add_zone (StringBuilder sb, string token, int action) {
+            int start = (int) sb.str.char_count ();
+            sb.append (token);
+            HeaderZone z = { start, (int) sb.str.char_count (), action };
+            header_zones += z;
         }
 
         private void draw_list (int h, int width) {

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -88,6 +88,10 @@ namespace Receiver {
             wire_core ();
             load_database ();
 
+            // Persist volume and last station via GSettings, shared with the GTK app.
+            AppState.get_default ().settings.bind ("volume", player, "volume", SettingsBindFlags.DEFAULT);
+            restore_last_station ();
+
             // Register MPRIS so desktop media keys control playback.
             mpris = new MprisService (this, player);
 
@@ -526,6 +530,19 @@ namespace Receiver {
 
         private void play_selected () {
             var station = selected_station ();
+            if (station != null) {
+                player.play (station);
+                AppState.get_default ().settings.set_int64 ("last-station-id", station.id);
+            }
+        }
+
+        // Resume the last played station on startup, like the GTK app.
+        private void restore_last_station () {
+            var id = AppState.get_default ().settings.get_int64 ("last-station-id");
+            if (id == 0) {
+                return;
+            }
+            var station = store.get_station_by_id (id);
             if (station != null) {
                 player.play (station);
             }

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -24,6 +24,10 @@ namespace Receiver {
         }
     }
 
+    public enum PickerMode {
+        NONE, COUNTRY, LANGUAGE
+    }
+
     public class Tui : Object {
         // Signal numbers (the GLib profile has no Posix.Signal binding).
         private const int SIGNAL_INT = 2;
@@ -55,6 +59,19 @@ namespace Receiver {
 
         private bool search_active = false;
         private string search_text = "";
+
+        // Country/language filter (Browse only). Labels are shown in the header;
+        // the empty string means "all" (no filter).
+        private string country_label = "";
+        private string language_label = "";
+
+        // Popup picker state for choosing a country/language.
+        private PickerMode picker = PickerMode.NONE;
+        private string[] picker_labels = {};
+        private string[] picker_values = {};
+        private string picker_query = "";
+        private int picker_sel = 0;
+        private int picker_off = 0;
 
         public int run () {
             Intl.setlocale (LocaleCategory.ALL, "");
@@ -206,7 +223,9 @@ namespace Receiver {
         private bool on_input (IOChannel source, IOCondition condition) {
             int ch;
             while ((ch = scr.getch ()) != Curses.ERR) {
-                if (search_active) {
+                if (picker != PickerMode.NONE) {
+                    handle_picker_key (ch);
+                } else if (search_active) {
                     handle_search_key (ch);
                 } else {
                     handle_key (ch);
@@ -280,6 +299,16 @@ namespace Receiver {
                         needs_redraw = true;
                     }
                     break;
+                case 'c':
+                    if (view == View.BROWSE) {
+                        open_country_picker ();
+                    }
+                    break;
+                case 'l':
+                    if (view == View.BROWSE) {
+                        open_language_picker ();
+                    }
+                    break;
                 case Curses.KEY_RESIZE:
                     needs_redraw = true;
                     break;
@@ -318,6 +347,152 @@ namespace Receiver {
                     }
                     break;
             }
+        }
+
+        // --- Country/language picker ----------------------------------------
+
+        private void open_country_picker () {
+            var codes = store.get_available_country_codes ();
+            var names = store.get_available_country_names ();
+            string[] labels = { "All countries" };
+            string[] values = { "all" };
+            for (int i = 0; i < names.length; i++) {
+                labels += names[i];
+                values += codes[i];
+            }
+            start_picker (PickerMode.COUNTRY, labels, values);
+        }
+
+        private void open_language_picker () {
+            var sorted = new GenericArray<string> ();
+            foreach (var code in store.get_available_languages ()) {
+                sorted.add (code);
+            }
+            sorted.sort ((a, b) => Languages.translate (a).collate (Languages.translate (b)));
+
+            string[] labels = { "All languages" };
+            string[] values = { "all" };
+            for (int i = 0; i < sorted.length; i++) {
+                labels += Languages.translate (sorted[i]);
+                values += sorted[i];
+            }
+            start_picker (PickerMode.LANGUAGE, labels, values);
+        }
+
+        private void start_picker (PickerMode mode, string[] labels, string[] values) {
+            picker = mode;
+            picker_labels = labels;
+            picker_values = values;
+            picker_query = "";
+            picker_sel = 0;
+            picker_off = 0;
+            needs_redraw = true;
+        }
+
+        // Indices of options matching the query. With an empty query the "All"
+        // entry sits at the top so clearing the filter is always one keypress.
+        private int[] picker_matches () {
+            var q = picker_query.down ();
+            int[] res = {};
+            for (int i = 0; i < picker_labels.length; i++) {
+                if (q == "" || picker_labels[i].down ().contains (q)) {
+                    res += i;
+                }
+            }
+            return res;
+        }
+
+        private void handle_picker_key (int ch) {
+            switch (ch) {
+                case 27: // Esc — cancel
+                    close_picker ();
+                    break;
+                case '\n':
+                case '\r':
+                case Curses.KEY_ENTER:
+                    picker_select ();
+                    break;
+                case Curses.KEY_UP:
+                    picker_move (-1);
+                    break;
+                case Curses.KEY_DOWN:
+                    picker_move (1);
+                    break;
+                case Curses.KEY_PPAGE:
+                    picker_move (-list_height ());
+                    break;
+                case Curses.KEY_NPAGE:
+                    picker_move (list_height ());
+                    break;
+                case Curses.KEY_BACKSPACE:
+                case 127:
+                case 8:
+                    if (picker_query.length > 0) {
+                        picker_query = picker_query[0 : picker_query.index_of_nth_char (
+                            picker_query.char_count () - 1)];
+                        picker_sel = 0;
+                        picker_off = 0;
+                    }
+                    needs_redraw = true;
+                    break;
+                case Curses.KEY_RESIZE:
+                    needs_redraw = true;
+                    break;
+                default:
+                    if (ch >= 32 && ch < 127) {
+                        picker_query += ((char) ch).to_string ();
+                        picker_sel = 0;
+                        picker_off = 0;
+                        needs_redraw = true;
+                    }
+                    break;
+            }
+        }
+
+        private void picker_move (int delta) {
+            int n = picker_matches ().length;
+            if (n == 0) {
+                picker_sel = 0;
+                picker_off = 0;
+                return;
+            }
+            picker_sel = (picker_sel + delta).clamp (0, n - 1);
+            int lh = list_height ();
+            if (picker_sel < picker_off) {
+                picker_off = picker_sel;
+            } else if (picker_sel >= picker_off + lh) {
+                picker_off = picker_sel - lh + 1;
+            }
+            needs_redraw = true;
+        }
+
+        private void picker_select () {
+            var idx = picker_matches ();
+            if (picker_sel < 0 || picker_sel >= idx.length) {
+                close_picker ();
+                return;
+            }
+            int real = idx[picker_sel];
+            string value = picker_values[real];
+            string label = (value == "all") ? "" : picker_labels[real];
+
+            if (picker == PickerMode.COUNTRY) {
+                store.country_filter = value;
+                country_label = label;
+            } else if (picker == PickerMode.LANGUAGE) {
+                store.language_filter = value;
+                language_label = label;
+            }
+            close_picker ();
+            // The list changed underfoot — reset the Browse cursor to the top.
+            selected = 0;
+            scroll = 0;
+            clamp_selection ();
+        }
+
+        private void close_picker () {
+            picker = PickerMode.NONE;
+            needs_redraw = true;
         }
 
         private void cycle_view (int dir) {
@@ -382,20 +557,55 @@ namespace Receiver {
             int w = Curses.COLS;
             scr.erase ();
 
-            draw_header (w);
-            draw_list (h, w);
-            draw_player_bar (h, w);
+            if (picker != PickerMode.NONE) {
+                draw_picker (h, w);
+            } else {
+                draw_header (w);
+                draw_list (h, w);
+                draw_player_bar (h, w);
+            }
 
             scr.noutrefresh ();
             Curses.doupdate ();
+        }
+
+        private void draw_picker (int h, int width) {
+            string title = (picker == PickerMode.COUNTRY) ? "Select country" : "Select language";
+            draw_bar (0, width, PAIR_HEADER, " %s — type to filter: %s".printf (title, picker_query));
+
+            var idx = picker_matches ();
+            int lh = list_height ();
+            if (idx.length == 0) {
+                scr.mvaddstr (1, 2, "No matches.");
+            } else {
+                for (int i = 0; i < lh; i++) {
+                    int p = picker_off + i;
+                    if (p >= idx.length) {
+                        break;
+                    }
+                    draw_line (1 + i, width, " " + picker_labels[idx[p]], p == picker_sel);
+                }
+            }
+            draw_bar (h - 1, width, PAIR_STATUS, " [↵] select   [Esc] cancel");
         }
 
         private void draw_header (int width) {
             string text;
             if (search_active) {
                 text = " Search: %s".printf (search_text);
+            } else if (view == View.BROWSE) {
+                var sb = new StringBuilder ();
+                sb.append (" Receiver · Browse (%d)".printf (item_count ()));
+                if (country_label != "") {
+                    sb.append ("  country:" + country_label);
+                }
+                if (language_label != "") {
+                    sb.append ("  lang:" + language_label);
+                }
+                sb.append ("   [c]/[l] filter  [/] search  [Tab] view  [q] quit");
+                text = sb.str;
             } else {
-                text = " Receiver · %s (%d)   [Tab] view  [↵] play  [space] pause  [+/-] vol  [f] fav  [/] search  [q] quit"
+                text = " Receiver · %s (%d)   [Tab] view  [↵] play  [space] pause  [f] fav  [q] quit"
                     .printf (view.label (), item_count ());
             }
             draw_bar (0, width, PAIR_HEADER, text);

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -774,11 +774,25 @@ namespace Receiver {
             if (search_active) {
                 text = " Search: %s▏   [↵] apply  [Esc] clear".printf (search_text);
             } else if (view == View.BROWSE) {
+                // Fixed action hints first so their click targets never move;
+                // the variable count and active filters follow.
                 var sb = new StringBuilder ();
-                sb.append (" Receiver · Browse (%d)".printf (item_count ()));
+                sb.append (" ");
+                add_zone (sb, "[Tab]view", ACT_VIEW);
+                sb.append ("  ");
+                add_zone (sb, "[c]country", ACT_COUNTRY);
+                sb.append ("  ");
+                add_zone (sb, "[l]lang", ACT_LANGUAGE);
+                sb.append ("  ");
+                add_zone (sb, "[/]search", ACT_SEARCH);
+                sb.append ("  ");
+                add_zone (sb, "[q]quit", ACT_QUIT);
+                sb.append ("   Browse (%d)".printf (item_count ()));
                 // Active filters double as clickable shortcuts to change them.
                 if (search_text != "") {
                     add_zone (sb, "  search:\"%s\"".printf (search_text), ACT_SEARCH);
+                    sb.append ("  ");
+                    add_zone (sb, "[Esc]clear", ACT_CLEAR);
                 }
                 if (country_label != "") {
                     add_zone (sb, "  country:" + country_label, ACT_COUNTRY);
@@ -786,27 +800,14 @@ namespace Receiver {
                 if (language_label != "") {
                     add_zone (sb, "  lang:" + language_label, ACT_LANGUAGE);
                 }
-                sb.append ("   ");
-                add_zone (sb, "[c]country", ACT_COUNTRY);
-                sb.append ("  ");
-                add_zone (sb, "[l]lang", ACT_LANGUAGE);
-                sb.append ("  ");
-                add_zone (sb, "[/]search", ACT_SEARCH);
-                if (search_text != "") {
-                    sb.append ("  ");
-                    add_zone (sb, "[Esc]clear", ACT_CLEAR);
-                }
-                sb.append ("  ");
-                add_zone (sb, "[Tab]view", ACT_VIEW);
-                sb.append ("  ");
-                add_zone (sb, "[q]quit", ACT_QUIT);
                 text = sb.str;
             } else {
                 var sb = new StringBuilder ();
-                sb.append (" Receiver · %s (%d)   ".printf (view.label (), item_count ()));
+                sb.append (" ");
                 add_zone (sb, "[Tab]view", ACT_VIEW);
                 sb.append ("  ");
                 add_zone (sb, "[q]quit", ACT_QUIT);
+                sb.append ("   %s (%d)".printf (view.label (), item_count ()));
                 text = sb.str;
             }
             draw_bar (0, width, PAIR_HEADER, text);

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -405,6 +405,7 @@ namespace Receiver {
     }
 
     public static int main (string[] args) {
+        Gst.init (ref args);
         return new Tui ().run ();
     }
 }

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -28,7 +28,7 @@ namespace Receiver {
         NONE, COUNTRY, LANGUAGE
     }
 
-    public class Tui : Object {
+    public class Tui : Object, MprisHost {
         // Signal numbers (the GLib profile has no Posix.Signal binding).
         private const int SIGNAL_INT = 2;
         private const int SIGNAL_TERM = 15;
@@ -49,6 +49,7 @@ namespace Receiver {
 
         private StationStore store = new StationStore ();
         private Player player = new Player ();
+        private MprisService mpris;
 
         private View view = View.BROWSE;
         // Cursor and scroll position, remembered per view.
@@ -86,6 +87,9 @@ namespace Receiver {
             store.country_filter = "all";
             wire_core ();
             load_database ();
+
+            // Register MPRIS so desktop media keys control playback.
+            mpris = new MprisService (this, player);
 
             init_screen ();
 
@@ -216,6 +220,14 @@ namespace Receiver {
                 return e != null ? store.get_station_by_id (e.station_id) : null;
             }
             return station_at (selected);
+        }
+
+        // MprisHost: a terminal app can't raise a window, so this is a no-op.
+        public void raise () {
+        }
+
+        public void quit () {
+            loop.quit ();
         }
 
         // --- Input -----------------------------------------------------------

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -317,6 +317,9 @@ namespace Receiver {
                         needs_redraw = true;
                     }
                     break;
+                case 27: // Esc — clear an applied search
+                    clear_search ();
+                    break;
                 case 'c':
                     if (view == View.BROWSE) {
                         open_country_picker ();
@@ -340,9 +343,13 @@ namespace Receiver {
                 case '\n':
                 case '\r':
                 case Curses.KEY_ENTER:
-                case 27: // Esc — confirm and leave search mode, keeping results
+                    // Apply and leave search mode, keeping results.
                     search_active = false;
                     needs_redraw = true;
+                    break;
+                case 27: // Esc — clear the query and leave search mode
+                    search_active = false;
+                    clear_search ();
                     break;
                 case Curses.KEY_BACKSPACE:
                 case 127:
@@ -534,6 +541,18 @@ namespace Receiver {
             }
         }
 
+        private void clear_search () {
+            if (search_text == "" && store.search_query == "") {
+                return;
+            }
+            search_text = "";
+            store.search_query = "";
+            selected = 0;
+            scroll = 0;
+            clamp_selection ();
+            needs_redraw = true;
+        }
+
         private void cycle_view (int dir) {
             saved_sel[(int) view] = selected;
             saved_off[(int) view] = scroll;
@@ -644,7 +663,7 @@ namespace Receiver {
         private void draw_header (int width) {
             string text;
             if (search_active) {
-                text = " Search: %s▏".printf (search_text);
+                text = " Search: %s▏   [↵] apply  [Esc] clear".printf (search_text);
             } else if (view == View.BROWSE) {
                 var sb = new StringBuilder ();
                 sb.append (" Receiver · Browse (%d)".printf (item_count ()));
@@ -657,7 +676,11 @@ namespace Receiver {
                 if (language_label != "") {
                     sb.append ("  lang:" + language_label);
                 }
-                sb.append ("   [c]/[l] filter  [/] search  [Tab] view  [q] quit");
+                sb.append ("   [c]/[l] filter  [/] search");
+                if (search_text != "") {
+                    sb.append ("  [Esc] clear");
+                }
+                sb.append ("  [Tab] view  [q] quit");
                 text = sb.str;
             } else {
                 text = " Receiver · %s (%d)   [Tab] view  [↵] play  [space] pause  [f] fav  [q] quit"

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -20,6 +20,9 @@ namespace Receiver {
 
         private const double VOLUME_STEP = 0.05;
 
+        // Keeps core log messages from corrupting the curses screen.
+        private static FileStream? log_stream;
+
         private MainLoop loop = new MainLoop ();
         private unowned Curses.Window scr;
         private IOChannel stdin_channel;
@@ -402,10 +405,32 @@ namespace Receiver {
             }
             return sb.str;
         }
-    }
 
-    public static int main (string[] args) {
-        Gst.init (ref args);
-        return new Tui ().run ();
+        // Redirect GLib log messages (from the core services) to a file so they
+        // don't print over the curses screen.
+        private static void redirect_logs () {
+            var dir = Path.build_filename (Environment.get_user_cache_dir (), "receiver");
+            DirUtils.create_with_parents (dir, 0755);
+            log_stream = FileStream.open (Path.build_filename (dir, "tui.log"), "w");
+            Log.set_writer_func ((level, fields) => {
+                // Drop verbose DEBUG/INFO chatter (GIO, dconf, …); keep
+                // messages, warnings and errors.
+                if ((level & (LogLevelFlags.LEVEL_DEBUG | LogLevelFlags.LEVEL_INFO)) != 0) {
+                    return LogWriterOutput.HANDLED;
+                }
+                if (log_stream != null) {
+                    log_stream.puts (Log.writer_format_fields (level, fields, false));
+                    log_stream.putc ('\n');
+                    log_stream.flush ();
+                }
+                return LogWriterOutput.HANDLED;
+            });
+        }
+
+        public static int main (string[] args) {
+            redirect_logs ();
+            Gst.init (ref args);
+            return new Tui ().run ();
+        }
     }
 }

--- a/src/tui/main.vala
+++ b/src/tui/main.vala
@@ -82,14 +82,16 @@ namespace Receiver {
                 return 1;
             }
 
-            // Skip language/country filtering ("all" bypasses those clauses).
-            store.language_filter = "all";
-            store.country_filter = "all";
             wire_core ();
-            load_database ();
 
-            // Persist volume and last station via GSettings, shared with the GTK app.
-            AppState.get_default ().settings.bind ("volume", player, "volume", SettingsBindFlags.DEFAULT);
+            // Persist player + filter state via GSettings, shared with the GTK app.
+            var settings = AppState.get_default ().settings;
+            settings.bind ("volume", player, "volume", SettingsBindFlags.DEFAULT);
+            settings.bind ("language-filter", store, "language-filter", SettingsBindFlags.DEFAULT);
+            settings.bind ("country-filter", store, "country-filter", SettingsBindFlags.DEFAULT);
+
+            load_database ();
+            sync_filter_labels ();
             restore_last_station ();
 
             // Register MPRIS so desktop media keys control playback.
@@ -509,6 +511,27 @@ namespace Receiver {
         private void close_picker () {
             picker = PickerMode.NONE;
             needs_redraw = true;
+        }
+
+        // Rebuild the header filter labels from filter codes restored via GSettings.
+        private void sync_filter_labels () {
+            country_label = "";
+            var cf = store.country_filter;
+            if (cf != "all" && cf != "") {
+                var codes = store.get_available_country_codes ();
+                var names = store.get_available_country_names ();
+                for (int i = 0; i < codes.length; i++) {
+                    if (codes[i] == cf) {
+                        country_label = names[i];
+                        break;
+                    }
+                }
+            }
+            language_label = "";
+            var lf = store.language_filter;
+            if (lf != "all" && lf != "") {
+                language_label = Languages.translate (lf);
+            }
         }
 
         private void cycle_view (int dir) {

--- a/vapi/ncursesw.vapi
+++ b/vapi/ncursesw.vapi
@@ -1,0 +1,148 @@
+/*
+ * Minimal Vala binding for ncursesw.
+ *
+ * Hand-written to cover only the surface the Receiver TUI uses: lifecycle,
+ * non-blocking input, windowed drawing, colour pairs and key/attribute
+ * constants. Link against the `ncursesw` pkg-config dependency.
+ */
+[CCode (cheader_filename = "curses.h", lower_case_cprefix = "")]
+namespace Curses {
+
+    [Compact]
+    [CCode (cname = "WINDOW", free_function = "delwin", has_type_id = false)]
+    public class Window {
+        // Initialise curses; returns the standard screen (owned by curses,
+        // never freed by us — hence unowned).
+        [CCode (cname = "initscr")]
+        public static unowned Window initscr ();
+
+        // Create a sub-window; freed with delwin via the compact free_function.
+        [CCode (cname = "newwin")]
+        public Window (int nlines, int ncols, int begin_y, int begin_x);
+
+        [CCode (cname = "keypad")]
+        public int keypad (bool enable);
+        [CCode (cname = "nodelay")]
+        public int nodelay (bool enable);
+        [CCode (cname = "wtimeout")]
+        public void set_timeout (int delay);
+
+        [CCode (cname = "wgetch")]
+        public int getch ();
+
+        [CCode (cname = "wrefresh")]
+        public int refresh ();
+        [CCode (cname = "wnoutrefresh")]
+        public int noutrefresh ();
+        [CCode (cname = "werase")]
+        public int erase ();
+        [CCode (cname = "wclear")]
+        public int clear ();
+        [CCode (cname = "wmove")]
+        public int move (int y, int x);
+
+        [CCode (cname = "waddstr")]
+        public int addstr (string str);
+        [CCode (cname = "mvwaddstr")]
+        public int mvaddstr (int y, int x, string str);
+
+        [CCode (cname = "wattron")]
+        public int attron (int attrs);
+        [CCode (cname = "wattroff")]
+        public int attroff (int attrs);
+
+        [CCode (cname = "mvwhline")]
+        public int hline (int y, int x, ulong ch, int n);
+
+        [CCode (cname = "getmaxx")]
+        public int getmaxx ();
+        [CCode (cname = "getmaxy")]
+        public int getmaxy ();
+    }
+
+    // Lifecycle
+    [CCode (cname = "endwin")]
+    public int endwin ();
+    [CCode (cname = "cbreak")]
+    public int cbreak ();
+    [CCode (cname = "noecho")]
+    public int noecho ();
+    [CCode (cname = "curs_set")]
+    public int curs_set (int visibility);
+    [CCode (cname = "doupdate")]
+    public int doupdate ();
+
+    // Colour
+    [CCode (cname = "has_colors")]
+    public bool has_colors ();
+    [CCode (cname = "start_color")]
+    public int start_color ();
+    [CCode (cname = "use_default_colors")]
+    public int use_default_colors ();
+    [CCode (cname = "init_pair")]
+    public int init_pair (int pair, int fg, int bg);
+    [CCode (cname = "COLOR_PAIR")]
+    public int color_pair (int pair);
+
+    // Globals (updated by curses, e.g. on resize)
+    [CCode (cname = "COLS")]
+    public int COLS;
+    [CCode (cname = "LINES")]
+    public int LINES;
+
+    // Return / colour constants
+    [CCode (cname = "ERR")]
+    public const int ERR;
+    [CCode (cname = "COLOR_BLACK")]
+    public const int COLOR_BLACK;
+    [CCode (cname = "COLOR_RED")]
+    public const int COLOR_RED;
+    [CCode (cname = "COLOR_GREEN")]
+    public const int COLOR_GREEN;
+    [CCode (cname = "COLOR_YELLOW")]
+    public const int COLOR_YELLOW;
+    [CCode (cname = "COLOR_BLUE")]
+    public const int COLOR_BLUE;
+    [CCode (cname = "COLOR_MAGENTA")]
+    public const int COLOR_MAGENTA;
+    [CCode (cname = "COLOR_CYAN")]
+    public const int COLOR_CYAN;
+    [CCode (cname = "COLOR_WHITE")]
+    public const int COLOR_WHITE;
+
+    // Attributes
+    [CCode (cname = "A_NORMAL")]
+    public const int A_NORMAL;
+    [CCode (cname = "A_REVERSE")]
+    public const int A_REVERSE;
+    [CCode (cname = "A_BOLD")]
+    public const int A_BOLD;
+    [CCode (cname = "A_DIM")]
+    public const int A_DIM;
+    [CCode (cname = "A_UNDERLINE")]
+    public const int A_UNDERLINE;
+
+    // Special keys (returned by getch when keypad is enabled)
+    [CCode (cname = "KEY_UP")]
+    public const int KEY_UP;
+    [CCode (cname = "KEY_DOWN")]
+    public const int KEY_DOWN;
+    [CCode (cname = "KEY_LEFT")]
+    public const int KEY_LEFT;
+    [CCode (cname = "KEY_RIGHT")]
+    public const int KEY_RIGHT;
+    [CCode (cname = "KEY_HOME")]
+    public const int KEY_HOME;
+    [CCode (cname = "KEY_END")]
+    public const int KEY_END;
+    [CCode (cname = "KEY_NPAGE")]
+    public const int KEY_NPAGE;
+    [CCode (cname = "KEY_PPAGE")]
+    public const int KEY_PPAGE;
+    [CCode (cname = "KEY_BACKSPACE")]
+    public const int KEY_BACKSPACE;
+    [CCode (cname = "KEY_ENTER")]
+    public const int KEY_ENTER;
+    [CCode (cname = "KEY_RESIZE")]
+    public const int KEY_RESIZE;
+}

--- a/vapi/ncursesw.vapi
+++ b/vapi/ncursesw.vapi
@@ -143,6 +143,8 @@ namespace Curses {
     public const int KEY_BACKSPACE;
     [CCode (cname = "KEY_ENTER")]
     public const int KEY_ENTER;
+    [CCode (cname = "KEY_BTAB")]
+    public const int KEY_BTAB;
     [CCode (cname = "KEY_RESIZE")]
     public const int KEY_RESIZE;
 }

--- a/vapi/ncursesw.vapi
+++ b/vapi/ncursesw.vapi
@@ -83,6 +83,10 @@ namespace Curses {
     public const uint BUTTON1_PRESSED;
     [CCode (cname = "BUTTON1_CLICKED")]
     public const uint BUTTON1_CLICKED;
+    [CCode (cname = "BUTTON3_PRESSED")]
+    public const uint BUTTON3_PRESSED;
+    [CCode (cname = "BUTTON3_CLICKED")]
+    public const uint BUTTON3_CLICKED;
     [CCode (cname = "BUTTON4_PRESSED")]
     public const uint BUTTON4_PRESSED;
     [CCode (cname = "BUTTON5_PRESSED")]

--- a/vapi/ncursesw.vapi
+++ b/vapi/ncursesw.vapi
@@ -60,6 +60,34 @@ namespace Curses {
         public int getmaxy ();
     }
 
+    // Mouse
+    [CCode (cname = "MEVENT", has_type_id = false)]
+    public struct MEvent {
+        public short id;
+        public int x;
+        public int y;
+        public int z;
+        public uint bstate;
+    }
+
+    [CCode (cname = "mousemask")]
+    public uint mousemask (uint newmask, out uint oldmask = null);
+    [CCode (cname = "getmouse")]
+    public int getmouse (out MEvent ev);
+
+    [CCode (cname = "KEY_MOUSE")]
+    public const int KEY_MOUSE;
+    [CCode (cname = "ALL_MOUSE_EVENTS")]
+    public const uint ALL_MOUSE_EVENTS;
+    [CCode (cname = "BUTTON1_PRESSED")]
+    public const uint BUTTON1_PRESSED;
+    [CCode (cname = "BUTTON1_CLICKED")]
+    public const uint BUTTON1_CLICKED;
+    [CCode (cname = "BUTTON4_PRESSED")]
+    public const uint BUTTON4_PRESSED;
+    [CCode (cname = "BUTTON5_PRESSED")]
+    public const uint BUTTON5_PRESSED;
+
     // Lifecycle
     [CCode (cname = "endwin")]
     public int endwin ();

--- a/vapi/posix-extras.vapi
+++ b/vapi/posix-extras.vapi
@@ -1,0 +1,6 @@
+/* Small libc bindings needed by the TUI that aren't in the GLib profile. */
+[CCode (cheader_filename = "unistd.h")]
+namespace PosixExtras {
+    [CCode (cname = "isatty")]
+    public int isatty (int fd);
+}


### PR DESCRIPTION
## Summary

Adds a full-featured ncurses terminal UI (`receiver-tui`) alongside the existing GTK app, sharing playback logic through a newly extracted `libreceiver-core` static library.

## What's included

- **Core extraction** — pull shared playback/model code into `libreceiver-core` so both the GTK app and the TUI build on it.
- **TUI** — ncurses-based browse + play client (`src/tui/main.vala`, `make run-tui`):
  - Browse and play stations, Favourites and History views
  - Country/language filters, persisted via GSettings
  - Search with live header term and Esc to clear
  - Volume and last-station persistence via GSettings
  - MPRIS media-key control wired in
  - Mouse support: click to play, wheel scroll, clickable header, mouse-driven picker, right-click to favourite
  - Receiver branding in the header
- **Build** — ncursesw + posix-extras VAPIs, meson options, and Makefile target.

## Test plan

- `make run-tui` from the build tree launches the TUI
- Browse, filter, search, favourite, and play stations
- Media keys and volume/station persistence survive restart
