### PR TITLE
feat: keep playing in the background when the window is closed

### DIFF
--- a/data/io.github.meehow.Receiver.desktop
+++ b/data/io.github.meehow.Receiver.desktop
@@ -8,3 +8,4 @@ Icon=io.github.meehow.Receiver
 Terminal=false
 Categories=Audio;Music;Player;GTK;
 StartupNotify=true
+DBusActivatable=true

--- a/data/io.github.meehow.Receiver.gschema.xml
+++ b/data/io.github.meehow.Receiver.gschema.xml
@@ -48,6 +48,11 @@
       <default>800</default>
       <summary>Window height</summary>
     </key>
+    <key name="run-in-background" type="b">
+      <default>true</default>
+      <summary>Keep playing in the background</summary>
+      <description>When enabled, closing the window keeps playback running in the background instead of quitting. Use Stop or the system Background Apps menu to exit.</description>
+    </key>
 
   </schema>
 </schemalist>

--- a/data/io.github.meehow.Receiver.gschema.xml
+++ b/data/io.github.meehow.Receiver.gschema.xml
@@ -49,7 +49,7 @@
       <summary>Window height</summary>
     </key>
     <key name="run-in-background" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Keep playing in the background</summary>
       <description>When enabled, closing the window keeps playback running in the background instead of quitting. Use Stop or the system Background Apps menu to exit.</description>
     </key>

--- a/data/io.github.meehow.Receiver.service.in
+++ b/data/io.github.meehow.Receiver.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=io.github.meehow.Receiver
+Exec=@bindir@/receiver --gapplication-service

--- a/meson.build
+++ b/meson.build
@@ -141,6 +141,16 @@ install_data('data/io.github.meehow.Receiver.desktop',
   install_dir: get_option('datadir') / 'applications'
 )
 
+# D-Bus activation service: lets the desktop activate the running instance
+# (raise it from MPRIS / background mode) instead of spawning a new process.
+configure_file(
+  input: 'data/io.github.meehow.Receiver.service.in',
+  output: 'io.github.meehow.Receiver.service',
+  configuration: {'bindir': get_option('prefix') / get_option('bindir')},
+  install: true,
+  install_dir: get_option('datadir') / 'dbus-1/services'
+)
+
 install_data('data/io.github.meehow.Receiver.metainfo.xml',
   install_dir: get_option('datadir') / 'metainfo'
 )

--- a/src/application.vala
+++ b/src/application.vala
@@ -10,7 +10,7 @@ namespace Receiver {
         public Application() {
             Object(
                 application_id: "io.github.meehow.Receiver",
-                flags: ApplicationFlags.DEFAULT_FLAGS | ApplicationFlags.NON_UNIQUE
+                flags: ApplicationFlags.DEFAULT_FLAGS
             );
         }
 
@@ -19,6 +19,38 @@ namespace Receiver {
             var win = active_window;
             if (win != null) {
                 win.present();
+            }
+        }
+
+        // Called by the window when it hides itself instead of quitting.
+        // Tells the desktop we intend to keep running and lets the user know.
+        public void enter_background() {
+            request_background_portal();
+
+            var n = new GLib.Notification(_("Receiver is playing in the background"));
+            n.set_body(_("Use the system media controls or Stop to exit."));
+            send_notification("background-playback", n);
+        }
+
+        // Best-effort Background portal request over D-Bus (no libportal needed,
+        // and a no-op when no portal is running, e.g. outside Flatpak).
+        private void request_background_portal() {
+            try {
+                var conn = Bus.get_sync(BusType.SESSION);
+                var options = new VariantBuilder(new VariantType("a{sv}"));
+                options.add("{sv}", "reason", new Variant.string(
+                    _("Receiver keeps playing radio after the window is closed")));
+                options.add("{sv}", "autostart", new Variant.boolean(false));
+                conn.call.begin(
+                    "org.freedesktop.portal.Desktop",
+                    "/org/freedesktop/portal/desktop",
+                    "org.freedesktop.portal.Background",
+                    "RequestBackground",
+                    new Variant("(sa{sv})", "", options),
+                    new VariantType("(o)"),
+                    DBusCallFlags.NONE, -1, null);
+            } catch (Error e) {
+                debug("Background portal unavailable: %s", e.message);
             }
         }
 
@@ -56,6 +88,15 @@ namespace Receiver {
                 }
             });
 
+            // When running in the background (window hidden), Stop means "done":
+            // tear the process down. Pause keeps it alive.
+            player.state_changed.connect((new_state) => {
+                var win = active_window;
+                if (new_state == PlayerState.STOPPED && win != null && !win.visible) {
+                    this.quit();
+                }
+            });
+
             // Record songs to history
             player.metadata_changed.connect((title) => {
                 if (player.current_station != null && player.state == PlayerState.PLAYING) {
@@ -80,6 +121,10 @@ namespace Receiver {
 
 
         private void setup_actions() {
+            // Run-in-background toggle (stateful, backed by GSettings)
+            var bg_action = AppState.get_default().settings.create_action("run-in-background");
+            this.add_action(bg_action);
+
             // Quit action
             var quit_action = new SimpleAction("quit", null);
             quit_action.activate.connect(() => {

--- a/src/application.vala
+++ b/src/application.vala
@@ -40,13 +40,10 @@ namespace Receiver {
         }
 
         // Called by the window when it hides itself instead of quitting.
-        // Tells the desktop we intend to keep running and lets the user know.
+        // Tells the desktop we intend to keep running (the system surfaces this
+        // via MPRIS controls and the Background Apps menu, so no notification).
         public void enter_background() {
             request_background_portal();
-
-            var n = new GLib.Notification(_("Receiver is playing in the background"));
-            n.set_body(_("Use the system media controls or Stop to exit."));
-            send_notification("background-playback", n);
         }
 
         // Best-effort Background portal request over D-Bus (no libportal needed,

--- a/src/application.vala
+++ b/src/application.vala
@@ -39,16 +39,11 @@ namespace Receiver {
             win.present();
         }
 
-        // Called by the window when it hides itself instead of quitting.
-        // Tells the desktop we intend to keep running (the system surfaces this
-        // via MPRIS controls and the Background Apps menu, so no notification).
-        public void enter_background() {
-            request_background_portal();
-        }
-
         // Best-effort Background portal request over D-Bus (no libportal needed,
-        // and a no-op when no portal is running, e.g. outside Flatpak).
-        private void request_background_portal() {
+        // and a no-op when no portal is running, e.g. outside Flatpak). Called by
+        // the window when it hides itself instead of quitting, so the desktop
+        // knows we intend to keep running (surfaced via the Background Apps menu).
+        public void request_background_portal() {
             try {
                 var conn = Bus.get_sync(BusType.SESSION);
                 var options = new VariantBuilder(new VariantType("a{sv}"));

--- a/src/application.vala
+++ b/src/application.vala
@@ -16,10 +16,27 @@ namespace Receiver {
 
         // MprisHost
         public void raise() {
-            var win = active_window;
-            if (win != null) {
-                win.present();
+            present_main_window();
+        }
+
+        // Bring the main window to the front, re-showing it if it was hidden by
+        // background mode. active_window is null while the only window is hidden,
+        // so look through the full window list (which still includes it) and only
+        // build a fresh window when there genuinely isn't one.
+        private void present_main_window() {
+            Gtk.Window? win = active_window;
+            if (win == null) {
+                unowned List<Gtk.Window> wins = get_windows();
+                if (wins != null) {
+                    win = wins.data;
+                }
             }
+            if (win == null) {
+                win = new MainWindow(this);
+                open_database();
+            }
+            win.set_visible(true);
+            win.present();
         }
 
         // Called by the window when it hides itself instead of quitting.
@@ -109,14 +126,7 @@ namespace Receiver {
         }
 
         protected override void activate() {
-            var window = this.active_window;
-            if (window == null) {
-                window = new MainWindow(this);
-            }
-            window.present();
-
-            // Open database after window is shown
-            open_database();
+            present_main_window();
         }
 
 

--- a/src/widgets/window.vala
+++ b/src/widgets/window.vala
@@ -29,6 +29,15 @@ namespace Receiver {
             this.close_request.connect(() => {
                 s.set_int("window-width", this.default_width);
                 s.set_int("window-height", this.default_height);
+
+                // Keep playing in the background: hide instead of destroying the
+                // window so the app's last window stays registered and it lives on.
+                if (s.get_boolean("run-in-background") &&
+                    app.player.state != PlayerState.STOPPED) {
+                    this.set_visible(false);
+                    app.enter_background();
+                    return true;
+                }
                 return false;
             });
         }
@@ -62,6 +71,7 @@ namespace Receiver {
             app.scrobbler.status_changed.connect(update_lastfm_label);
 
             menu.append(_("Song History"), "win.history");
+            menu.append(_("Keep Playing in Background"), "app.run-in-background");
             menu.append(_("About Receiver"), "win.about");
 
             menu_button.menu_model = menu;

--- a/src/widgets/window.vala
+++ b/src/widgets/window.vala
@@ -35,7 +35,7 @@ namespace Receiver {
                 if (s.get_boolean("run-in-background") &&
                     app.player.state != PlayerState.STOPPED) {
                     this.set_visible(false);
-                    app.enter_background();
+                    app.request_background_portal();
                     return true;
                 }
                 return false;

--- a/src/widgets/window.vala
+++ b/src/widgets/window.vala
@@ -32,8 +32,10 @@ namespace Receiver {
 
                 // Keep playing in the background: hide instead of destroying the
                 // window so the app's last window stays registered and it lives on.
+                // Only when there is actually playback (not when stopped or errored).
+                var state = app.player.state;
                 if (s.get_boolean("run-in-background") &&
-                    app.player.state != PlayerState.STOPPED) {
+                    (state == PlayerState.PLAYING || state == PlayerState.PAUSED)) {
                     this.set_visible(false);
                     app.request_background_portal();
                     return true;


### PR DESCRIPTION
## Summary

Keep playing in the background when the window is closed, with the lifecycle tied to Stop rather than Pause. Opt-in via a menu toggle (default off).

## Behaviour

- Closing the window while **playing or paused** hides it instead of quitting, so playback and MPRIS keep running. The hidden window stays registered with the application, so its use-count keeps the process alive; raising re-presents the same window with no rebuild.
- Closing while **stopped or errored** quits as before.
- While backgrounded, **Stop** (MPRIS, media controls, `playerctl`) tears the process down; **Pause** keeps it alive.
- A "Keep Playing in Background" toggle in the primary menu controls the behaviour (stateful action backed by GSettings key `run-in-background`, default off).

## Restoring the window

- `raise()` (MPRIS) and `activate()` both go through a shared `present_main_window()` that finds the hidden window via `get_windows()` and re-shows it, instead of building a duplicate. `active_window` is null while the only window is hidden, which is why the previous lookup failed.
- Dropped `ApplicationFlags.NON_UNIQUE` so relaunching re-presents the existing instance instead of spawning a second process.
- Marked the app `DBusActivatable` and ship a D-Bus `.service` file so the desktop activates the running instance over D-Bus.

## Desktop integration

- On entering the background, makes a best-effort Background portal `RequestBackground` over plain GDBus (no libportal dependency; a no-op outside Flatpak) so GNOME lists the app under Background Apps, which also provides a discoverable Quit.

## Notes

- New translatable string in `src/application.vala` (the portal reason); `src/application.vala` should be added to `po/POTFILES` and translations regenerated at release time.

## Test plan

Requires an installed build (`make install` or the Flatpak), the MPRIS/activation paths launch the installed binary, not the dev tree:

- Play a station, close the window: window hides, audio keeps playing.
- Click Receiver in GNOME media controls: existing window returns (no second instance).
- Press Stop while hidden: app exits.
- Toggle off: closing the window quits.
