### PR TITLE
fix: missing icons on deb and AppImage (#17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,11 +118,18 @@ appimage: build $(LINUXDEPLOY) $(LINUXDEPLOY_GTK)
 	    /usr/lib/x86_64-linux-gnu/gio/modules/libgiolibproxy.so \
 	    $(APPDIR)/usr/lib/x86_64-linux-gnu/gio/modules/
 	gio-querymodules $(APPDIR)/usr/lib/x86_64-linux-gnu/gio/modules
-	@# Bundle only Adwaita symbolic icons (needed by GTK4/Libadwaita)
+	@# Bundle Adwaita symbolic icons (needed by GTK4/Libadwaita)
 	mkdir -p $(APPDIR)/usr/share/icons/Adwaita
 	cp /usr/share/icons/Adwaita/index.theme $(APPDIR)/usr/share/icons/Adwaita/
 	cp -r /usr/share/icons/Adwaita/symbolic $(APPDIR)/usr/share/icons/Adwaita/
 	-cp -r /usr/share/icons/Adwaita/symbolic-up-to-32 $(APPDIR)/usr/share/icons/Adwaita/
+	@# hicolor is the base theme Adwaita inherits from; without its index.theme
+	@# GTK fails to build the theme chain and shows only its built-in icons
+	mkdir -p $(APPDIR)/usr/share/icons/hicolor
+	cp /usr/share/icons/hicolor/index.theme $(APPDIR)/usr/share/icons/hicolor/
+	@# Regenerate icon caches so GTK reliably resolves the bundled themes
+	-gtk4-update-icon-cache -ft $(APPDIR)/usr/share/icons/Adwaita
+	-gtk4-update-icon-cache -ft $(APPDIR)/usr/share/icons/hicolor
 	VERSION=$(VERSION) DEPLOY_GTK_VERSION=4 ./$(LINUXDEPLOY) \
 		--appdir $(APPDIR) \
 		--plugin gtk \

--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Package: receiver
 Architecture: any
 Depends: ${shlibs:Depends},
          ${misc:Depends},
+         adwaita-icon-theme,
          gstreamer1.0-plugins-base,
          gstreamer1.0-plugins-good,
          webp-pixbuf-loader

--- a/src/widgets/history_page.vala
+++ b/src/widgets/history_page.vala
@@ -90,7 +90,7 @@ namespace Receiver {
         }
 
         private void build_ui() {
-            var icon = new Gtk.Image.from_icon_name("music-note-single-symbolic");
+            var icon = new Gtk.Image.from_icon_name("audio-x-generic-symbolic");
             icon.add_css_class("dim-label");
             icon.valign = Gtk.Align.CENTER;
             this.append(icon);


### PR DESCRIPTION
Fixes #17.

## Problem

On the deb and AppImage, symbolic icons that aren't part of GTK's own built-in set rendered as the missing-icon placeholder (a white exclamation mark): the favourite star, the Browse/Favourites view-switcher tab icons, and station artwork placeholders. The flatpak was unaffected (its runtime ships the full Adwaita theme).

Root cause: GTK4 embeds only a small set of `actions` symbolic icons in libgtk itself; everything else needs the Adwaita icon theme to be present **and loadable**. Neither the deb nor the AppImage guaranteed that.

## Changes

- **history note icon**: `music-note-single-symbolic` isn't in the Adwaita theme at all (no channel has it), so it always rendered broken. Switched to `audio-x-generic-symbolic`, which is in Adwaita and already used for station artwork.
- **deb**: add `adwaita-icon-theme` to `Depends`. `${shlibs:Depends}` only resolves shared libraries, not the icon-theme data package, so a minimal system got broken icons.
- **AppImage**: also bundle `hicolor`'s `index.theme`. Adwaita inherits from hicolor; without the base theme's index, GTK can't build the theme chain and falls back to only its built-in icons (exactly the reported symptom). Also regenerate the icon caches for both themes.

## Verification

Simulated the AppImage bundle and queried `GtkIconTheme` against it: `starred-symbolic`, `non-starred-symbolic`, and `audio-x-generic-symbolic` all resolve; `music-note-single-symbolic` does not (confirming the swap was required).

Note: a full `make appimage` (needs linuxdeploy + network) should get one CI run to confirm end to end. The matching CI change to install the icon themes on the AppImage build host is in a separate branch (`ci/appimage-icon-deps`) because pushing workflow changes needs the `workflow` token scope.
