### PR TITLE
build: give meson its own _build dir to avoid flatpak clash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Build directories
+_build/
 builddir/
 obj-x86_64-linux-gnu/
 .flatpak-builder

--- a/Makefile
+++ b/Makefile
@@ -13,31 +13,31 @@ VERSION = $(shell grep "version:" meson.build | head -1 | sed "s/.*'\(.*\)'.*/\1
         flatpak-build flatpak-run flatpak-lint-manifest flatpak-lint-repo flatpak-submit \
         translations-check translations-update
 
-builddir:
-	meson setup builddir --prefix=/usr --buildtype=release
+_build:
+	meson setup _build --prefix=/usr --buildtype=release
 
-build: builddir
-	meson compile -C builddir
+build: _build
+	meson compile -C _build
 
 install: build
-	meson install -C builddir
+	meson install -C _build
 
 clean:
-	rm -rf builddir
+	rm -rf _build
 
 run: build
 	glib-compile-schemas data/
 	GSETTINGS_SCHEMA_DIR=$(CURDIR)/data \
 	XDG_DATA_DIRS=$(CURDIR)/data:/usr/share \
-	LOCALEDIR=$(CURDIR)/builddir/po \
-	./builddir/receiver
+	LOCALEDIR=$(CURDIR)/_build/po \
+	./_build/receiver
 
 run-tui: build
 	glib-compile-schemas data/
 	GSETTINGS_SCHEMA_DIR=$(CURDIR)/data \
 	XDG_DATA_DIRS=$(CURDIR)/data:/usr/share \
-	LOCALEDIR=$(CURDIR)/builddir/po \
-	./builddir/receiver-tui
+	LOCALEDIR=$(CURDIR)/_build/po \
+	./_build/receiver-tui
 
 deb:
 	dpkg-buildpackage -us -uc -b
@@ -48,9 +48,9 @@ translations-check:
 		msgfmt --statistics -o /dev/null $$file; \
 	done
 
-translations-update: builddir
-	meson compile -C builddir receiver-pot
-	meson compile -C builddir receiver-update-po
+translations-update: _build
+	meson compile -C _build receiver-pot
+	meson compile -C _build receiver-update-po
 
 translations-prune:
 	@for file in po/*.po; do \
@@ -79,7 +79,7 @@ $(LINUXDEPLOY_GTK):
 
 appimage: build $(LINUXDEPLOY) $(LINUXDEPLOY_GTK)
 	rm -rf $(APPDIR)
-	DESTDIR=$(CURDIR)/$(APPDIR) meson install -C builddir
+	DESTDIR=$(CURDIR)/$(APPDIR) meson install -C _build
 	@# Bundle GStreamer plugins
 	mkdir -p $(APPDIR)/usr/lib/x86_64-linux-gnu/gstreamer-1.0
 	cp $(GST_LIBDIR)/libgstcoreelements.so \


### PR DESCRIPTION
## Problem

`flathub-build` (inside `org.flatpak.Builder`) hard-codes `builddir` as its flatpak-builder output directory, the same name the Makefile used for the meson build tree. Running `make flatpak-build` overwrote the meson `builddir` with a flatpak app tree, so a subsequent `make run` failed:

```
ERROR: Current directory is not a meson build directory: `.../builddir`.
```

## Fix

Move the meson build tree to `_build` across all targets (build/install/run/run-tui/appimage/translations) and gitignore it. `builddir` is now left to flatpak, so the two never collide.
