### PR TITLE
release v0.6.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
 subprojects/ytdl/data/*.js linguist-vendored
+
+# Translation catalogs are generated; collapse them in diffs and keep them
+# out of language statistics.
+po/*.po linguist-generated=true
+po/*.pot linguist-generated=true

--- a/data/io.github.meehow.Receiver.metainfo.xml
+++ b/data/io.github.meehow.Receiver.metainfo.xml
@@ -77,6 +77,19 @@
   </screenshots>
   
   <releases>
+    <release version="0.6.0" date="2026-06-30">
+      <description>
+        <ul>
+          <li>Add a terminal UI (receiver-tui): browse and play, Favourites and History, country and language filters, search, MPRIS media keys, and mouse support</li>
+          <li>Keep playing in the background when the window is closed (optional; toggle in the menu)</li>
+          <li>Fix missing favourite and tab icons on the .deb and AppImage</li>
+          <li>Smoother playback of high-bitrate streams by pausing while buffering</li>
+          <li>Apply a consistent cubic volume curve and align the player bar title</li>
+          <li>Load station artwork even when the list is too short to scroll</li>
+          <li>Reserve scrollbar height in the genre strip with classic scrollbars</li>
+        </ul>
+      </description>
+    </release>
     <release version="0.5.0" date="2026-04-02">
       <description>
         <ul>

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+receiver (0.6.0-1) unstable; urgency=medium
+
+  * Add a terminal UI (receiver-tui): browse and play, Favourites and
+    History, country/language filters, search, MPRIS media keys, and mouse
+    support
+  * Keep playing in the background when the window is closed (optional;
+    toggle in the menu)
+  * Fix missing favourite and tab icons on the .deb and AppImage
+  * Smoother playback of high-bitrate streams (pause while buffering)
+  * Apply a consistent cubic volume curve and align the player-bar title
+  * Load station artwork even when the list is too short to scroll
+  * Reserve scrollbar height in the genre strip with classic scrollbars
+
+ -- Michał Adamski <michal.adamski@808bits.com>  Tue, 30 Jun 2026 00:55:43 +0200
+
 receiver (0.5.0-1) unstable; urgency=medium
 
   * Replace home screen with dedicated Browse and Favourites tabs

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('receiver', 'vala', 'c',
-  version: '0.5.0',
+  version: '0.6.0',
   meson_version: '>= 0.59.0',
   default_options: ['warning_level=2']
 )

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,5 @@
 src/main.vala
+src/application.vala
 src/utils/languages.vala
 src/widgets/window.vala
 src/widgets/favourites_page.vala

--- a/po/af.po
+++ b/po/af.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver speel steeds radio nadat die venster toegemaak is"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Kieslys"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Liedgeskiedenis"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Hou aan speel in die agtergrond"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Oor Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Blaai"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Gunstelinge"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stasie-inligting"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasies gelaai"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Terugspeel-fout: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Speel nou: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Hervat: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Kanselleer Last.fm-magtiging"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Ontkoppel van Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Koppel aan Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-magtiging gekanselleer"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Van Last.fm ontkoppel"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Verbind met Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kon nie aan Last.fm koppel nie"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Gee toegang in jou blaaier…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-magtiging het uitgetel"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Aan Last.fm gekoppel"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Ontdek 30,000+ geverifieerde radiostasies van regoor die wêreld"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Geen gunstelinge"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Merk stasies terwyl jy blaai om hulle hier by te voeg"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Soek stasies…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle tale"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filter volgens taal"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle lande"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filter volgens land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Geen stasies"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laai…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u van %d stasies"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasies: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Laai stasies"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Geen resultate"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Wag asseblief…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Geen stasies pas by jou soektog"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kon nie stasies laai nie"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stasie"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Merkers"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webwerf"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bistempo"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stroom-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Speel nie"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Kies 'n stasie"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buffer tans…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Speel nou"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Onderbreek"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Herkoppel…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Soek op YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Soektog het misluk: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Geen YouTube-resultate gevind"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultate onbeskikbaar"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Laai af: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Gekanselleer"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Aflaai het misluk: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Gestoor: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Laai liedjie af"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Kanselleer aflaai"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nog Geen Liedjies"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Liedjies sal hier verskyn soos jy na radiostasies luister"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Sopas"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min. gelede"
 msgstr[1] "%d min. gelede"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d uur gelede"
 msgstr[1] "%d ure gelede"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/af.po
+++ b/po/af.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver speel steeds radio nadat die venster toegemaak is"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Kieslys"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Liedgeskiedenis"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Hou aan speel in die agtergrond"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Oor Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Blaai"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Gunstelinge"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stasie-inligting"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasies gelaai"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Terugspeel-fout: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Speel nou: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Hervat: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Kanselleer Last.fm-magtiging"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Ontkoppel van Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Koppel aan Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-magtiging gekanselleer"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Van Last.fm ontkoppel"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Verbind met Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kon nie aan Last.fm koppel nie"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Gee toegang in jou blaaier…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-magtiging het uitgetel"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Aan Last.fm gekoppel"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Ontdek 30,000+ geverifieerde radiostasies van regoor die wêreld"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Merk stasies terwyl jy blaai om hulle hier by te voeg"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Soek stasies…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle tale"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filter volgens taal"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle lande"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filter volgens land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Geen stasies"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laai…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u van %d stasies"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasies: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Laai stasies"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Geen resultate"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Wag asseblief…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Geen stasies pas by jou soektog"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kon nie stasies laai nie"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Stroom-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Speel nie"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Kies 'n stasie"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buffer tans…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Speel nou"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Onderbreek"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Herkoppel…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Speel nou"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ak.po
+++ b/po/ak.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ak\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver kɔ so bɔ radio bere a wɔato tokuru no"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Nnwom Ho Abakɔsɛm"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Kɔ so bɔ wɔ akyiri"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Fa Receiver Ho"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Hwehwɛ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Nea wopɛ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Dwumadibea ho nsɛm"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Wɔde nneɛma %d ahyɛ mu"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Mfomso: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Bɔ mu mfomso: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Seisei rebɔ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Resan abɔ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Gyae Last.fm Tumi"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Tew wo ho fi Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Ka wo ho hyɛ Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm tumi agyae"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Wɔatew wo ho afi Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Rekafo Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Antumi anka ho anhyɛ Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Ma kwan wɔ wo browser mu…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm tumi bere asa"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Wɔaka ho ahyɛ Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Hu radio steshɔn 30,000+ firi wiase nyinaa"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nea wopɛ biara nni hɔ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Hyɛ nsoromabotan wɔ dwumadibea so bere a wohwehwɛ de ka ha ho"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Hwehwɛ nneɛma…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Kasa Nyinaa"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Yi firi kasa mu"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Aman nyinaa"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Hwehwɛ ɔman so"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nneɛma Biara Nni Hɔ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Rehyɛ mu…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u wɔ %d nneɛma mu"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Nneɛma: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Rehyɛ Nneɛma Mu"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nsɛm Biara Nni Hɔ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Mepa wo kyɛw, twɛn…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nneɛma biara nhyia wo hwehwɛ no"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Antumi anhyɛ nneɛma mu"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Dwumadibea"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ɔman"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Nsɛmfua"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Wɛbsaet"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodɛk"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bit tɛmpɔ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Nsuo URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Rembɔ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Paw nneɛma bi"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ɛreto…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Seisei rebɔ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Wɔagyina"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Resan abom…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Rehwehwɛ YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Hwehwɛ no anni yie: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube nsɛm biara nni hɔ"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Nsɛm nyinaa nni hɔ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Retwe: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Wɔagyae"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Twe no anni yie: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Wɔakora: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Twe dwom"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Gyae twe no"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nnwom Nni Hɔ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Nnwom bɛda adi ha sɛ wotie radio steshɔn"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Seesei"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "bere %d nie kan"
 msgstr[1] "bere %d nie kan"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "dɔnhwere %d nie kan"
 msgstr[1] "dɔnhwere %d nie kan"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ak.po
+++ b/po/ak.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ak\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver kɔ so bɔ radio bere a wɔato tokuru no"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Nnwom Ho Abakɔsɛm"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Kɔ so bɔ wɔ akyiri"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Fa Receiver Ho"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Hwehwɛ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Nea wopɛ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Dwumadibea ho nsɛm"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Wɔde nneɛma %d ahyɛ mu"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Mfomso: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Bɔ mu mfomso: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Seisei rebɔ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Resan abɔ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Gyae Last.fm Tumi"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Tew wo ho fi Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Ka wo ho hyɛ Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm tumi agyae"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Wɔatew wo ho afi Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Rekafo Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Antumi anka ho anhyɛ Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Ma kwan wɔ wo browser mu…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm tumi bere asa"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Wɔaka ho ahyɛ Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Hu radio steshɔn 30,000+ firi wiase nyinaa"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Hyɛ nsoromabotan wɔ dwumadibea so bere a wohwehwɛ de ka ha ho"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Hwehwɛ nneɛma…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Kasa Nyinaa"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Yi firi kasa mu"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Aman nyinaa"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Hwehwɛ ɔman so"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nneɛma Biara Nni Hɔ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Rehyɛ mu…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u wɔ %d nneɛma mu"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Nneɛma: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Rehyɛ Nneɛma Mu"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nsɛm Biara Nni Hɔ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Mepa wo kyɛw, twɛn…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nneɛma biara nhyia wo hwehwɛ no"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Antumi anhyɛ nneɛma mu"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Nsuo URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Rembɔ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Paw nneɛma bi"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ɛreto…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Seisei rebɔ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Wɔagyina"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Resan abom…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Seisei rebɔ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/am.po
+++ b/po/am.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: am\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "መስኮቱ ከተዘጋ በኋላም Receiver ሬዲዮ ማጫወቱን ይቀጥላል"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ምናሌ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "የዘፈን ታሪክ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "በጀርባ ማጫወት ቀጥል"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "ስለ Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ያስሱ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ተወዳጆች"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "የጣቢያ መረጃ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ጣቢያዎች ተጭነዋል"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ስህተት: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "የማጫወቻ ስህተት: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "አሁን እየተጫወተ ነው: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "እየቀጠለ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "የLast.fm ፈቃድ ሰርዝ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "ከLast.fm ግንኙነት አቋርጥ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "ከLast.fm ጋር ተገናኝ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "የLast.fm ፈቃድ ተሰርዟል"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "ከLast.fm ተለያይቷል"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "ከLast.fm ጋር በመገናኘት ላይ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "ከLast.fm ጋር መገናኘት አልተቻለም"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "በአሳሽዎ ውስጥ ፈቃድ ይስጡ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "የLast.fm ፈቃድ ጊዜው አልፏል"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "ከLast.fm ጋር ተገናኝቷል"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ከመላው ዓለም ከ30,000 በላይ የተረጋገጡ የሬዲዮ ጣቢያዎችን ያግኙ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ተወዳጆች የሉም"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "እዚህ ለማከል ሲያስሱ ጣቢያዎችን በኮከብ ምልክት ያድርጉ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ጣቢያዎችን ፈልግ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ሁሉም ቋንቋዎች"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "በቋንቋ ያጣሩ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ሁሉም ሀገራት"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "በሀገር አጣራ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ምንም ጣቢያዎች የሉም"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "በመጫን ላይ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ከ %d ጣቢያዎች"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ጣቢያዎች: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ጣቢያዎች በመጫን ላይ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ውጤት የለም"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "እባክዎ ይጠብቁ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ከፍለጋዎ ጋር የሚዛመድ ጣቢያ የለም"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ጣቢያዎችን መጫን አልተቻለም"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ጣቢያ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ሀገር"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "መለያዎች"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ድረገጽ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ኮዴክ"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ቢትሬት"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ዥረት URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "እየተጫወተ አይደለም"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ጣቢያ ይምረጡ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "በማጠራቀም ላይ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "አሁን እየተጫወተ ነው"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ቆሟል"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "እንደገና በመገናኘት ላይ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube ላይ በመፈለግ ላይ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ፍለጋ አልተሳካም: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "የYouTube ውጤት አልተገኘም"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ሁሉም ውጤቶች አይገኙም"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "በማውረድ ላይ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ተሰርዟል"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ማውረድ አልተሳካም: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ተቀምጧል: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ዘፈን አውርድ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ማውረድ ሰርዝ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ገና ምንም ዘፈኖች የሉም"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ሬዲዮ ጣቢያዎችን ሲያዳምጡ ዘፈኖች እዚህ ይታያሉ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "አሁን"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "ከ%d ደቂቃ በፊት"
 msgstr[1] "ከ%d ደቂቃዎች በፊት"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "ከ%d ሰዓት በፊት"
 msgstr[1] "ከ%d ሰዓታት በፊት"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/am.po
+++ b/po/am.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: am\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "መስኮቱ ከተዘጋ በኋላም Receiver ሬዲዮ ማጫወቱን ይቀጥላል"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ምናሌ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "የዘፈን ታሪክ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "በጀርባ ማጫወት ቀጥል"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "ስለ Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ያስሱ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ተወዳጆች"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "የጣቢያ መረጃ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ጣቢያዎች ተጭነዋል"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ስህተት: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "የማጫወቻ ስህተት: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "አሁን እየተጫወተ ነው: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "እየቀጠለ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "የLast.fm ፈቃድ ሰርዝ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "ከLast.fm ግንኙነት አቋርጥ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "ከLast.fm ጋር ተገናኝ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "የLast.fm ፈቃድ ተሰርዟል"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "ከLast.fm ተለያይቷል"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "ከLast.fm ጋር በመገናኘት ላይ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "ከLast.fm ጋር መገናኘት አልተቻለም"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "በአሳሽዎ ውስጥ ፈቃድ ይስጡ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "የLast.fm ፈቃድ ጊዜው አልፏል"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "ከLast.fm ጋር ተገናኝቷል"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ከመላው ዓለም ከ30,000 በላይ የተረጋገጡ የሬዲዮ ጣቢያዎችን ያግኙ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "እዚህ ለማከል ሲያስሱ ጣቢያዎችን በኮከብ ምልክት ያድርጉ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ጣቢያዎችን ፈልግ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ሁሉም ቋንቋዎች"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "በቋንቋ ያጣሩ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ሁሉም ሀገራት"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "በሀገር አጣራ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ምንም ጣቢያዎች የሉም"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "በመጫን ላይ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ከ %d ጣቢያዎች"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ጣቢያዎች: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ጣቢያዎች በመጫን ላይ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ውጤት የለም"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "እባክዎ ይጠብቁ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ከፍለጋዎ ጋር የሚዛመድ ጣቢያ የለም"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ጣቢያዎችን መጫን አልተቻለም"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ዥረት URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "እየተጫወተ አይደለም"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ጣቢያ ይምረጡ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "በማጠራቀም ላይ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "አሁን እየተጫወተ ነው"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ቆሟል"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "እንደገና በመገናኘት ላይ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "አሁን እየተጫወተ ነው"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/an.po
+++ b/po/an.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: an\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver sigue chugando radio dimpués de zarrar a finestra"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historial de cantas"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continar chugando en segundo plano"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Sobre Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Navegar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Información d'a estación"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estacions cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducción: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproducindo: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprendendo: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorización de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconnectar de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Connectar a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorización de Last.fm cancelada"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectau de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connectando a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "No s'ha puesto connectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Concede acceso en o tuyo navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "L'autorización de Last.fm ha expirato"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connectau a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubre mas de 30.000 estacions de radio verificadas de tot o mundo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca estacions mientras navegas pa adhibir-las aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Buscar estacions…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Todas as luengas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar por luenga"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Toz os países"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Sin estacions"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargando estacions"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sin resultaus"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Per favor, espera…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Garra estación coincide con a busca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "No s'han puesto cargar as estacions"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL d'o fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "No reproducindo"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleccionar una estación"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Almagazinando en búfer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Reproducindo"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconnectando…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Reproducindo"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/an.po
+++ b/po/an.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: an\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver sigue chugando radio dimpués de zarrar a finestra"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historial de cantas"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continar chugando en segundo plano"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Sobre Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Navegar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Información d'a estación"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estacions cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducción: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproducindo: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprendendo: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorización de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconnectar de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Connectar a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorización de Last.fm cancelada"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectau de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connectando a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "No s'ha puesto connectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Concede acceso en o tuyo navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "L'autorización de Last.fm ha expirato"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connectau a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubre mas de 30.000 estacions de radio verificadas de tot o mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sin favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca estacions mientras navegas pa adhibir-las aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Buscar estacions…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Todas as luengas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar por luenga"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Toz os países"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Sin estacions"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargando estacions"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sin resultaus"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Per favor, espera…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Garra estación coincide con a busca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "No s'han puesto cargar as estacions"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Estación"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Puesto web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Còdec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL d'o fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "No reproducindo"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleccionar una estación"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Almagazinando en búfer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Reproducindo"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconnectando…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Buscando en YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "A busca ha fallau: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "No s'han trobau resultaus en YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Toz os resultaus no disponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Descargando: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancelau"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "A descarga ha fallau: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Alzau: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Descargar canción"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancelar descarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Garra canta encara"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "As cantas amaneixerán aquí mientres escoltes estacions de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Agora mesmo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "fa %d min"
 msgstr[1] "fa %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "fa %d hora"
 msgstr[1] "fa %d horas"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ar.po
+++ b/po/ar.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "يستمر Receiver في تشغيل الراديو بعد إغلاق النافذة"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "القائمة"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "سجلّ الأغاني"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "متابعة التشغيل في الخلفية"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "عن Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "تصفّح"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "المفضّلة"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "معلومات المحطة"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "تم تحميل %d محطة"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "خطأ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "خطأ في التشغيل: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "يعمل الآن: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "استئناف: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "إلغاء تصريح Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "قطع الاتصال من Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "الاتصال بـ Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "تم إلغاء تصريح Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "تم قطع الاتصال من Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "جارٍ الاتصال بـ Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "فشل الاتصال بـ Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "امنح الإذن في متصفحك…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "انتهت مهلة تصريح Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "تم الاتصال بـ Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "اكتشف أكثر من 30,000 محطة إذاعية موثّقة من جميع أنحاء العالم"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "لا توجد مفضّلة"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "أضف نجمة للمحطات أثناء التصفح لإضافتها هنا"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "البحث عن محطات…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "جميع اللغات"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "تصفية حسب اللغة"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "جميع الدول"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "تصفية حسب الدولة"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "لا توجد محطات"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "جارٍ التحميل…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u من %d محطة"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "المحطات: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "جارٍ تحميل المحطات"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "لا توجد نتائج"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "يرجى الانتظار…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "لا توجد محطات تطابق بحثك"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "تعذر تحميل المحطات"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "محطة"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "الدولة"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "وسوم"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "الموقع الإلكتروني"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "الترميز"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "معدّل البت"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "رابط البث"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "لا يعمل"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "اختر محطة"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "جارٍ التخزين المؤقت…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "يعمل الآن"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "متوقف مؤقتاً"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "إعادة الاتصال…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "جارٍ البحث في YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "فشل البحث: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "لم يتم العثور على نتائج في YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "جميع النتائج غير متوفرة"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "جارٍ التنزيل: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "تم الإلغاء"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "فشل التنزيل: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "تم الحفظ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "تنزيل الأغنية"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "إلغاء التنزيل"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "لا توجد أغاني بعد"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ستظهر الأغاني هنا أثناء استماعك لمحطات الراديو"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "الآن"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -306,7 +304,7 @@ msgstr[3] "قبل %d دقائق"
 msgstr[4] "قبل %d دقيقة"
 msgstr[5] "قبل %d دقيقة"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -317,7 +315,7 @@ msgstr[3] "قبل %d ساعات"
 msgstr[4] "قبل %d ساعة"
 msgstr[5] "قبل %d ساعة"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ar.po
+++ b/po/ar.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "يستمر Receiver في تشغيل الراديو بعد إغلاق النافذة"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "القائمة"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "سجلّ الأغاني"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "متابعة التشغيل في الخلفية"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "عن Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "تصفّح"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "المفضّلة"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "معلومات المحطة"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "تم تحميل %d محطة"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "خطأ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "خطأ في التشغيل: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "يعمل الآن: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "استئناف: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "إلغاء تصريح Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "قطع الاتصال من Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "الاتصال بـ Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "تم إلغاء تصريح Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "تم قطع الاتصال من Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "جارٍ الاتصال بـ Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "فشل الاتصال بـ Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "امنح الإذن في متصفحك…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "انتهت مهلة تصريح Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "تم الاتصال بـ Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "اكتشف أكثر من 30,000 محطة إذاعية موثّقة من جميع أنحاء العالم"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "أضف نجمة للمحطات أثناء التصفح لإضافتها هنا"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "البحث عن محطات…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "جميع اللغات"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "تصفية حسب اللغة"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "جميع الدول"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "تصفية حسب الدولة"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "لا توجد محطات"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "جارٍ التحميل…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u من %d محطة"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "المحطات: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "جارٍ تحميل المحطات"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "لا توجد نتائج"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "يرجى الانتظار…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "لا توجد محطات تطابق بحثك"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "تعذر تحميل المحطات"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "رابط البث"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "لا يعمل"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "اختر محطة"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "جارٍ التخزين المؤقت…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "يعمل الآن"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "متوقف مؤقتاً"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "إعادة الاتصال…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "يعمل الآن"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/as.po
+++ b/po/as.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: as\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "উইণ্ডো বন্ধ কৰাৰ পিছতো Receiver-এ ৰেডিঅ' বজাই থাকে"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "মেনু"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "গীতৰ ইতিহাস"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "নেপথ্যত বজাই ৰাখক"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver-ৰ বিষয়ে"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ব্ৰাউজ কৰক"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "প্ৰিয়"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ষ্টেচনৰ তথ্য"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ষ্টেচন লোড হ'ল"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ত্ৰুটি: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "প্লেবেক ত্ৰুটি: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "এতিয়া বাজি আছে: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "পুনৰাৰম্ভ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm অনুমোদন বাতিল কৰক"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-ৰ পৰা সংযোগ বিচ্ছিন্ন কৰক"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-লৈ সংযোগ কৰক"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm অনুমোদন বাতিল কৰা হৈছে"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-ৰ পৰা সংযোগ বিচ্ছিন্ন"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-লৈ সংযোগ কৰি আছে…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-লৈ সংযোগ কৰিব পৰা নগ'ল"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "আপোনাৰ ব্ৰাউজাৰত অনুমতি দিয়ক…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm অনুমোদনৰ সময় শেষ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-লৈ সংযুক্ত"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "সমগ্ৰ বিশ্বৰ 30,000-ৰো অধিক প্ৰমাণিত ৰেডিঅ' ষ্টেচন আৱিষ্কাৰ কৰক"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ইয়াত যোগ কৰিবলৈ ব্ৰাউজ কৰোঁতে ষ্টেচনসমূহত তাৰকা চিহ্ন দিয়ক"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ষ্টেচন সন্ধান কৰক…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "সকলো ভাষা"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ভাষা অনুসৰি ফিল্টাৰ কৰক"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "সকলো দেশ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "দেশ অনুসৰি ফিল্টাৰ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "কোনো ষ্টেচন নাই"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "লোড হৈ আছে…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ষ্টেচন"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ষ্টেচন: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ষ্টেচন লোড হৈ আছে"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "কোনো ফলাফল নাই"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "অনুগ্ৰহ কৰি ৰ'ব…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "আপোনাৰ সন্ধানৰ সৈতে কোনো ষ্টেচন মিলা নাই"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ষ্টেচন লোড কৰিব পৰা নগ'ল"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ষ্ট্ৰীম URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "বাজি নাই"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "এটা ষ্টেচন বাছক"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "বাফাৰ হৈ আছে…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "এতিয়া বাজি আছে"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "বিৰতি"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "পুনৰ সংযোগ হৈ আছে…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "এতিয়া বাজি আছে"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/as.po
+++ b/po/as.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: as\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "উইণ্ডো বন্ধ কৰাৰ পিছতো Receiver-এ ৰেডিঅ' বজাই থাকে"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "মেনু"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "গীতৰ ইতিহাস"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "নেপথ্যত বজাই ৰাখক"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver-ৰ বিষয়ে"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ব্ৰাউজ কৰক"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "প্ৰিয়"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ষ্টেচনৰ তথ্য"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ষ্টেচন লোড হ'ল"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ত্ৰুটি: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "প্লেবেক ত্ৰুটি: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "এতিয়া বাজি আছে: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "পুনৰাৰম্ভ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm অনুমোদন বাতিল কৰক"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-ৰ পৰা সংযোগ বিচ্ছিন্ন কৰক"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-লৈ সংযোগ কৰক"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm অনুমোদন বাতিল কৰা হৈছে"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-ৰ পৰা সংযোগ বিচ্ছিন্ন"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-লৈ সংযোগ কৰি আছে…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-লৈ সংযোগ কৰিব পৰা নগ'ল"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "আপোনাৰ ব্ৰাউজাৰত অনুমতি দিয়ক…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm অনুমোদনৰ সময় শেষ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-লৈ সংযুক্ত"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "সমগ্ৰ বিশ্বৰ 30,000-ৰো অধিক প্ৰমাণিত ৰেডিঅ' ষ্টেচন আৱিষ্কাৰ কৰক"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "কোনো প্ৰিয় নাই"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ইয়াত যোগ কৰিবলৈ ব্ৰাউজ কৰোঁতে ষ্টেচনসমূহত তাৰকা চিহ্ন দিয়ক"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ষ্টেচন সন্ধান কৰক…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "সকলো ভাষা"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ভাষা অনুসৰি ফিল্টাৰ কৰক"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "সকলো দেশ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "দেশ অনুসৰি ফিল্টাৰ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "কোনো ষ্টেচন নাই"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "লোড হৈ আছে…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ষ্টেচন"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ষ্টেচন: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ষ্টেচন লোড হৈ আছে"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "কোনো ফলাফল নাই"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "অনুগ্ৰহ কৰি ৰ'ব…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "আপোনাৰ সন্ধানৰ সৈতে কোনো ষ্টেচন মিলা নাই"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ষ্টেচন লোড কৰিব পৰা নগ'ল"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ষ্টেচন"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "দেশ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "টেগ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ৱেবছাইট"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "কোডেক"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "বিটৰেট"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ষ্ট্ৰীম URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "বাজি নাই"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "এটা ষ্টেচন বাছক"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "বাফাৰ হৈ আছে…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "এতিয়া বাজি আছে"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "বিৰতি"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "পুনৰ সংযোগ হৈ আছে…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-ত সন্ধান কৰি আছে…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "সন্ধান বিফল: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "কোনো YouTube ফলাফল পোৱা নগ'ল"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "সকলো ফলাফল অনুপলব্ধ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ডাউনলোড হৈ আছে: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "বাতিল কৰা হ'ল"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ডাউনলোড বিফল: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "সংৰক্ষিত: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "গান ডাউনলোড কৰক"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ডাউনলোড বাতিল কৰক"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "এতিয়ালৈকে কোনো গীত নাই"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "আপুনি ৰেডিঅ' ষ্টেচন শুনাৰ লগে লগে গীতবোৰ ইয়াত দেখা যাব"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "এইমাত্ৰ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d মিনিট আগতে"
 msgstr[1] "%d মিনিট আগতে"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ঘণ্টা আগতে"
 msgstr[1] "%d ঘণ্টা আগতে"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ast.po
+++ b/po/ast.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ast\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver sigue reproduciendo la radio dempués de zarrar la ventana"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historial de canciones"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Siguir reproduciendo en segundu planu"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Tocante a Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Restolar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Información de la estación"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estaciones cargaes"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducción: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproduciendo: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reanudando: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Encaboxar l'autorización de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconectase de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conectase a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Encaboxóse l'autorización de Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconectóse de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Conectando a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nun se pudo conectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Concede accesu nel to restolador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Caducó l'autorización de Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conectóse a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubre más de 30.000 estaciones de radio verificaes de tol mundu"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca estaciones al restolar pa amestales equí"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Buscar estaciones…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Toles llingües"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Peñerar por llingua"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tolos países"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ensin estaciones"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estaciones"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estaciones: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargando estaciones"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ensin resultaos"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Espera, por favor…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nenguna estación coincide cola to gueta"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nun se pudieron cargar les estaciones"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL del fluxu"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nun ta reproduciendo"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleiciona una estación"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Almacenando nel búfer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Reproduciendo"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En posa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconeutando…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Reproduciendo"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ast.po
+++ b/po/ast.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ast\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver sigue reproduciendo la radio dempués de zarrar la ventana"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historial de canciones"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Siguir reproduciendo en segundu planu"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Tocante a Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Restolar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Información de la estación"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estaciones cargaes"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducción: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproduciendo: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reanudando: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Encaboxar l'autorización de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconectase de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conectase a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Encaboxóse l'autorización de Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconectóse de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Conectando a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nun se pudo conectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Concede accesu nel to restolador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Caducó l'autorización de Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conectóse a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubre más de 30.000 estaciones de radio verificaes de tol mundu"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ensin favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca estaciones al restolar pa amestales equí"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Buscar estaciones…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Toles llingües"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Peñerar por llingua"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tolos países"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ensin estaciones"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estaciones"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estaciones: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargando estaciones"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ensin resultaos"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Espera, por favor…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nenguna estación coincide cola to gueta"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nun se pudieron cargar les estaciones"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Estación"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sitiu web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Códec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Tasa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del fluxu"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nun ta reproduciendo"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleiciona una estación"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Almacenando nel búfer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Reproduciendo"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En posa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconeutando…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Buscando en YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "La gueta falló: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nun s'atoparon resultaos en YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tolos resultaos nun tán disponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Baxando: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Encaboxáu"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "La descarga falló: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Guardáu: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Baxar canción"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Encaboxar descarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Entá nun hai canciones"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Les canciones van apaecer equí mentanto escuches estaciones de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Agora mesmo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "hai %d min"
 msgstr[1] "hai %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "hai %d hora"
 msgstr[1] "hai %d hores"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/az.po
+++ b/po/az.po
@@ -3,314 +3,312 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Pəncərə bağlandıqdan sonra Receiver radionu səsləndirməyə davam edir"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Mahnı tarixçəsi"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Arxa planda səsləndirməyə davam et"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver haqqında"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Gözdən keçir"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Sevimlilər"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stansiya məlumatı"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yükləndi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Xəta: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oxutma xətası: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "İndi oxuyur: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Davam edir: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm icazəsini ləğv et"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-dən ayrıl"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ə qoşul"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm icazəsi ləğv edildi"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-dən ayrıldı"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ə qoşulur…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ə qoşulmaq alınmadı"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Brauzerinizdə icazə verin…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm icazəsinin vaxtı bitdi"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ə qoşuldu"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Dünyanın hər yerindən 30,000+ təsdiqlənmiş radio stansiyasını kəşf edin"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sevimli yoxdur"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Bura əlavə etmək üçün gözdən keçirərkən stansiyaları ulduzla işarələyin"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stansiyaları axtar…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Bütün dillər"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Dilə görə süz"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Bütün ölkələr"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Ölkəyə görə süz"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stansiya yoxdur"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Yüklənir…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stansiyalar yüklənir"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nəticə yoxdur"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Zəhmət olmasa gözləyin…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Axtarışınıza uyğun stansiya tapılmadı"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stansiyalar yüklənə bilmədi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stansiya"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ölkə"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiketlər"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Vebsayt"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitreyt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Axın URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Oxumur"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stansiya seçin"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufer doldurulur…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "İndi oxuyur"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Fasilə"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Yenidən qoşulur…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-da axtarılır…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Axtarış uğursuz oldu: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube nəticəsi tapılmadı"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Bütün nəticələr əlçatmazdır"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Yüklənir: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Ləğv edildi"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Yükləmə uğursuz oldu: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saxlanıldı: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Mahnını yüklə"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Yükləməni ləğv et"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Hələ heç bir mahnı yoxdur"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Radio stansiyalarını dinlədikcə mahnılar burada görünəcək"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "İndicə"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d dəq əvvəl"
 msgstr[1] "%d dəq əvvəl"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d saat əvvəl"
 msgstr[1] "%d saat əvvəl"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/az.po
+++ b/po/az.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Pəncərə bağlandıqdan sonra Receiver radionu səsləndirməyə davam edir"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Mahnı tarixçəsi"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Arxa planda səsləndirməyə davam et"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver haqqında"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Gözdən keçir"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Sevimlilər"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stansiya məlumatı"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yükləndi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Xəta: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oxutma xətası: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "İndi oxuyur: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Davam edir: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm icazəsini ləğv et"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-dən ayrıl"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ə qoşul"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm icazəsi ləğv edildi"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-dən ayrıldı"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ə qoşulur…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ə qoşulmaq alınmadı"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Brauzerinizdə icazə verin…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm icazəsinin vaxtı bitdi"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ə qoşuldu"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Dünyanın hər yerindən 30,000+ təsdiqlənmiş radio stansiyasını kəşf edin"
@@ -115,64 +123,65 @@ msgstr "Sevimli yoxdur"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Bura əlavə etmək üçün gözdən keçirərkən stansiyaları ulduzla işarələyin"
+msgstr ""
+"Bura əlavə etmək üçün gözdən keçirərkən stansiyaları ulduzla işarələyin"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stansiyaları axtar…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Bütün dillər"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Dilə görə süz"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Bütün ölkələr"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Ölkəyə görə süz"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stansiya yoxdur"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Yüklənir…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stansiyalar yüklənir"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nəticə yoxdur"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Zəhmət olmasa gözləyin…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Axtarışınıza uyğun stansiya tapılmadı"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stansiyalar yüklənə bilmədi"
 
@@ -205,25 +214,29 @@ msgid "Stream URL"
 msgstr "Axın URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Oxumur"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stansiya seçin"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufer doldurulur…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "İndi oxuyur"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Fasilə"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Yenidən qoşulur…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "İndi oxuyur"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/az_IR.po
+++ b/po/az_IR.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: az_IR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "پنجره باغلانان‌دان سونرا دا Receiver رادیونو چالماغا داوام ائدیر"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "منیو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ماهنی تاریخچه‌سی"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "آرخا پلاندا چالماغا داوام ائت"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver حاقّیندا"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "گؤزدن کئچیر"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "سئویملیلر"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "استانسییا معلوماتی"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yükləndi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Xəta: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oxutma xətası: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "İndi oxuyur: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Davam edir: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ایجازه‌سینی لغو ائت"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-دن آیریل"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ه قوشول"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ایجازه‌سی لغو ائدیلدی"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-دن آیریلدی"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ه قوشولور…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ه قوشولماق آلینمادی"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "بروزئرینیزده ایجازه وئرین…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ایجازه‌سینین وقتی بیتدی"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ه قوشولدو"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "دونیانین هر یئریندن ۳۰٬۰۰۰+ تأییدلنمیش رادیو ایستگاهینی کشف ائدین"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "سئویملی یوخدور"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "بورا اضافه ائتمک اوچون گؤزدن کئچیررکن استانسییالاری اولدوزلا ایشارهلیین"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stansiyaları axtar…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Bütün dillər"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Dilə görə süz"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "بوتون اؤلکه‌لر"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "اؤلکه‌یه گؤره سوز"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stansiya yoxdur"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Yüklənir…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stansiyalar yüklənir"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nəticə yoxdur"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Zəhmət olmasa gözləyin…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Axtarışınıza uyğun stansiya tapılmadı"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stansiyalar yüklənə bilmədi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "استانسییا"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "اؤلکه"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ائتیکتلر"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "وبسایت"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کودک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "بیتریت"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "آخین URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Oxumur"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stansiya seçin"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "بوفئرلنیر…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "İndi oxuyur"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Fasilə"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Yenidən qoşulur…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-da axtarılır…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Axtarış uğursuz oldu: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube nəticəsi tapılmadı"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Bütün nəticələr əlçatmazdır"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Yüklənir: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Ləğv edildi"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Yükləmə uğursuz oldu: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saxlanıldı: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Mahnını yüklə"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Yükləməni ləğv et"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "هله هئچ بیر ماهنی یوخدور"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "رادیو ایستگاهلارینی دینله‌دیکجه ماهنیلار بورادا گؤرونه‌جک"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ایندیجه"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d دقیقه اؤنجه"
 msgstr[1] "%d دقیقه اؤنجه"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ساعات اؤنجه"
 msgstr[1] "%d ساعات اؤنجه"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/az_IR.po
+++ b/po/az_IR.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: az_IR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "پنجره باغلانان‌دان سونرا دا Receiver رادیونو چالماغا داوام ائدیر"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "منیو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ماهنی تاریخچه‌سی"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "آرخا پلاندا چالماغا داوام ائت"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver حاقّیندا"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "گؤزدن کئچیر"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "سئویملیلر"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "استانسییا معلوماتی"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yükləndi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Xəta: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oxutma xətası: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "İndi oxuyur: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Davam edir: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ایجازه‌سینی لغو ائت"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-دن آیریل"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ه قوشول"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ایجازه‌سی لغو ائدیلدی"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-دن آیریلدی"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ه قوشولور…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ه قوشولماق آلینمادی"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "بروزئرینیزده ایجازه وئرین…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ایجازه‌سینین وقتی بیتدی"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ه قوشولدو"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "دونیانین هر یئریندن ۳۰٬۰۰۰+ تأییدلنمیش رادیو ایستگاهینی کشف ائدین"
 
@@ -114,64 +122,65 @@ msgstr "سئویملی یوخدور"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "بورا اضافه ائتمک اوچون گؤزدن کئچیررکن استانسییالاری اولدوزلا ایشارهلیین"
+msgstr ""
+"بورا اضافه ائتمک اوچون گؤزدن کئچیررکن استانسییالاری اولدوزلا ایشارهلیین"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stansiyaları axtar…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Bütün dillər"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Dilə görə süz"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "بوتون اؤلکه‌لر"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "اؤلکه‌یه گؤره سوز"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stansiya yoxdur"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Yüklənir…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stansiyalar yüklənir"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nəticə yoxdur"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Zəhmət olmasa gözləyin…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Axtarışınıza uyğun stansiya tapılmadı"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stansiyalar yüklənə bilmədi"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "آخین URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Oxumur"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stansiya seçin"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "بوفئرلنیر…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "İndi oxuyur"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Fasilə"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Yenidən qoşulur…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "İndi oxuyur"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bal.po
+++ b/po/bal.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: bal\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "چارگ بند بوتگ‌ءَ رند هم Receiver رادیو جنگ‌ءَ دوام دنت"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "مینو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ترانگانی تاریخ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "پُشتی دیمءَ جنگ‌ءَ دوام کن"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver بارگ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "بروز"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "پسندیدگ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "اسٹیشنءِ مالومات"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d اسٹیشن لوڈ بوت"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "خرابی: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک خرابی: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "الان غږیدگ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "دوبارہ شروع کنگ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm اجازت منسوخ کنیت"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm چه جتا بیت"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm گوں وصل بیت"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm اجازت منسوخ بوت"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm چه جتا بوت"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm گوں وصل بوت دئیگ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm گوں وصل نه بوت"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "وتی براؤزر ء تها دسترسی بدییت…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm اجازتء وخت گوستگ بوت"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm گوں وصل بوت"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "سرتاسر دنیا ء 30,000+ تصدیق بوتگین ریڈیو اسٹیشن دزگیر کنیت"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "پسندیدگ نیست"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "اِدا گیشَ کنگءَ بروز کنگءِ وختءَ اسٹیشناں ستارہ بکنیت"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "اسٹیشن گشتگ بکن…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "گشنک زبان"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "زبان وار فلٹر بکن"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ٹوہیں ملکان"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ملکءِ رُو فلٹر"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "اسٹیشن نیست"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "لوڈ بو اینت…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d اسٹیشن"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "اسٹیشن: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "اسٹیشن لوڈ بو اینت"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "نتیجگ نیست"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "مہربانی کنت صبر بکن…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "شمئے گشتگ اَت ھچ اسٹیشن نمچاکیت"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "اسٹیشن لوڈ نبوتنت"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "اسٹیشن"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ملک"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ٹیگ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ویب سائٹ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کوڈیک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "بٹ ریٹ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "سٹریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "غږ نہ بو اینت"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "اسٹیشنے بچار"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "بفر کنگ ئنت…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "الان غږیدگ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ودارتگ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "دوبارہ جڑ بو اینت…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube اَت گشتگ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "گشتگ ناکام بوت: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube نتیجگ پیدا نبوت"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "گشنک نتیجگ دستیاب نہ اینت"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ڈاؤنلوڈ بو اینت: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "منسوخ بوت"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ڈاؤنلوڈ ناکام بوت: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "محفوظ بوت: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ترانگ ڈاؤنلوڈ بکن"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ڈاؤنلوڈ منسوخ بکن"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "تاهنو کس ترانگ نیست"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ریڈیو اسٹیشن گوش دارگ ء وهدا ترانگ ادا پیش بنت"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "هنو"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d لمحه پیسر"
 msgstr[1] "%d لمحه پیسر"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ساعت پیسر"
 msgstr[1] "%d ساعت پیسر"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/bal.po
+++ b/po/bal.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: bal\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "چارگ بند بوتگ‌ءَ رند هم Receiver رادیو جنگ‌ءَ دوام دنت"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "مینو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ترانگانی تاریخ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "پُشتی دیمءَ جنگ‌ءَ دوام کن"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver بارگ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "بروز"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "پسندیدگ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "اسٹیشنءِ مالومات"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d اسٹیشن لوڈ بوت"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "خرابی: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک خرابی: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "الان غږیدگ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "دوبارہ شروع کنگ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm اجازت منسوخ کنیت"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm چه جتا بیت"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm گوں وصل بیت"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm اجازت منسوخ بوت"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm چه جتا بوت"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm گوں وصل بوت دئیگ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm گوں وصل نه بوت"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "وتی براؤزر ء تها دسترسی بدییت…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm اجازتء وخت گوستگ بوت"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm گوں وصل بوت"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "سرتاسر دنیا ء 30,000+ تصدیق بوتگین ریڈیو اسٹیشن دزگیر کنیت"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "اِدا گیشَ کنگءَ بروز کنگءِ وختءَ اسٹیشناں ستارہ بکنیت"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "اسٹیشن گشتگ بکن…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "گشنک زبان"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "زبان وار فلٹر بکن"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ٹوہیں ملکان"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ملکءِ رُو فلٹر"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "اسٹیشن نیست"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "لوڈ بو اینت…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d اسٹیشن"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "اسٹیشن: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "اسٹیشن لوڈ بو اینت"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "نتیجگ نیست"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "مہربانی کنت صبر بکن…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "شمئے گشتگ اَت ھچ اسٹیشن نمچاکیت"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "اسٹیشن لوڈ نبوتنت"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "سٹریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "غږ نہ بو اینت"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "اسٹیشنے بچار"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "بفر کنگ ئنت…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "الان غږیدگ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ودارتگ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "دوبارہ جڑ بو اینت…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "الان غږیدگ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/be.po
+++ b/po/be.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver працягвае граць радыё пасля закрыцця акна"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Гісторыя песень"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Працягваць граць у фоне"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Пра Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Аглядаць"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Абранае"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Інфармацыя пра станцыю"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Загружана %d станцый"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Памылка: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Памылка прайгравання: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Зараз іграе: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Аднаўленне: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Скасаваць аўтарызацыю Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Адключыцца ад Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Падключыцца да Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Аўтарызацыя Last.fm скасавана"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Адключана ад Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Падключэнне да Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Не ўдалося падключыцца да Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Дайце доступ у вашым браўзеры…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Час аўтарызацыі Last.fm выйшаў"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Падключана да Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Адкрыйце 30,000+ правераных радыёстанцый з усяго свету"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Адзначце станцыі зоркай падчас агляду, каб дадаць іх сюды"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Шукаць станцыі…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Усе мовы"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Фільтр па мове"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Усе краіны"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Фільтраваць па краіне"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Няма станцый"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Загрузка…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u з %d станцый"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцыі: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Загрузка станцый"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Няма вынікаў"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Калі ласка, пачакайце…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ні адна станцыя не адпавядае вашаму пошуку"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Не ўдалося загрузіць станцыі"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL патоку"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Не іграе"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Выберыце станцыю"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферызацыя…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Зараз іграе"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Прыпынена"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Перападключэнне…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Зараз іграе"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/be.po
+++ b/po/be.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: be\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver працягвае граць радыё пасля закрыцця акна"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Гісторыя песень"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Працягваць граць у фоне"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Пра Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Аглядаць"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Абранае"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Інфармацыя пра станцыю"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Загружана %d станцый"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Памылка: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Памылка прайгравання: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Зараз іграе: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Аднаўленне: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Скасаваць аўтарызацыю Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Адключыцца ад Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Падключыцца да Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Аўтарызацыя Last.fm скасавана"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Адключана ад Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Падключэнне да Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Не ўдалося падключыцца да Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Дайце доступ у вашым браўзеры…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Час аўтарызацыі Last.fm выйшаў"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Падключана да Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Адкрыйце 30,000+ правераных радыёстанцый з усяго свету"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Няма абранага"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Адзначце станцыі зоркай падчас агляду, каб дадаць іх сюды"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Шукаць станцыі…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Усе мовы"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Фільтр па мове"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Усе краіны"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Фільтраваць па краіне"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Няма станцый"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Загрузка…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u з %d станцый"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцыі: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Загрузка станцый"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Няма вынікаў"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Калі ласка, пачакайце…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ні адна станцыя не адпавядае вашаму пошуку"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Не ўдалося загрузіць станцыі"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станцыя"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Краіна"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Тэгі"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Вэб-сайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодэк"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Бітрэйт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL патоку"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Не іграе"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Выберыце станцыю"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферызацыя…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Зараз іграе"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Прыпынена"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Перападключэнне…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Пошук на YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Пошук не ўдаўся: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Вынікі YouTube не знойдзены"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Усе вынікі недаступныя"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Спампоўка: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Скасавана"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Спампоўка не ўдалася: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Захавана: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Спампаваць песню"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Скасаваць спампоўку"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Песень пакуль няма"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Песні з'явяцца тут, калі вы слухаеце радыёстанцыі"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Толькі што"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "%d хвіліну таму"
 msgstr[1] "%d хвіліны таму"
 msgstr[2] "%d хвілін таму"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "%d гадзіну таму"
 msgstr[1] "%d гадзіны таму"
 msgstr[2] "%d гадзін таму"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/be@latin.po
+++ b/po/be@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: be@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver praciahvaje hrać radyjo paśla začynieńnia akna"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Mieniu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historija piesień"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Praciahvać hrać u fonie"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Pra Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Ahladać"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Abranaje"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Infarmacyja pra stancyju"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Zahružana %d stancyj"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Pamylka: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Pamylka prajhravannja: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Zaraz ihraje: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Adnaŭljennje: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Skasavać aŭtaryzacyju Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Adklučycca ad Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Padklučycca da Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Aŭtaryzacyja Last.fm skasavana"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Adklučana ad Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Padklučennie da Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nie ŭdałosia padklučycca da Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dajcie dostup u vašym braŭziery…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Čas aŭtaryzacyi Last.fm vyjšaŭ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Padklučana da Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Adkryjcie 30,000+ pravieranych radyjostancyj z usiaho svietu"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Adznačcie stancyi zorkaj padčas ahliadu, kab dadać ich siudy"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Šukac stancyi…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Usje movy"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtr pa movje"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Usie krainy"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtravaць pa krainie"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Njama stancyj"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Zahruzka…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d stancyj"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stancyi: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Zahruzka stancyj"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Njama vynikaŭ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Kali laska, pačakajcje…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ni adna stancyja nje adpavjadaje vašamu pošuku"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nje ŭdalosja zahruzic stancyi"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL patoku"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nje ihraje"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Vybjerycje stancyju"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buferyzacyja…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Zaraz ihraje"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Prypynjena"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Pjerapadključennje…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Zaraz ihraje"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/be@latin.po
+++ b/po/be@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: be@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver praciahvaje hrać radyjo paśla začynieńnia akna"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Mieniu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historija piesień"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Praciahvać hrać u fonie"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Pra Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Ahladać"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Abranaje"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Infarmacyja pra stancyju"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Zahružana %d stancyj"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Pamylka: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Pamylka prajhravannja: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Zaraz ihraje: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Adnaŭljennje: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Skasavać aŭtaryzacyju Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Adklučycca ad Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Padklučycca da Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Aŭtaryzacyja Last.fm skasavana"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Adklučana ad Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Padklučennie da Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nie ŭdałosia padklučycca da Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dajcie dostup u vašym braŭziery…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Čas aŭtaryzacyi Last.fm vyjšaŭ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Padklučana da Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Adkryjcie 30,000+ pravieranych radyjostancyj z usiaho svietu"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Niama abranaha"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Adznačcie stancyi zorkaj padčas ahliadu, kab dadać ich siudy"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Šukac stancyi…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Usje movy"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtr pa movje"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Usie krainy"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtravaць pa krainie"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Njama stancyj"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Zahruzka…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d stancyj"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stancyi: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Zahruzka stancyj"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Njama vynikaŭ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Kali laska, pačakajcje…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ni adna stancyja nje adpavjadaje vašamu pošuku"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nje ŭdalosja zahruzic stancyi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stancyja"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Kraina"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tehi"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Veb-sajt"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrejt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL patoku"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nje ihraje"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Vybjerycje stancyju"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buferyzacyja…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Zaraz ihraje"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Prypynjena"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Pjerapadključennje…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Pošuk na YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Pošuk nje ŭdaŭsja: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Vyniki YouTube nje znojdzjeny"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Usje vyniki njedastupnyja"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Spampoŭka: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Skasavana"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Spampoŭka nje ŭdalasja: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Zachavana: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Spampavac pjesnju"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Skasavac spampoŭku"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Piesień pakul niama"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Piesni z'javiacca tut, kali vy słuchajecie radyjostancyi"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Toĺki što"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "%d chvilinu tamu"
 msgstr[1] "%d chviliny tamu"
 msgstr[2] "%d chvilin tamu"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "%d hadzinu tamu"
 msgstr[1] "%d hadziny tamu"
 msgstr[2] "%d hadzin tamu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/bg.po
+++ b/po/bg.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver продължава да пуска радио след затваряне на прозореца"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "История на песните"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Продължаване във фонов режим"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Относно Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Разглеждане"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Любими"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Информация за станция"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Заредени %d станции"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Грешка при възпроизвеждане: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Сега се изпълнява: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Възобновяване: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Отмяна на оторизацията в Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Прекъсване на връзката с Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Свързване с Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Оторизацията в Last.fm е отменена"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Връзката с Last.fm е прекъсната"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Свързване с Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Неуспешно свързване с Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Дайте достъп в браузъра си…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Времето за оторизация в Last.fm изтече"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Свързан с Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Открийте над 30 000 проверени радиостанции от цял свят"
 
@@ -114,64 +122,65 @@ msgstr "Няма любими"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Отбележете станции със звезда, докато разглеждате, за да ги добавите тук"
+msgstr ""
+"Отбележете станции със звезда, докато разглеждате, за да ги добавите тук"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Търсене на станции…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Всички езици"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Филтриране по език"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Всички държави"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Филтриране по държава"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Няма станции"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Зареждане…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u от %d станции"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станции: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Зареждане на станции"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Няма резултати"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Моля, изчакайте…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Няма станции, отговарящи на търсенето ви"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Станциите не можаха да бъдат заредени"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL на потока"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Не се изпълнява"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Изберете станция"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буфериране…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Сега се изпълнява"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "На пауза"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Повторно свързване…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Сега се изпълнява"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bg.po
+++ b/po/bg.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver продължава да пуска радио след затваряне на прозореца"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "История на песните"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Продължаване във фонов режим"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Относно Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Разглеждане"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Любими"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Информация за станция"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Заредени %d станции"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Грешка при възпроизвеждане: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Сега се изпълнява: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Възобновяване: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Отмяна на оторизацията в Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Прекъсване на връзката с Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Свързване с Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Оторизацията в Last.fm е отменена"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Връзката с Last.fm е прекъсната"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Свързване с Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Неуспешно свързване с Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Дайте достъп в браузъра си…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Времето за оторизация в Last.fm изтече"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Свързан с Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Открийте над 30 000 проверени радиостанции от цял свят"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Няма любими"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Отбележете станции със звезда, докато разглеждате, за да ги добавите тук"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Търсене на станции…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Всички езици"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Филтриране по език"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Всички държави"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Филтриране по държава"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Няма станции"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Зареждане…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u от %d станции"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станции: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Зареждане на станции"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Няма резултати"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Моля, изчакайте…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Няма станции, отговарящи на търсенето ви"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Станциите не можаха да бъдат заредени"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станция"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Държава"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Етикети"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Уебсайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрейт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL на потока"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Не се изпълнява"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Изберете станция"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буфериране…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Сега се изпълнява"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "На пауза"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Повторно свързване…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Търсене в YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Търсенето е неуспешно: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Не са намерени резултати в YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Всички резултати са недостъпни"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Изтегляне: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Отменено"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Изтеглянето е неуспешно: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Запазено: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Изтегляне на песен"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Отмяна на изтеглянето"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Все още няма песни"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Песните ще се появяват тук, докато слушате радиостанции"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Току-що"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "преди %d минута"
 msgstr[1] "преди %d минути"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "преди %d час"
 msgstr[1] "преди %d часа"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/bn.po
+++ b/po/bn.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: bn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "উইন্ডো বন্ধ করার পরেও Receiver রেডিও চালিয়ে যায়"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "মেনু"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "গানের ইতিহাস"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "নেপথ্যে চালিয়ে যান"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver সম্পর্কে"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ব্রাউজ করুন"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "পছন্দসই"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "স্টেশনের তথ্য"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d স্টেশন লোড হয়েছে"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ত্রুটি: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "প্লেব্যাক ত্রুটি: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "এখন চলছে: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "পুনরায় শুরু হচ্ছে: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm অনুমোদন বাতিল করুন"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন করুন"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হন"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm অনুমোদন বাতিল হয়েছে"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-এ সংযোগ হচ্ছে…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হতে ব্যর্থ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "আপনার ব্রাউজারে অনুমতি দিন…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm অনুমোদনের সময় শেষ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "সারা বিশ্বের ৩০,০০০+ যাচাইকৃত রেডিও স্টেশন আবিষ্কার করুন"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "এখানে যোগ করতে ব্রাউজ করার সময় স্টেশনগুলিতে তারকা চিহ্ন দিন"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "স্টেশন খুঁজুন…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "সব ভাষা"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ভাষা অনুযায়ী ফিল্টার করুন"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "সব দেশ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "দেশ অনুসারে ফিল্টার"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "কোনো স্টেশন নেই"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "লোড হচ্ছে…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d স্টেশন"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "স্টেশন: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "স্টেশন লোড হচ্ছে"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "কোনো ফলাফল নেই"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "অনুগ্রহ করে অপেক্ষা করুন…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "আপনার অনুসন্ধানের সাথে কোনো স্টেশন মেলেনি"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "স্টেশন লোড করা যায়নি"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "স্ট্রিম URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "চলছে না"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "একটি স্টেশন নির্বাচন করুন"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "বাফার হচ্ছে…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "এখন চলছে"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "বিরতি"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "পুনরায় সংযোগ হচ্ছে…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "এখন চলছে"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bn.po
+++ b/po/bn.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: bn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "উইন্ডো বন্ধ করার পরেও Receiver রেডিও চালিয়ে যায়"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "মেনু"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "গানের ইতিহাস"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "নেপথ্যে চালিয়ে যান"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver সম্পর্কে"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ব্রাউজ করুন"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "পছন্দসই"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "স্টেশনের তথ্য"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d স্টেশন লোড হয়েছে"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ত্রুটি: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "প্লেব্যাক ত্রুটি: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "এখন চলছে: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "পুনরায় শুরু হচ্ছে: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm অনুমোদন বাতিল করুন"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন করুন"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হন"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm অনুমোদন বাতিল হয়েছে"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-এ সংযোগ হচ্ছে…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হতে ব্যর্থ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "আপনার ব্রাউজারে অনুমতি দিন…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm অনুমোদনের সময় শেষ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "সারা বিশ্বের ৩০,০০০+ যাচাইকৃত রেডিও স্টেশন আবিষ্কার করুন"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "কোনো পছন্দসই নেই"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "এখানে যোগ করতে ব্রাউজ করার সময় স্টেশনগুলিতে তারকা চিহ্ন দিন"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "স্টেশন খুঁজুন…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "সব ভাষা"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ভাষা অনুযায়ী ফিল্টার করুন"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "সব দেশ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "দেশ অনুসারে ফিল্টার"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "কোনো স্টেশন নেই"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "লোড হচ্ছে…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d স্টেশন"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "স্টেশন: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "স্টেশন লোড হচ্ছে"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "কোনো ফলাফল নেই"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "অনুগ্রহ করে অপেক্ষা করুন…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "আপনার অনুসন্ধানের সাথে কোনো স্টেশন মেলেনি"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "স্টেশন লোড করা যায়নি"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "স্টেশন"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "দেশ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ট্যাগ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ওয়েবসাইট"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "কোডেক"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "বিটরেট"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "স্ট্রিম URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "চলছে না"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "একটি স্টেশন নির্বাচন করুন"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "বাফার হচ্ছে…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "এখন চলছে"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "বিরতি"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "পুনরায় সংযোগ হচ্ছে…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-এ খোঁজা হচ্ছে…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "অনুসন্ধান ব্যর্থ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "কোনো YouTube ফলাফল পাওয়া যায়নি"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "সব ফলাফল অনুপলব্ধ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ডাউনলোড হচ্ছে: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "বাতিল করা হয়েছে"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ডাউনলোড ব্যর্থ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "সংরক্ষিত: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "গান ডাউনলোড করুন"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ডাউনলোড বাতিল করুন"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "এখনো কোনো গান নেই"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "আপনি রেডিও স্টেশন শোনার সাথে সাথে গানগুলি এখানে দেখা যাবে"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "এইমাত্র"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d মিনিট আগে"
 msgstr[1] "%d মিনিট আগে"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ঘণ্টা আগে"
 msgstr[1] "%d ঘণ্টা আগে"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: bn_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "উইন্ডো বন্ধ করার পরেও Receiver রেডিও চালিয়ে যায়"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "মেনু"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "গানের ইতিহাস"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "নেপথ্যে চালিয়ে যান"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver সম্পর্কে"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ব্রাউজ করুন"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "পছন্দসই"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "স্টেশনের তথ্য"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d স্টেশন লোড হয়েছে"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ত্রুটি: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "প্লেব্যাক ত্রুটি: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "এখন চলছে: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "পুনরায় শুরু হচ্ছে: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm অনুমোদন বাতিল করুন"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন করুন"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হন"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm অনুমোদন বাতিল হয়েছে"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-এ সংযোগ হচ্ছে…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হতে ব্যর্থ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "আপনার ব্রাউজারে অনুমতি দিন…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm অনুমোদনের সময় শেষ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "সারা বিশ্বের ৩০,০০০+ যাচাইকৃত রেডিও স্টেশন আবিষ্কার করুন"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "এখানে যোগ করতে ব্রাউজ করার সময় স্টেশনগুলিতে তারকা চিহ্ন দিন"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "স্টেশন খুঁজুন…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "সব ভাষা"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ভাষা অনুযায়ী ফিল্টার করুন"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "সব দেশ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "দেশ অনুসারে ফিল্টার"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "কোনো স্টেশন নেই"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "লোড হচ্ছে…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d স্টেশন"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "স্টেশন: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "স্টেশন লোড হচ্ছে"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "কোনো ফলাফল নেই"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "অনুগ্রহ করে অপেক্ষা করুন…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "আপনার অনুসন্ধানের সাথে কোনো স্টেশন মেলেনি"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "স্টেশন লোড করা যায়নি"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "স্ট্রিম URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "চলছে না"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "একটি স্টেশন নির্বাচন করুন"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "বাফার হচ্ছে…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "এখন চলছে"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "বিরতি"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "পুনরায় সংযোগ হচ্ছে…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "এখন চলছে"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: bn_IN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "উইন্ডো বন্ধ করার পরেও Receiver রেডিও চালিয়ে যায়"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "মেনু"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "গানের ইতিহাস"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "নেপথ্যে চালিয়ে যান"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver সম্পর্কে"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ব্রাউজ করুন"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "পছন্দসই"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "স্টেশনের তথ্য"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d স্টেশন লোড হয়েছে"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ত্রুটি: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "প্লেব্যাক ত্রুটি: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "এখন চলছে: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "পুনরায় শুরু হচ্ছে: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm অনুমোদন বাতিল করুন"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন করুন"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হন"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm অনুমোদন বাতিল হয়েছে"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm থেকে সংযোগ বিচ্ছিন্ন"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-এ সংযোগ হচ্ছে…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত হতে ব্যর্থ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "আপনার ব্রাউজারে অনুমতি দিন…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm অনুমোদনের সময় শেষ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-এ সংযুক্ত"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "সারা বিশ্বের ৩০,০০০+ যাচাইকৃত রেডিও স্টেশন আবিষ্কার করুন"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "কোনো পছন্দসই নেই"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "এখানে যোগ করতে ব্রাউজ করার সময় স্টেশনগুলিতে তারকা চিহ্ন দিন"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "স্টেশন খুঁজুন…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "সব ভাষা"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ভাষা অনুযায়ী ফিল্টার করুন"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "সব দেশ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "দেশ অনুসারে ফিল্টার"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "কোনো স্টেশন নেই"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "লোড হচ্ছে…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d স্টেশন"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "স্টেশন: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "স্টেশন লোড হচ্ছে"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "কোনো ফলাফল নেই"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "অনুগ্রহ করে অপেক্ষা করুন…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "আপনার অনুসন্ধানের সাথে কোনো স্টেশন মেলেনি"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "স্টেশন লোড করা যায়নি"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "স্টেশন"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "দেশ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ট্যাগ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ওয়েবসাইট"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "কোডেক"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "বিটরেট"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "স্ট্রিম URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "চলছে না"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "একটি স্টেশন নির্বাচন করুন"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "বাফার হচ্ছে…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "এখন চলছে"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "বিরতি"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "পুনরায় সংযোগ হচ্ছে…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-এ খোঁজা হচ্ছে…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "অনুসন্ধান ব্যর্থ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "কোনো YouTube ফলাফল পাওয়া যায়নি"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "সব ফলাফল অনুপলব্ধ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ডাউনলোড হচ্ছে: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "বাতিল করা হয়েছে"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ডাউনলোড ব্যর্থ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "সংরক্ষিত: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "গান ডাউনলোড করুন"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ডাউনলোড বাতিল করুন"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "এখনো কোনো গান নেই"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "আপনি রেডিও স্টেশন শোনার সাথে সাথে গানগুলি এখানে দেখা যাবে"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "এইমাত্র"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d মিনিট আগে"
 msgstr[1] "%d মিনিট আগে"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ঘণ্টা আগে"
 msgstr[1] "%d ঘণ্টা আগে"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/bo.po
+++ b/po/bo.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: bo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "སྒེའུ་ཁུང་བརྒྱབ་རྗེས་སུའང་ Receiver ཡིས་རླུང་འཕྲིན་གཏོང་མུ་མཐུད་བྱེད།"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "འདེམ་བྱང་"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "གཞས་ཀྱི་ལོ་རྒྱུས"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "རྒྱབ་ཕྱོགས་སུ་གཏོང་མུ་མཐུད་བྱེད།"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver སྐོར"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "བཤར་འཚོལ།"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "དགའ་ཤོས།"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "འཕྲིན་ལས་ཁང་གི་གནས་ཚུལ།"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "འཚོལ་ཁང་ %d ཕབ་ལེན་བྱས་ཟིན།"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ནོར་འཁྲུལ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "སླར་གསོའི་ནོར་འཁྲུལ: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ད་ལྟ་གཏོང་བཞིན་པ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "མུ་མཐུད: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm དབང་སྐུར་མེད་པར་གཏོང"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ནས་བཅད"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ལ་སྦྲེལ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm དབང་སྐུར་མེད་པར་བཏང"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ནས་བཅད་ཟིན"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ལ་སྦྲེལ་བཞིན་པ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ལ་སྦྲེལ་མི་ཐུབ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ཁྱོད་ཀྱི་བཤར་ཆས་ནང་ཆོག་མཆན་སྤྲོད…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm དབང་སྐུར་དུས་ཚོད་ཟིན"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ལ་སྦྲེལ་ཟིན"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "འཛམ་གླིང་ཡོངས་ནས་30,000+ བརྟག་ཞིབ་བྱས་པའི་རླུང་འཕྲིན་ལས་ཁུངས་རྙེད"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "འདིར་སྣོན་པའི་ཆེད་བཤར་འཚོལ་སྐབས་འཕྲིན་ལས་ཁང་ལ་སྐར་རྟགས་རྒྱབ།"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "འཚོལ་ཁང་འཚོལ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "སྐད་ཡིག་ཚང་མ།"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "སྐད་ཡིག་ལྟར་ཚགས་མ།"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "རྒྱལ་ཁབ་ཚང་མ།"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "རྒྱལ་ཁབ་ལྟར་བཙག"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "འཚོལ་ཁང་མེད།"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ཕབ་ལེན་བྱེད་བཞིན…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d འཚོལ་ཁང་།"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "འཚོལ་ཁང་: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "འཚོལ་ཁང་ཕབ་ལེན་བྱེད་བཞིན།"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "འབྲས་བུ་མེད།"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "སྒུག་རོགས…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ཁྱེད་ཀྱི་འཚོལ་ཞིབ་དང་མཐུན་པའི་འཚོལ་ཁང་མེད།"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "འཚོལ་ཁང་ཕབ་ལེན་བྱེད་མ་ཐུབ།"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "རྒྱུན་སྟོན་URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "གཏོང་བཞིན་མེད།"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "འཚོལ་ཁང་ཞིག་འདེམས།"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "གསོག་འཇོག་བྱེད་བཞིན…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ད་ལྟ་གཏོང་བཞིན་པ།"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "མཚམས་བཞག"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "སླར་སྦྲེལ་བྱེད་བཞིན…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ད་ལྟ་གཏོང་བཞིན་པ།"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bo.po
+++ b/po/bo.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: bo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "སྒེའུ་ཁུང་བརྒྱབ་རྗེས་སུའང་ Receiver ཡིས་རླུང་འཕྲིན་གཏོང་མུ་མཐུད་བྱེད།"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "འདེམ་བྱང་"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "གཞས་ཀྱི་ལོ་རྒྱུས"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "རྒྱབ་ཕྱོགས་སུ་གཏོང་མུ་མཐུད་བྱེད།"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver སྐོར"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "བཤར་འཚོལ།"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "དགའ་ཤོས།"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "འཕྲིན་ལས་ཁང་གི་གནས་ཚུལ།"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "འཚོལ་ཁང་ %d ཕབ་ལེན་བྱས་ཟིན།"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ནོར་འཁྲུལ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "སླར་གསོའི་ནོར་འཁྲུལ: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ད་ལྟ་གཏོང་བཞིན་པ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "མུ་མཐུད: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm དབང་སྐུར་མེད་པར་གཏོང"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ནས་བཅད"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ལ་སྦྲེལ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm དབང་སྐུར་མེད་པར་བཏང"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ནས་བཅད་ཟིན"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ལ་སྦྲེལ་བཞིན་པ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ལ་སྦྲེལ་མི་ཐུབ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ཁྱོད་ཀྱི་བཤར་ཆས་ནང་ཆོག་མཆན་སྤྲོད…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm དབང་སྐུར་དུས་ཚོད་ཟིན"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ལ་སྦྲེལ་ཟིན"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "འཛམ་གླིང་ཡོངས་ནས་30,000+ བརྟག་ཞིབ་བྱས་པའི་རླུང་འཕྲིན་ལས་ཁུངས་རྙེད"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "དགའ་ཤོས་མེད།"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "འདིར་སྣོན་པའི་ཆེད་བཤར་འཚོལ་སྐབས་འཕྲིན་ལས་ཁང་ལ་སྐར་རྟགས་རྒྱབ།"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "འཚོལ་ཁང་འཚོལ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "སྐད་ཡིག་ཚང་མ།"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "སྐད་ཡིག་ལྟར་ཚགས་མ།"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "རྒྱལ་ཁབ་ཚང་མ།"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "རྒྱལ་ཁབ་ལྟར་བཙག"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "འཚོལ་ཁང་མེད།"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ཕབ་ལེན་བྱེད་བཞིན…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d འཚོལ་ཁང་།"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "འཚོལ་ཁང་: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "འཚོལ་ཁང་ཕབ་ལེན་བྱེད་བཞིན།"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "འབྲས་བུ་མེད།"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "སྒུག་རོགས…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ཁྱེད་ཀྱི་འཚོལ་ཞིབ་དང་མཐུན་པའི་འཚོལ་ཁང་མེད།"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "འཚོལ་ཁང་ཕབ་ལེན་བྱེད་མ་ཐུབ།"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "འཕྲིན་ལས་ཁང་།"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "རྒྱལ་ཁབ།"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ཁ་བྱང་།"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "དྲ་ཚིགས།"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "བསྒྱུར་བཅོས།"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "བིཊ་ཚད།"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "རྒྱུན་སྟོན་URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "གཏོང་བཞིན་མེད།"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "འཚོལ་ཁང་ཞིག་འདེམས།"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "གསོག་འཇོག་བྱེད་བཞིན…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ད་ལྟ་གཏོང་བཞིན་པ།"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "མཚམས་བཞག"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "སླར་སྦྲེལ་བྱེད་བཞིན…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-ནང་འཚོལ་བཞིན…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "འཚོལ་ཞིབ་ཕམ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube-འབྲས་བུ་རྙེད་མ་ཐུབ།"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "འབྲས་བུ་ཚང་མ་མི་ཐོབ།"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ཕབ་ལེན་བྱེད་བཞིན: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "མེད་པར་བཏང་།"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ཕབ་ལེན་ཕམ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ཉར་ཚགས་བྱས: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "གླུ་ཕབ་ལེན།"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ཕབ་ལེན་མེད་པར་གཏོང་།"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ད་ལྟ་གཞས་མེད"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "རླུང་འཕྲིན་ལས་ཁུངས་ཉན་སྐབས་གཞས་འདིར་སྟོན"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ད་ལྟ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "སྐར་མ་ %d སྔོན"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "ཆུ་ཚོད་ %d སྔོན"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/br.po
+++ b/po/br.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver a gendalc'h da seniñ ar radio goude bezañ serret ar prenestr"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Rollad"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Roll ar c'hanaouennoù"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Kenderc'hel da seniñ en drekleur"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Diwar-benn Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Furchal"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Muiañ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Titouroù ar savlec'h"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d savourenn karget"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fazi: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Fazi lenn: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "O seniñ bremañ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Kenderc'hel: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Nullañ aotre Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Digennaskañ diouzh Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kevreañ ouzh Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Nullet eo bet aotre Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Digennasket diouzh Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "O kevreañ ouzh Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "N'haller ket kevreañ ouzh Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Roit an aotre en ho merdeer…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Diamzeret eo aotre Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Kevreet ouzh Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Dizoloit muioc'h eget 30 000 skingomz radio gwiriekaet eus ar bed a-bezh"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Muian ebet"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Steredennit savlec'hioù en ur furchal evit o ouzhpennañ amañ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Klask savourioù…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "An holl yezhoù"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Silañ dre yezh"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "An holl vroioù"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Silañ dre vro"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Savourenn ebet"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "O kargañ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u eus %d savourenn"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Savourioù: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "O kargañ ar savourioù"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Disoc'h ebet"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Gortozit mar plij…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Savourenn ebet ne glot gant ho klask"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "N'eo ket bet posupl kargañ ar savourioù"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Savlec'h"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Bro"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Klavioù"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Lec'hienn"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Fonnder"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ar froud"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "N'emañ ket o seniñ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Diuzit ur savourenn"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "O c'hargañ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "O seniñ bremañ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Ehanet"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Oc'h adkevreañ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "O klask war YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Klask c'hwitet: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Disoc'h YouTube ebet kavet"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "An holl zisoc'hoù n'int ket hegerz"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "O pellgargañ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Nullet"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Pellgargañ c'hwitet: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Enrollet: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Pellgargañ ar son"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Nullañ ar pellgargañ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "N'eus kanaouenn ebet c'hoazh"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Diskouezet e vo ar c'hanaouennoù amañ pa selaouit ar skingomzoù radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Bremañ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d vunutenn zo"
 msgstr[1] "%d vunutenn zo"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d eur zo"
 msgstr[1] "%d eur zo"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/br.po
+++ b/po/br.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver a gendalc'h da seniñ ar radio goude bezañ serret ar prenestr"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Rollad"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Roll ar c'hanaouennoù"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Kenderc'hel da seniñ en drekleur"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Diwar-benn Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Furchal"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Muiañ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Titouroù ar savlec'h"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d savourenn karget"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fazi: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Fazi lenn: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "O seniñ bremañ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Kenderc'hel: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Nullañ aotre Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Digennaskañ diouzh Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kevreañ ouzh Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Nullet eo bet aotre Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Digennasket diouzh Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "O kevreañ ouzh Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "N'haller ket kevreañ ouzh Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Roit an aotre en ho merdeer…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Diamzeret eo aotre Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Kevreet ouzh Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Dizoloit muioc'h eget 30 000 skingomz radio gwiriekaet eus ar bed a-bezh"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Steredennit savlec'hioù en ur furchal evit o ouzhpennañ amañ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Klask savourioù…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "An holl yezhoù"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Silañ dre yezh"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "An holl vroioù"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Silañ dre vro"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Savourenn ebet"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "O kargañ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u eus %d savourenn"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Savourioù: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "O kargañ ar savourioù"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Disoc'h ebet"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Gortozit mar plij…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Savourenn ebet ne glot gant ho klask"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "N'eo ket bet posupl kargañ ar savourioù"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL ar froud"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "N'emañ ket o seniñ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Diuzit ur savourenn"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "O c'hargañ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "O seniñ bremañ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Ehanet"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Oc'h adkevreañ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "O seniñ bremañ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bs.po
+++ b/po/bs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver nastavlja reproducirati radio nakon zatvaranja prozora"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historija pjesama"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Nastavi reprodukciju u pozadini"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informacije o stanici"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Učitano %d stanica"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Greška: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Greška reprodukcije: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sada svira: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nastavlja se: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Otkaži Last.fm autorizaciju"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Prekini vezu s Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Poveži se s Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autorizacija otkazana"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Veza s Last.fm prekinuta"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Povezivanje s Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Povezivanje s Last.fm nije uspjelo"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dozvolite pristup u svom pregledniku…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autorizacija je istekla"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Povezan s Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Otkrijte 30.000+ provjerenih radio stanica iz cijelog svijeta"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Označite stanice zvjezdicom dok pregledavate da ih dodate ovdje"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Pretraži stanice…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Svi jezici"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Sve zemlje"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtriraj po zemlji"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nema stanica"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Učitavanje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d stanica"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanice: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Učitavanje stanica"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nema rezultata"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Molimo sačekajte…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nijedna stanica ne odgovara vašoj pretrazi"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nije moguće učitati stanice"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL streama"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne svira"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Odaberite stanicu"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Punjenje međuspremnika…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Sada svira"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ponovno povezivanje…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Sada svira"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/bs.po
+++ b/po/bs.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: bs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver nastavlja reproducirati radio nakon zatvaranja prozora"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historija pjesama"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Nastavi reprodukciju u pozadini"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informacije o stanici"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Učitano %d stanica"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Greška: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Greška reprodukcije: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sada svira: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nastavlja se: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Otkaži Last.fm autorizaciju"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Prekini vezu s Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Poveži se s Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autorizacija otkazana"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Veza s Last.fm prekinuta"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Povezivanje s Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Povezivanje s Last.fm nije uspjelo"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dozvolite pristup u svom pregledniku…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autorizacija je istekla"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Povezan s Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Otkrijte 30.000+ provjerenih radio stanica iz cijelog svijeta"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nema favorita"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Označite stanice zvjezdicom dok pregledavate da ih dodate ovdje"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Pretraži stanice…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Svi jezici"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Sve zemlje"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtriraj po zemlji"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nema stanica"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Učitavanje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d stanica"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanice: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Učitavanje stanica"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nema rezultata"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Molimo sačekajte…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nijedna stanica ne odgovara vašoj pretrazi"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nije moguće učitati stanice"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stanica"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Zemlja"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Web stranica"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Brzina prijenosa"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL streama"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne svira"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Odaberite stanicu"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Punjenje međuspremnika…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Sada svira"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ponovno povezivanje…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Pretraživanje YouTubea…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Pretraga neuspješna: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nisu pronađeni YouTube rezultati"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Svi rezultati nedostupni"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Preuzimanje: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Otkazano"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Preuzimanje neuspješno: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Sačuvano: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Preuzmi pjesmu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Otkaži preuzimanje"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Još nema pjesama"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Pjesme će se pojaviti ovdje dok slušate radio stanice"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Upravo sada"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "prije %d minutu"
 msgstr[1] "prije %d minute"
 msgstr[2] "prije %d minuta"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "prije %d sat"
 msgstr[1] "prije %d sata"
 msgstr[2] "prije %d sati"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ca.po
+++ b/po/ca.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver continua reproduint la ràdio després de tancar la finestra"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historial de cançons"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continua reproduint en segon pla"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Quant a Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Explora"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Preferits"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informació de l'emissora"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "S'han carregat %d estacions"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducció: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "S'està reproduint: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprenent: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancel·la l'autorització de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconnecta de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Connecta a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "L'autorització de Last.fm s'ha cancel·lat"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectat de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connectant a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "No s'ha pogut connectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Atorgueu accés al vostre navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "L'autorització de Last.fm ha expirat"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connectat a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descobriu més de 30.000 estacions de ràdio verificades d'arreu del món"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sense preferits"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca emissores mentre explores per afegir-les aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cerca estacions…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Totes les llengües"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtra per idioma"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tots els països"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtra per país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Cap estació"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "S'està carregant…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "S'estan carregant les estacions"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sense resultats"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Si us plau, espereu…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Cap estació coincideix amb la cerca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "No s'han pogut carregar les estacions"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Emissora"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Lloc web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Còdec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "No s'està reproduint"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleccioneu una estació"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "S'està emplenant la memòria intermèdia…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "S'està reproduint"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "S'està reconnectant…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "S'està cercant a YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "La cerca ha fallat: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "No s'han trobat resultats a YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tots els resultats no estan disponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "S'està baixant: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancel·lat"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "La baixada ha fallat: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Desat: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Baixa la cançó"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancel·la la baixada"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Encara no hi ha cançons"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Les cançons apareixeran aquí mentre escolteu estacions de ràdio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ara mateix"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "fa %d minut"
 msgstr[1] "fa %d minuts"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "fa %d hora"
 msgstr[1] "fa %d hores"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ca.po
+++ b/po/ca.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continua reproduint la ràdio després de tancar la finestra"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historial de cançons"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continua reproduint en segon pla"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Quant a Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Explora"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Preferits"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informació de l'emissora"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "S'han carregat %d estacions"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducció: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "S'està reproduint: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprenent: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancel·la l'autorització de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconnecta de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Connecta a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "L'autorització de Last.fm s'ha cancel·lat"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectat de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connectant a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "No s'ha pogut connectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Atorgueu accés al vostre navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "L'autorització de Last.fm ha expirat"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connectat a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descobriu més de 30.000 estacions de ràdio verificades d'arreu del món"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca emissores mentre explores per afegir-les aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cerca estacions…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Totes les llengües"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtra per idioma"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tots els països"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtra per país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Cap estació"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "S'està carregant…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "S'estan carregant les estacions"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sense resultats"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Si us plau, espereu…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Cap estació coincideix amb la cerca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "No s'han pogut carregar les estacions"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL del flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "No s'està reproduint"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleccioneu una estació"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "S'està emplenant la memòria intermèdia…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "S'està reproduint"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "S'està reconnectant…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "S'està reproduint"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ca@valencia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continua reproduint la ràdio després de tancar la finestra"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historial de cançons"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continua reproduint en segon pla"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Quant a Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Explora"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Preferits"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informació de l'emissora"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "S'han carregat %d estacions"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducció: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "S'està reproduint: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprenent: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancel·la l'autorització de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconnecta de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Connecta a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "L'autorització de Last.fm s'ha cancel·lat"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectat de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connectant a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "No s'ha pogut connectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Atorgueu accés al vostre navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "L'autorització de Last.fm ha expirat"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connectat a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descobriu més de 30.000 estacions de ràdio verificades d'arreu del món"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca emissores mentre explores per a afegir-les ací"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cerca estacions…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Totes les llengües"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtra per idioma"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tots els països"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtra per país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Cap estació"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "S'està carregant…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "S'estan carregant les estacions"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sense resultats"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Per favor, espereu…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Cap estació coincideix amb la cerca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "No s'han pogut carregar les estacions"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL del flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "No s'està reproduint"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleccioneu una estació"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "S'està emplenant la memòria intermèdia…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "S'està reproduint"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "S'està reconnectant…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "S'està reproduint"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ca@valencia.po
+++ b/po/ca@valencia.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ca@valencia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver continua reproduint la ràdio després de tancar la finestra"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historial de cançons"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continua reproduint en segon pla"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Quant a Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Explora"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Preferits"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informació de l'emissora"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "S'han carregat %d estacions"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducció: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "S'està reproduint: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprenent: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancel·la l'autorització de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconnecta de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Connecta a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "L'autorització de Last.fm s'ha cancel·lat"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectat de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connectant a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "No s'ha pogut connectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Atorgueu accés al vostre navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "L'autorització de Last.fm ha expirat"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connectat a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descobriu més de 30.000 estacions de ràdio verificades d'arreu del món"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sense preferits"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca emissores mentre explores per a afegir-les ací"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cerca estacions…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Totes les llengües"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtra per idioma"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tots els països"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtra per país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Cap estació"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "S'està carregant…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "S'estan carregant les estacions"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sense resultats"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Per favor, espereu…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Cap estació coincideix amb la cerca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "No s'han pogut carregar les estacions"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Emissora"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Lloc web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Còdec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "No s'està reproduint"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleccioneu una estació"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "S'està emplenant la memòria intermèdia…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "S'està reproduint"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "S'està reconnectant…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "S'està cercant a YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "La cerca ha fallat: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "No s'han trobat resultats a YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tots els resultats no estan disponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "S'està baixant: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancel·lat"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "La baixada ha fallat: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Desat: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Baixa la cançó"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancel·la la baixada"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Encara no hi ha cançons"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Les cançons apareixeran ací mentre escolteu estacions de ràdio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ara mateix"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "fa %d minut"
 msgstr[1] "fa %d minuts"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "fa %d hora"
 msgstr[1] "fa %d hores"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ckb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver دوای داخستنی پەنجەرەکە بەردەوام دەبێت لە لێدانی ڕادیۆ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "مێنیو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "مێژووی گۆرانی"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "بەردەوامبوون لە لێدان لە پاشبنەمادا"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "دەربارەی Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "گەڕان"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "دڵخوازەکان"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "زانیاری وێستگە"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d وێستگە بارکرا"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "هەڵە: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "هەڵەی لێدان: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ئێستا دەخوێنرێتەوە: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "بەردەوامبوونەوە: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "ھەڵوەشاندنەوەی ڕێگەپێدانی Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "پچڕاندنی پەیوەندی لە Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "پەیوەستبوون بە Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "ڕێگەپێدانی Last.fm ھەڵوەشایەوە"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "پەیوەندی لە Last.fm پچڕا"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "پەیوەستبوون بە Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "پەیوەستبوون بە Last.fm سەرنەکەوت"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "لە وێبگەڕەکەتدا ڕێگەپێبدە…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "کات بەسەرچوونی ڕێگەپێدانی Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "پەیوەستبوو بە Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "دۆزینەوەی ٣٠٬٠٠٠+ وێستگەی ڕادیۆی پشتڕاستکراوە لە سەرانسەری جیھان"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "هیچ دڵخوازێک نییە"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "لەکاتی گەڕاندا وێستگەکان ئەستێرە بکە بۆ زیادکردنیان لێرە"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "گەڕان بۆ وێستگەکان…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "هەموو زمانەکان"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "پاڵاوتن بەپێی زمان"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "هەموو وڵاتەکان"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "پاڵاوتن بەپێی وڵات"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "هیچ وێستگەیەک نییە"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "بارکردن…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u لە %d وێستگە"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "وێستگەکان: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "بارکردنی وێستگەکان"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "هیچ ئەنجامێک نییە"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "تکایە چاوەڕوان بە…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "هیچ وێستگەیەک لەگەڵ گەڕانەکەت ناگونجێت"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "وێستگەکان بارنەکران"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "وێستگە"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "وڵات"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "تاگەکان"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "پەڕەی ئینتەرنێت"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کۆدێک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ڕێژەی بیت"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "بەستەری وەشان"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "لێنادرێت"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "وێستگەیەک هەڵبژێرە"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "بارکردن…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ئێستا دەخوێنرێتەوە"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "وەستێنرا"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "دووبارە پەیوەندیکردنەوە…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "گەڕان لە YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "گەڕان سەرکەوتوو نەبوو: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "هیچ ئەنجامی YouTube نەدۆزرایەوە"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "هەموو ئەنجامەکان بەردەست نین"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "دابەزاندن: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "هەڵوەشایەوە"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "دابەزاندن سەرکەوتوو نەبوو: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "پاشەکەوتکرا: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "گۆرانی دابەزێنە"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "دابەزاندن هەڵوەشێنەوە"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ھێشتا گۆرانی نییە"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "گۆرانییەکان ئێرە دەردەکەون کاتێک گوێ لە وێستگەی ڕادیۆ دەگریت"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ئێستا"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d خولەک لەمەوبەر"
 msgstr[1] "%d خولەک لەمەوبەر"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d کاتژمێر لەمەوبەر"
 msgstr[1] "%d کاتژمێر لەمەوبەر"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ckb.po
+++ b/po/ckb.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ckb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver دوای داخستنی پەنجەرەکە بەردەوام دەبێت لە لێدانی ڕادیۆ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "مێنیو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "مێژووی گۆرانی"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "بەردەوامبوون لە لێدان لە پاشبنەمادا"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "دەربارەی Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "گەڕان"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "دڵخوازەکان"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "زانیاری وێستگە"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d وێستگە بارکرا"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "هەڵە: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "هەڵەی لێدان: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ئێستا دەخوێنرێتەوە: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "بەردەوامبوونەوە: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "ھەڵوەشاندنەوەی ڕێگەپێدانی Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "پچڕاندنی پەیوەندی لە Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "پەیوەستبوون بە Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "ڕێگەپێدانی Last.fm ھەڵوەشایەوە"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "پەیوەندی لە Last.fm پچڕا"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "پەیوەستبوون بە Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "پەیوەستبوون بە Last.fm سەرنەکەوت"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "لە وێبگەڕەکەتدا ڕێگەپێبدە…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "کات بەسەرچوونی ڕێگەپێدانی Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "پەیوەستبوو بە Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "دۆزینەوەی ٣٠٬٠٠٠+ وێستگەی ڕادیۆی پشتڕاستکراوە لە سەرانسەری جیھان"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "لەکاتی گەڕاندا وێستگەکان ئەستێرە بکە بۆ زیادکردنیان لێرە"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "گەڕان بۆ وێستگەکان…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "هەموو زمانەکان"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "پاڵاوتن بەپێی زمان"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "هەموو وڵاتەکان"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "پاڵاوتن بەپێی وڵات"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "هیچ وێستگەیەک نییە"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "بارکردن…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u لە %d وێستگە"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "وێستگەکان: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "بارکردنی وێستگەکان"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "هیچ ئەنجامێک نییە"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "تکایە چاوەڕوان بە…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "هیچ وێستگەیەک لەگەڵ گەڕانەکەت ناگونجێت"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "وێستگەکان بارنەکران"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "بەستەری وەشان"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "لێنادرێت"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "وێستگەیەک هەڵبژێرە"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "بارکردن…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ئێستا دەخوێنرێتەوە"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "وەستێنرا"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "دووبارە پەیوەندیکردنەوە…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ئێستا دەخوێنرێتەوە"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/crh.po
+++ b/po/crh.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: crh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Pencere qapatılğan soñ Receiver radyonı çalmağa devam ete"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Yır tarihı"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Arqa planda çalmağa devam et"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver aqqında"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Közden keçir"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Sevimli"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stansiya malümatı"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yüklendi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Hata: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oynav hatası: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Şimdi oynay: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Devam ete: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm icazetini bekor et"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-den ayrıl"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ge bağlan"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm icazeti bekor etildi"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-den ayrıldı"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ge bağlanıla…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ge bağlanıp olamadı"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Brauzeriñizde icazet beriñiz…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm icazetiniñ vaqtı çıqtı"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ge bağlandı"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dünya boyunca 30 000+ tastıqlangan radio stantsiyalarını keşfet"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sevimli yoq"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Burağa qoşmaq içün közden keçirgende stansiyelerni yıldızla işaretle"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stansiyalarni qıdır…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Bütün tiller"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Til boyunca süz"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Bütün memleketler"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Memleketke köre süz"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stansiya yoq"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Yüklene…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stansiyalar yüklene"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Netice yoq"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Lütfen bekleñiz…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Qıdıruvıñızğa uyğun stansiya tapılmadı"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stansiyalarnı yüklemek mümkün olmadı"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stansiya"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Memleket"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tegler"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Vebsayt"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitreyt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Aqın URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Oynamay"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stansiya saylaňız"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buferleştirile…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Şimdi oynay"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Toqtatıldı"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Yañıdan bağlana…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-da qıdırıla…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Qıdıruv başarısız: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube neticesi tapılmadı"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Bütün neticeler irişilmez"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Yüklene: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Bekar etildi"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Yükleme başarısız: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saqlandı: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Yırnı yükle"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Yüklemeni bekar et"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Daa yır yoq"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Radio stantsiyalarını diñlegeniñizde yırlar mında körünecek"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Şimdi"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d daq evel"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d saat evel"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/crh.po
+++ b/po/crh.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: crh\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Pencere qapatılğan soñ Receiver radyonı çalmağa devam ete"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Yır tarihı"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Arqa planda çalmağa devam et"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver aqqında"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Közden keçir"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Sevimli"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stansiya malümatı"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yüklendi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Hata: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oynav hatası: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Şimdi oynay: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Devam ete: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm icazetini bekor et"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-den ayrıl"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ge bağlan"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm icazeti bekor etildi"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-den ayrıldı"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ge bağlanıla…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ge bağlanıp olamadı"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Brauzeriñizde icazet beriñiz…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm icazetiniñ vaqtı çıqtı"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ge bağlandı"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dünya boyunca 30 000+ tastıqlangan radio stantsiyalarını keşfet"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Burağa qoşmaq içün közden keçirgende stansiyelerni yıldızla işaretle"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stansiyalarni qıdır…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Bütün tiller"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Til boyunca süz"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Bütün memleketler"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Memleketke köre süz"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stansiya yoq"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Yüklene…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stansiyalar yüklene"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Netice yoq"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Lütfen bekleñiz…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Qıdıruvıñızğa uyğun stansiya tapılmadı"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stansiyalarnı yüklemek mümkün olmadı"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Aqın URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Oynamay"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stansiya saylaňız"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buferleştirile…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Şimdi oynay"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Toqtatıldı"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Yañıdan bağlana…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Şimdi oynay"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/cs.po
+++ b/po/cs.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver po zavření okna pokračuje v přehrávání rádia"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Nabídka"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historie skladeb"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Pokračovat v přehrávání na pozadí"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O aplikaci Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Oblíbené"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informace o stanici"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Načteno %d stanic"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Chyba přehrávání: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nyní hraje: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Obnovení: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Zrušit autorizaci Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Odpojit od Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Připojit k Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizace Last.fm zrušena"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Odpojeno od Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Připojování k Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nepodařilo se připojit k Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Udělte přístup ve svém prohlížeči…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizace Last.fm vypršela"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Připojeno k Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Objevte více než 30 000 ověřených rozhlasových stanic z celého světa"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Při procházení označte stanice hvězdičkou a přidejte je sem"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Hledat stanice…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Všechny jazyky"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrovat podle jazyka"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Všechny země"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrovat podle země"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Žádné stanice"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Načítání…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d stanic"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanic: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Načítání stanic"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Žádné výsledky"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Čekejte prosím…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Žádné stanice neodpovídají vašemu hledání"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nepodařilo se načíst stanice"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL streamu"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nepřehrává se"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Vyberte stanici"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ukládání do vyrovnávací paměti…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nyní hraje"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pozastaveno"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Opětovné připojování…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nyní hraje"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/cs.po
+++ b/po/cs.po
@@ -3,298 +3,296 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver po zavření okna pokračuje v přehrávání rádia"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Nabídka"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historie skladeb"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Pokračovat v přehrávání na pozadí"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O aplikaci Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Procházet"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Oblíbené"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informace o stanici"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Načteno %d stanic"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Chyba přehrávání: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nyní hraje: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Obnovení: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Zrušit autorizaci Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Odpojit od Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Připojit k Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizace Last.fm zrušena"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Odpojeno od Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Připojování k Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nepodařilo se připojit k Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Udělte přístup ve svém prohlížeči…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizace Last.fm vypršela"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Připojeno k Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Objevte více než 30 000 ověřených rozhlasových stanic z celého světa"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Žádné oblíbené"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Při procházení označte stanice hvězdičkou a přidejte je sem"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Hledat stanice…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Všechny jazyky"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrovat podle jazyka"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Všechny země"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrovat podle země"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Žádné stanice"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Načítání…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d stanic"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanic: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Načítání stanic"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Žádné výsledky"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Čekejte prosím…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Žádné stanice neodpovídají vašemu hledání"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nepodařilo se načíst stanice"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stanice"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Země"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Štítky"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webové stránky"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Datový tok"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL streamu"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nepřehrává se"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Vyberte stanici"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ukládání do vyrovnávací paměti…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nyní hraje"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pozastaveno"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Opětovné připojování…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Hledání na YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Hledání selhalo: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nebyly nalezeny žádné výsledky na YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Všechny výsledky jsou nedostupné"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Stahování: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Zrušeno"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Stahování selhalo: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Uloženo: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Stáhnout skladbu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Zrušit stahování"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Zatím žádné skladby"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Skladby se zde zobrazí při poslechu rozhlasových stanic"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Právě teď"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -302,7 +300,7 @@ msgstr[0] "před %d minutou"
 msgstr[1] "před %d minutami"
 msgstr[2] "před %d minutami"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -310,7 +308,7 @@ msgstr[0] "před %d hodinou"
 msgstr[1] "před %d hodinami"
 msgstr[2] "před %d hodinami"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/cy.po
+++ b/po/cy.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n!=8 && n!=11) ? "
 "2 : 3;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Mae Receiver yn parhau i chwarae'r radio ar ôl cau'r ffenestr"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Dewislen"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Hanes Caneuon"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Parhau i chwarae yn y cefndir"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Ynglŷn â Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Pori"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Ffefrynnau"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Gwybodaeth yr orsaf"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Llwythwyd %d gorsaf"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Gwall: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Gwall chwarae: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Yn chwarae nawr: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ailddechrau: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Canslo awdurdodiad Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Datgysylltu o Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Cysylltu â Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Canslwyd awdurdodiad Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Datgysylltwyd o Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Yn cysylltu â Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Methwyd cysylltu â Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Rhowch fynediad yn eich porwr…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Amser awdurdodiad Last.fm wedi dod i ben"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Wedi cysylltu â Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Darganfyddwch 30,000+ o orsafoedd radio dilys o bob cwr o'r byd"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Dim ffefrynnau"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Serennu gorsafoedd wrth bori i'w hychwanegu yma"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Chwilio gorsafoedd…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Pob Iaith"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Hidlo yn ôl iaith"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Pob gwlad"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Hidlo yn ôl gwlad"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Dim Gorsafoedd"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Yn llwytho…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u o %d gorsaf"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Gorsafoedd: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Yn Llwytho Gorsafoedd"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Dim Canlyniadau"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Arhoswch…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Dim gorsafoedd yn cyfateb i'ch chwiliad"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Methu llwytho gorsafoedd"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Gorsaf"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Gwlad"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tagiau"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Gwefan"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Cyfradd didau"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL y ffrwd"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ddim yn Chwarae"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Dewiswch orsaf"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Yn byffro…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Yn chwarae nawr"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Wedi Oedi"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Yn ailgysylltu…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Yn chwilio YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Chwiliad wedi methu: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Dim canlyniadau YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Pob canlyniad ddim ar gael"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Yn lawrlwytho: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Wedi Canslo"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Lawrlwytho wedi methu: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Wedi cadw: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Lawrlwytho cân"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Canslo lawrlwytho"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Dim Caneuon Eto"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Bydd caneuon yn ymddangos yma wrth i chi wrando ar orsafoedd radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Nawr"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -304,7 +302,7 @@ msgstr[1] "%d funud yn ôl"
 msgstr[2] "%d munud yn ôl"
 msgstr[3] "%d munud yn ôl"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -313,7 +311,7 @@ msgstr[1] "%d awr yn ôl"
 msgstr[2] "%d awr yn ôl"
 msgstr[3] "%d awr yn ôl"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/cy.po
+++ b/po/cy.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: cy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n!=8 && n!=11) ? "
 "2 : 3;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Mae Receiver yn parhau i chwarae'r radio ar ôl cau'r ffenestr"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Dewislen"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Hanes Caneuon"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Parhau i chwarae yn y cefndir"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Ynglŷn â Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Pori"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Ffefrynnau"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Gwybodaeth yr orsaf"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Llwythwyd %d gorsaf"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Gwall: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Gwall chwarae: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Yn chwarae nawr: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ailddechrau: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Canslo awdurdodiad Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Datgysylltu o Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Cysylltu â Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Canslwyd awdurdodiad Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Datgysylltwyd o Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Yn cysylltu â Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Methwyd cysylltu â Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Rhowch fynediad yn eich porwr…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Amser awdurdodiad Last.fm wedi dod i ben"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Wedi cysylltu â Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Darganfyddwch 30,000+ o orsafoedd radio dilys o bob cwr o'r byd"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Serennu gorsafoedd wrth bori i'w hychwanegu yma"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Chwilio gorsafoedd…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Pob Iaith"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Hidlo yn ôl iaith"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Pob gwlad"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Hidlo yn ôl gwlad"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Dim Gorsafoedd"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Yn llwytho…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u o %d gorsaf"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Gorsafoedd: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Yn Llwytho Gorsafoedd"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Dim Canlyniadau"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Arhoswch…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Dim gorsafoedd yn cyfateb i'ch chwiliad"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Methu llwytho gorsafoedd"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL y ffrwd"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ddim yn Chwarae"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Dewiswch orsaf"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Yn byffro…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Yn chwarae nawr"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Wedi Oedi"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Yn ailgysylltu…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Yn chwarae nawr"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/da.po
+++ b/po/da.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver fortsætter med at afspille radio, efter vinduet er lukket"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Sanghistorik"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Fortsæt afspilning i baggrunden"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritter"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stationsinfo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationer indlæst"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fejl: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspilningsfejl: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spiller nu: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Genoptager: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Annuller Last.fm-godkendelse"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Afbryd forbindelsen til Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Opret forbindelse til Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-godkendelse annulleret"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Forbindelsen til Last.fm afbrudt"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Forbinder til Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kunne ikke oprette forbindelse til Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Giv adgang i din browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-godkendelse udløb"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Forbundet til Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Opdag 30.000+ verificerede radiostationer fra hele verden"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ingen favoritter"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Markér stationer mens du gennemser for at tilføje dem her"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Søg stationer…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle sprog"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrer efter sprog"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle lande"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrer efter land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ingen stationer"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Indlæser…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u af %d stationer"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationer: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Indlæser stationer"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ingen resultater"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vent venligst…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ingen stationer matcher din søgning"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kunne ikke indlæse stationer"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Station"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Mærker"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Websted"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bithastighed"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Spiller ikke"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Vælg en station"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Mellemlagrer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Spiller nu"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Sat på pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Genopretter forbindelse…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Søger på YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Søgning mislykkedes: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ingen YouTube-resultater fundet"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultater utilgængelige"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Downloader: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Annulleret"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download mislykkedes: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Gemt: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Download sang"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Annuller download"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ingen sange endnu"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Sange vises her, når du lytter til radiostationer"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Lige nu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min. siden"
 msgstr[1] "%d min. siden"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d time siden"
 msgstr[1] "%d timer siden"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/da.po
+++ b/po/da.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: da\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver fortsætter med at afspille radio, efter vinduet er lukket"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Sanghistorik"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Fortsæt afspilning i baggrunden"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Gennemse"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritter"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stationsinfo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationer indlæst"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fejl: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspilningsfejl: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spiller nu: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Genoptager: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Annuller Last.fm-godkendelse"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Afbryd forbindelsen til Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Opret forbindelse til Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-godkendelse annulleret"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Forbindelsen til Last.fm afbrudt"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Forbinder til Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kunne ikke oprette forbindelse til Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Giv adgang i din browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-godkendelse udløb"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Forbundet til Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Opdag 30.000+ verificerede radiostationer fra hele verden"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Markér stationer mens du gennemser for at tilføje dem her"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Søg stationer…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle sprog"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrer efter sprog"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle lande"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrer efter land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ingen stationer"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Indlæser…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u af %d stationer"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationer: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Indlæser stationer"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ingen resultater"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vent venligst…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ingen stationer matcher din søgning"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kunne ikke indlæse stationer"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Spiller ikke"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Vælg en station"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Mellemlagrer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Spiller nu"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Sat på pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Genopretter forbindelse…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Spiller nu"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "PO-Revision-Date: 2026-02-06 22:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
@@ -16,101 +16,109 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver spielt das Radio weiter, nachdem das Fenster geschlossen wurde"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Songverlauf"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Im Hintergrund weiterspielen"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Über Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Senderinfo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d Sender geladen"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Wiedergabefehler: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Aktuelle Wiedergabe: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Fortsetzen: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-Autorisierung abbrechen"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Von Last.fm trennen"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Mit Last.fm verbinden"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-Autorisierung abgebrochen"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Von Last.fm getrennt"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Verbinde mit Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Verbindung zu Last.fm fehlgeschlagen"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Zugriff in Ihrem Browser gewähren…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-Autorisierung abgelaufen"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Mit Last.fm verbunden"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Entdecken Sie über 30.000 verifizierte Radiosender aus aller Welt"
 
@@ -120,64 +128,65 @@ msgstr "Keine Favoriten"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Sender beim Durchsuchen mit einem Stern markieren, um sie hier hinzuzufügen"
+msgstr ""
+"Sender beim Durchsuchen mit einem Stern markieren, um sie hier hinzuzufügen"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Sender suchen…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle Sprachen"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Nach Sprache filtern"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle Länder"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Nach Land filtern"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Keine Sender"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laden…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u von %d Sendern"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Sender: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Sender werden geladen"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Keine Ergebnisse"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Bitte warten…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Keine Sender entsprechen Ihrer Suche"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Sender konnten nicht geladen werden"
 
@@ -210,25 +219,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Keine Wiedergabe"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Sender auswählen"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Wird gepuffert…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Aktuelle Wiedergabe"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Verbinde erneut…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Aktuelle Wiedergabe"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/de.po
+++ b/po/de.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "PO-Revision-Date: 2026-02-06 22:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: German\n"
@@ -16,306 +16,305 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver spielt das Radio weiter, nachdem das Fenster geschlossen wurde"
+msgstr ""
+"Receiver spielt das Radio weiter, nachdem das Fenster geschlossen wurde"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Songverlauf"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Im Hintergrund weiterspielen"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Über Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Durchsuchen"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Senderinfo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d Sender geladen"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Wiedergabefehler: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Aktuelle Wiedergabe: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Fortsetzen: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-Autorisierung abbrechen"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Von Last.fm trennen"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Mit Last.fm verbinden"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-Autorisierung abgebrochen"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Von Last.fm getrennt"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Verbinde mit Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Verbindung zu Last.fm fehlgeschlagen"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Zugriff in Ihrem Browser gewähren…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-Autorisierung abgelaufen"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Mit Last.fm verbunden"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Entdecken Sie über 30.000 verifizierte Radiosender aus aller Welt"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Keine Favoriten"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Sender beim Durchsuchen mit einem Stern markieren, um sie hier hinzuzufügen"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Sender suchen…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle Sprachen"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Nach Sprache filtern"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle Länder"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Nach Land filtern"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Keine Sender"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laden…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u von %d Sendern"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Sender: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Sender werden geladen"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Keine Ergebnisse"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Bitte warten…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Keine Sender entsprechen Ihrer Suche"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Sender konnten nicht geladen werden"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Sender"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Schlagwörter"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webseite"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Keine Wiedergabe"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Sender auswählen"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Wird gepuffert…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Aktuelle Wiedergabe"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Verbinde erneut…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Suche auf YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Suche fehlgeschlagen: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Keine YouTube-Ergebnisse gefunden"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle Ergebnisse nicht verfügbar"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Wird heruntergeladen: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download fehlgeschlagen: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Gespeichert: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Lied herunterladen"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Download abbrechen"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Noch keine Titel"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Titel werden hier angezeigt, wenn Sie Radiosender hören"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Gerade eben"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "vor %d Min."
 msgstr[1] "vor %d Min."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "vor %d Stunde"
 msgstr[1] "vor %d Stunden"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/de_CH.po
+++ b/po/de_CH.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: de_CH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver spielt das Radio weiter, nachdem das Fenster geschlossen wurde"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Songverlauf"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Im Hintergrund weiterspielen"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Über Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Durchsuche"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorite"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Sänderinfo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d Stationen geladen"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Wiedergabefehler: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spielt jetzt: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Fortsetzen: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-Autorisierung abbrechen"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Von Last.fm trennen"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Mit Last.fm verbinden"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-Autorisierung abgebrochen"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Von Last.fm getrennt"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Verbinde mit Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Verbindung zu Last.fm fehlgeschlagen"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Zugriff in Ihrem Browser gewähren…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-Autorisierung abgelaufen"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Mit Last.fm verbunden"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Entdecken Sie über 30'000 verifizierte Radiosender aus aller Welt"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Sänder bim Durchsuche mit emne Stärn markiere, zum si do hinzuefüege"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stationen suchen…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle Sprachen"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Nach Sprache filtern"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alli Länder"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Nach Land filtere"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Keine Stationen"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laden…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u von %d Stationen"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationen: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stationen werden geladen"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Keine Ergebnisse"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Bitte warten…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Keine Stationen entsprechen Ihrer Suche"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stationen konnten nicht geladen werden"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Keine Wiedergabe"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Station auswählen"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Wird gepuffert…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Spielt jetzt"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Verbindung wird wiederhergestellt…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Spielt jetzt"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/de_CH.po
+++ b/po/de_CH.po
@@ -3,312 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: de_CH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver spielt das Radio weiter, nachdem das Fenster geschlossen wurde"
+msgstr ""
+"Receiver spielt das Radio weiter, nachdem das Fenster geschlossen wurde"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Songverlauf"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Im Hintergrund weiterspielen"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Über Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Durchsuche"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorite"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Sänderinfo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d Stationen geladen"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Wiedergabefehler: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spielt jetzt: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Fortsetzen: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-Autorisierung abbrechen"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Von Last.fm trennen"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Mit Last.fm verbinden"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-Autorisierung abgebrochen"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Von Last.fm getrennt"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Verbinde mit Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Verbindung zu Last.fm fehlgeschlagen"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Zugriff in Ihrem Browser gewähren…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-Autorisierung abgelaufen"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Mit Last.fm verbunden"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Entdecken Sie über 30'000 verifizierte Radiosender aus aller Welt"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Kei Favorite"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Sänder bim Durchsuche mit emne Stärn markiere, zum si do hinzuefüege"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stationen suchen…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle Sprachen"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Nach Sprache filtern"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alli Länder"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Nach Land filtere"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Keine Stationen"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laden…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u von %d Stationen"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationen: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stationen werden geladen"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Keine Ergebnisse"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Bitte warten…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Keine Stationen entsprechen Ihrer Suche"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stationen konnten nicht geladen werden"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Sänder"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Schlagwörter"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Websiite"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Keine Wiedergabe"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Station auswählen"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Wird gepuffert…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Spielt jetzt"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Verbindung wird wiederhergestellt…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube wird durchsucht…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Suche fehlgeschlagen: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Keine YouTube-Ergebnisse gefunden"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle Ergebnisse nicht verfügbar"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Wird heruntergeladen: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Abgebrochen"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download fehlgeschlagen: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Gespeichert: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Lied herunterladen"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Download abbrechen"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Noch keine Titel"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Titel werden hier angezeigt, wenn Sie Radiosender hören"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Gerade eben"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "vor %d Min."
 msgstr[1] "vor %d Min."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "vor %d Stunde"
 msgstr[1] "vor %d Stunden"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/dv.po
+++ b/po/dv.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: dv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ވިންޑޯ ބަންދުކުރުމަށްފަހުވެސް Receiver ރޭޑިއޯ ޖަހަމުންދާނެ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "މެނޫ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ލަވައިގެ ތާރީޚު"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ބެކްގްރައުންޑްގައި ޖަހަމުން ގެންދޭ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver އާ ބެހޭ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ހޯދާ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ފެވަރިޓްސް"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ސްޓޭޝަން މައުލޫމާތު"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ސްޓޭޝަން ލޯޑްކުރެވިއްޖެ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "މައްސަލައެއް: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ޕްލޭބެކް މައްސަލައެއް: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "މިހާރު ކުޅެނީ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ކުރިއަށް ގެންދަނީ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ހުއްދަ ކެންސަލް ކުރޭ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm އިން ޑިސްކަނެކްޓް ކުރޭ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm އަށް ކަނެކްޓް ކުރޭ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ހުއްދަ ކެންސަލް ކުރެވިއްޖެ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm އިން ޑިސްކަނެކްޓް ކުރެވިއްޖެ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm އަށް ކަނެކްޓް ކުރަނީ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm އަށް ކަނެކްޓް ނުވި"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ބްރައުޒަރުގައި ހުއްދަ ދެއްވާ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ހުއްދައިގެ ވަގުތު ހަމަވެއްޖެ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm އަށް ކަނެކްޓް ވެއްޖެ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ދުނިޔޭގެ އެކި ކަންކޮޅުތަކުން 30,000+ ވެރިފައި ކޮށްފައިވާ ރޭޑިއޯ ސްޓޭޝަން ހޯދާ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "މިތަނަށް އިތުރުކުރުމަށް ބްރައުޒް ކުރާއިރު ސްޓޭޝަންތަކުގައި ސްޓާރ ޖައްސާ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ސްޓޭޝަންތައް ހޯދާ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ހުރިހާ ބަހެއް"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ބަހުން ފިލްޓަރ ކުރޭ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ހުރިހާ ޤައުމެއް"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ޤައުމުން ފިލްޓާ ކުރޭ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ސްޓޭޝަނެއް ނެތް"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ލޯޑް ކުރަނީ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ސްޓޭޝަން"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ސްޓޭޝަންތައް: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ސްޓޭޝަންތައް ލޯޑް ކުރަނީ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ނަތީޖާ ނެތް"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "މަޑުކޮށްލައްވާ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ތިޔަ ހޯދުމާ ގުޅޭ ސްޓޭޝަނެއް ނެތް"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ސްޓޭޝަންތައް ލޯޑެއް ނުކުރެވުނު"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ސްޓްރީމް URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ނުކުޅެއެވެ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ސްޓޭޝަނެއް ހޮވާ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ބަފަރ ކުރަނީ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "މިހާރު ކުޅެނީ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "މަޑުކޮށްފައި"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "އަލުން ގުޅަނީ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "މިހާރު ކުޅެނީ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/dv.po
+++ b/po/dv.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: dv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ވިންޑޯ ބަންދުކުރުމަށްފަހުވެސް Receiver ރޭޑިއޯ ޖަހަމުންދާނެ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "މެނޫ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ލަވައިގެ ތާރީޚު"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ބެކްގްރައުންޑްގައި ޖަހަމުން ގެންދޭ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver އާ ބެހޭ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ހޯދާ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ފެވަރިޓްސް"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ސްޓޭޝަން މައުލޫމާތު"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ސްޓޭޝަން ލޯޑްކުރެވިއްޖެ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "މައްސަލައެއް: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ޕްލޭބެކް މައްސަލައެއް: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "މިހާރު ކުޅެނީ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ކުރިއަށް ގެންދަނީ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ހުއްދަ ކެންސަލް ކުރޭ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm އިން ޑިސްކަނެކްޓް ކުރޭ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm އަށް ކަނެކްޓް ކުރޭ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ހުއްދަ ކެންސަލް ކުރެވިއްޖެ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm އިން ޑިސްކަނެކްޓް ކުރެވިއްޖެ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm އަށް ކަނެކްޓް ކުރަނީ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm އަށް ކަނެކްޓް ނުވި"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ބްރައުޒަރުގައި ހުއްދަ ދެއްވާ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ހުއްދައިގެ ވަގުތު ހަމަވެއްޖެ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm އަށް ކަނެކްޓް ވެއްޖެ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ދުނިޔޭގެ އެކި ކަންކޮޅުތަކުން 30,000+ ވެރިފައި ކޮށްފައިވާ ރޭޑިއޯ ސްޓޭޝަން ހޯދާ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ފެވަރިޓެއް ނެތް"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "މިތަނަށް އިތުރުކުރުމަށް ބްރައުޒް ކުރާއިރު ސްޓޭޝަންތަކުގައި ސްޓާރ ޖައްސާ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ސްޓޭޝަންތައް ހޯދާ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ހުރިހާ ބަހެއް"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ބަހުން ފިލްޓަރ ކުރޭ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ހުރިހާ ޤައުމެއް"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ޤައުމުން ފިލްޓާ ކުރޭ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ސްޓޭޝަނެއް ނެތް"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ލޯޑް ކުރަނީ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ސްޓޭޝަން"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ސްޓޭޝަންތައް: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ސްޓޭޝަންތައް ލޯޑް ކުރަނީ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ނަތީޖާ ނެތް"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "މަޑުކޮށްލައްވާ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ތިޔަ ހޯދުމާ ގުޅޭ ސްޓޭޝަނެއް ނެތް"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ސްޓޭޝަންތައް ލޯޑެއް ނުކުރެވުނު"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ސްޓޭޝަން"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ޤައުމު"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ޓެގްތައް"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ވެބްސައިޓް"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ކޯޑެކް"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ބިޓްރޭޓް"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ސްޓްރީމް URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ނުކުޅެއެވެ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ސްޓޭޝަނެއް ހޮވާ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ބަފަރ ކުރަނީ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "މިހާރު ކުޅެނީ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "މަޑުކޮށްފައި"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "އަލުން ގުޅަނީ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube ގައި ހޯދަނީ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ހޯދުން ނާކާމިޔާބުވީ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ނަތީޖާ ނުފެނުނު"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ހުރިހާ ނަތީޖާ ލިބެން ނެތް"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ޑައުންލޯޑް ކުރަނީ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ކެންސަލް ކުރެވިއްޖެ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ޑައުންލޯޑް ނާކާމިޔާބުވީ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ސޭވް ކުރެވިއްޖެ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ލަވަ ޑައުންލޯޑް ކުރޭ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ޑައުންލޯޑް ކެންސަލް ކުރޭ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "އަދި ލަވައެއް ނެތް"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ރޭޑިއޯ ސްޓޭޝަންތައް އަޑުއަހާއިރު ލަވަތައް މިތާ ފެންނާނެ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "މިހާރު"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d މިނެޓް ކުރިން"
 msgstr[1] "%d މިނެޓް ކުރިން"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ގަޑިއިރު ކުރިން"
 msgstr[1] "%d ގަޑިއިރު ކުރިން"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/dz.po
+++ b/po/dz.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: dz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "སྒོ་སྒྲིག་ཁ་བསྡམས་ཞིནམ་ལས་ Receiver གིས་རླུང་འཕྲིན་གཏང་མུ་མཐུད་འབད་འོང་།"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "དཀར་ཆག"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "གཞས་ཀྱི་ལོ་རྒྱུས"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "རྒྱབ་ཁར་གཏང་མུ་མཐུད་འབད།"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver སྐོར་ལས"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "བལྟ།"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "དགའ་མཆོག"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ས་ཚིགས་ཀྱི་གནས་ཚུལ།"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "རླུང་འཕྲིན་འཐུས་སྒྲིག %d ཐོན་ཡོད"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "འཛོལ་བ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "སྒྲ་སྐྱོན: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ད་ལྟ་གཏོང་བཞིན་པ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "བསྐྱར་གཏོང: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm དབང་བསྐུར་ཆ་མེད་གཏང"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ལས་བཅད"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ལུ་འབྲེལ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm དབང་བསྐུར་ཆ་མེད་བཏང་ཡོདཔ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ལས་བཅད་ཡོདཔ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ལུ་འབྲེལ་བཞིན…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ལུ་འབྲེལ་མ་ཚུགས"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ཁྱོད་ཀྱི་བཤར་ཆས་ནང་ལུ་ཆོག་མཆན་བྱིན…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm དབང་བསྐུར་དུས་ཚོད་ཚང་ཡོདཔ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ལུ་འབྲེལ་ཡོདཔ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "འཛམ་གླིང་ཡོངས་ལས་30,000+ བརྟག་ཞིབ་འབད་ཡོད་མི་རླུང་འཕྲིན་ས་ཚིགས་འཚོལ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "འདི་ནང་བཅུག་ནིའི་དོན་ལུ་བལྟ་བའི་སྐབས་ས་ཚིགས་ལུ་སྐར་མ་རྟགས་བཀལ།"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "རླུང་འཕྲིན་འཚོལ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "སྐད་ཡིག་ཚང་མ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "སྐད་ཡིག་ལྟར་བཙག"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "རྒྱལ་ཁབ་ཆ་མཉམ།"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "རྒྱལ་ཁབ་ལུ་གཞི་བཞག་བཙག"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "རླུང་འཕྲིན་མེད"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ཐོན་བཞིན་པ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "རླུང་འཕྲིན %d ནང་ལས %u"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "རླུང་འཕྲིན: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "རླུང་འཕྲིན་ཐོན་བཞིན་པ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "གྲུབ་འབྲས་མེད"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "སྒུག་རོགས…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "འཚོལ་བའི་རླུང་འཕྲིན་མ་རྙེད"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "རླུང་འཕྲིན་ཐོན་མ་ཚུགས"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "རྒྱུན་བཏང་URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "གཏོང་མིན་འདུག"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "རླུང་འཕྲིན་གཅིག་གདམ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ཤུགས་ཁམས་འཛིན་བཞིན་པ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ད་ལྟ་གཏོང་བཞིན་པ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "བཀག་ཡོད"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "བསྐྱར་འབྲེལ་བཞིན་པ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ད་ལྟ་གཏོང་བཞིན་པ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/dz.po
+++ b/po/dz.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: dz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "སྒོ་སྒྲིག་ཁ་བསྡམས་ཞིནམ་ལས་ Receiver གིས་རླུང་འཕྲིན་གཏང་མུ་མཐུད་འབད་འོང་།"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "དཀར་ཆག"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "གཞས་ཀྱི་ལོ་རྒྱུས"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "རྒྱབ་ཁར་གཏང་མུ་མཐུད་འབད།"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver སྐོར་ལས"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "བལྟ།"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "དགའ་མཆོག"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ས་ཚིགས་ཀྱི་གནས་ཚུལ།"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "རླུང་འཕྲིན་འཐུས་སྒྲིག %d ཐོན་ཡོད"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "འཛོལ་བ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "སྒྲ་སྐྱོན: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ད་ལྟ་གཏོང་བཞིན་པ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "བསྐྱར་གཏོང: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm དབང་བསྐུར་ཆ་མེད་གཏང"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ལས་བཅད"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ལུ་འབྲེལ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm དབང་བསྐུར་ཆ་མེད་བཏང་ཡོདཔ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ལས་བཅད་ཡོདཔ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ལུ་འབྲེལ་བཞིན…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ལུ་འབྲེལ་མ་ཚུགས"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ཁྱོད་ཀྱི་བཤར་ཆས་ནང་ལུ་ཆོག་མཆན་བྱིན…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm དབང་བསྐུར་དུས་ཚོད་ཚང་ཡོདཔ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ལུ་འབྲེལ་ཡོདཔ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "འཛམ་གླིང་ཡོངས་ལས་30,000+ བརྟག་ཞིབ་འབད་ཡོད་མི་རླུང་འཕྲིན་ས་ཚིགས་འཚོལ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "དགའ་མཆོག་མེད།"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "འདི་ནང་བཅུག་ནིའི་དོན་ལུ་བལྟ་བའི་སྐབས་ས་ཚིགས་ལུ་སྐར་མ་རྟགས་བཀལ།"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "རླུང་འཕྲིན་འཚོལ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "སྐད་ཡིག་ཚང་མ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "སྐད་ཡིག་ལྟར་བཙག"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "རྒྱལ་ཁབ་ཆ་མཉམ།"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "རྒྱལ་ཁབ་ལུ་གཞི་བཞག་བཙག"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "རླུང་འཕྲིན་མེད"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ཐོན་བཞིན་པ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "རླུང་འཕྲིན %d ནང་ལས %u"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "རླུང་འཕྲིན: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "རླུང་འཕྲིན་ཐོན་བཞིན་པ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "གྲུབ་འབྲས་མེད"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "སྒུག་རོགས…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "འཚོལ་བའི་རླུང་འཕྲིན་མ་རྙེད"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "རླུང་འཕྲིན་ཐོན་མ་ཚུགས"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ས་ཚིགས།"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "རྒྱལ་ཁབ།"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ཁ་བྱང་།"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ཝེབ་སའིཊ།"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ཀོ་ཌེཀ།"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "བིཊ་ཚད།"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "རྒྱུན་བཏང་URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "གཏོང་མིན་འདུག"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "རླུང་འཕྲིན་གཅིག་གདམ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ཤུགས་ཁམས་འཛིན་བཞིན་པ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ད་ལྟ་གཏོང་བཞིན་པ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "བཀག་ཡོད"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "བསྐྱར་འབྲེལ་བཞིན་པ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube འཚོལ་བཞིན་པ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "འཚོལ་མ་ཐུབ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube གྲུབ་འབྲས་མ་རྙེད"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "གྲུབ་འབྲས་ཚང་མ་མེད"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ཕབ་ལེན་བཞིན་པ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "མེད་པ་བཟོས"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ཕབ་ལེན་མ་ཐུབ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "བཞག་ཡོད: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "གླུ་ཕབ་ལེན"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ཕབ་ལེན་མེད་པ་བཟོ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ད་ལྟོ་གཞས་མིན་འདུག"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "རླུང་འཕྲིན་ས་ཚིགས་ཉན་པའི་སྐབས་གཞས་ཚུ་འདི་ནང་སྟོན་འོང"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ད་ལྟོ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "སྐར་མ་ %d ཧེ་མ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "ཆུ་ཚོད་ %d ཧེ་མ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/el.po
+++ b/po/el.po
@@ -3,315 +3,314 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Το Receiver συνεχίζει να αναπαράγει ραδιόφωνο μετά το κλείσιμο του παραθύρου"
+msgstr ""
+"Το Receiver συνεχίζει να αναπαράγει ραδιόφωνο μετά το κλείσιμο του παραθύρου"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Μενού"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Ιστορικό τραγουδιών"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Συνέχιση αναπαραγωγής στο παρασκήνιο"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Σχετικά με το Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Περιήγηση"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Αγαπημένα"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Πληροφορίες σταθμού"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Φορτώθηκαν %d σταθμοί"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Σφάλμα: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Σφάλμα αναπαραγωγής: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Αναπαράγεται τώρα: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Συνεχίζεται: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Ακύρωση εξουσιοδότησης Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Αποσύνδεση από Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Σύνδεση στο Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Η εξουσιοδότηση Last.fm ακυρώθηκε"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Αποσυνδέθηκε από το Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Σύνδεση στο Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Αποτυχία σύνδεσης στο Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Παραχωρήστε πρόσβαση στον περιηγητή σας…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Η εξουσιοδότηση Last.fm έληξε"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Συνδέθηκε στο Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Ανακαλύψτε πάνω από 30.000 επαληθευμένους ραδιοφωνικούς σταθμούς από όλο τον "
 "κόσμο"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Χωρίς αγαπημένα"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Σημειώστε σταθμούς με αστέρι κατά την περιήγηση για να τους προσθέσετε εδώ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Αναζήτηση σταθμών…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Όλες οι γλώσσες"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Φιλτράρισμα κατά γλώσσα"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Όλες οι χώρες"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Φίλτρο ανά χώρα"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Δεν βρέθηκαν σταθμοί"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Φόρτωση…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u από %d σταθμούς"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Σταθμοί: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Φόρτωση σταθμών"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Κανένα αποτέλεσμα"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Παρακαλώ περιμένετε…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Κανένας σταθμός δεν ταιριάζει με την αναζήτησή σας"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Δεν ήταν δυνατή η φόρτωση σταθμών"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Σταθμός"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Χώρα"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Ετικέτες"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Ιστοσελίδα"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Κωδικοποιητής"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Ρυθμός bit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ροής"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Δεν αναπαράγεται"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Επιλέξτε σταθμό"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Προσωρινή αποθήκευση…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Αναπαράγεται τώρα"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Σε παύση"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Επανασύνδεση…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Αναζήτηση στο YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Η αναζήτηση απέτυχε: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Δεν βρέθηκαν αποτελέσματα YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Όλα τα αποτελέσματα μη διαθέσιμα"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Λήψη: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Ακυρώθηκε"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Η λήψη απέτυχε: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Αποθηκεύτηκε: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Λήψη τραγουδιού"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Ακύρωση λήψης"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Κανένα τραγούδι ακόμα"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Τα τραγούδια θα εμφανιστούν εδώ καθώς ακούτε ραδιοφωνικούς σταθμούς"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Μόλις τώρα"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d λεπτό πριν"
 msgstr[1] "%d λεπτά πριν"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ώρα πριν"
 msgstr[1] "%d ώρες πριν"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/el.po
+++ b/po/el.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: el\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Το Receiver συνεχίζει να αναπαράγει ραδιόφωνο μετά το κλείσιμο του παραθύρου"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Μενού"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Ιστορικό τραγουδιών"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Συνέχιση αναπαραγωγής στο παρασκήνιο"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Σχετικά με το Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Περιήγηση"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Αγαπημένα"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Πληροφορίες σταθμού"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Φορτώθηκαν %d σταθμοί"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Σφάλμα: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Σφάλμα αναπαραγωγής: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Αναπαράγεται τώρα: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Συνεχίζεται: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Ακύρωση εξουσιοδότησης Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Αποσύνδεση από Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Σύνδεση στο Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Η εξουσιοδότηση Last.fm ακυρώθηκε"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Αποσυνδέθηκε από το Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Σύνδεση στο Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Αποτυχία σύνδεσης στο Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Παραχωρήστε πρόσβαση στον περιηγητή σας…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Η εξουσιοδότηση Last.fm έληξε"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Συνδέθηκε στο Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Ανακαλύψτε πάνω από 30.000 επαληθευμένους ραδιοφωνικούς σταθμούς από όλο τον "
@@ -116,64 +124,65 @@ msgstr "Χωρίς αγαπημένα"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Σημειώστε σταθμούς με αστέρι κατά την περιήγηση για να τους προσθέσετε εδώ"
+msgstr ""
+"Σημειώστε σταθμούς με αστέρι κατά την περιήγηση για να τους προσθέσετε εδώ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Αναζήτηση σταθμών…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Όλες οι γλώσσες"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Φιλτράρισμα κατά γλώσσα"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Όλες οι χώρες"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Φίλτρο ανά χώρα"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Δεν βρέθηκαν σταθμοί"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Φόρτωση…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u από %d σταθμούς"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Σταθμοί: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Φόρτωση σταθμών"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Κανένα αποτέλεσμα"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Παρακαλώ περιμένετε…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Κανένας σταθμός δεν ταιριάζει με την αναζήτησή σας"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Δεν ήταν δυνατή η φόρτωση σταθμών"
 
@@ -206,25 +215,29 @@ msgid "Stream URL"
 msgstr "URL ροής"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Δεν αναπαράγεται"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Επιλέξτε σταθμό"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Προσωρινή αποθήκευση…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Αναπαράγεται τώρα"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Σε παύση"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Επανασύνδεση…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Αναπαράγεται τώρα"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/eo.po
+++ b/po/eo.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver daŭre ludas radion post kiam la fenestro estas fermita"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menuo"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Kanta historio"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Daŭrigi ludadon en la fono"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Pri Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Foliumi"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Preferatoj"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stacio-informo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stacioj ŝargitaj"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Eraro: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Reprodukteraro: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nun ludas: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Daŭrigas: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Nuligi Last.fm-aŭtorizadon"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Malkonektiĝi de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Konektiĝi al Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-aŭtorizado nuligita"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Malkonektita de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Konektiĝas al Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Malsukcesis konektiĝi al Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Donu aliron en via retumilo…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-aŭtorizado eltempiĝis"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Konektita al Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Malkovru pli ol 30 000 kontrolitajn radistaciojn el la tuta mondo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Stelu staciojn dum foliumado por aldoni ilin ĉi tien"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Serĉi staciojn…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Ĉiuj lingvoj"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtri laŭ lingvo"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Ĉiuj landoj"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtri laŭ lando"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Neniuj stacioj"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ŝargas…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u el %d stacioj"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacioj: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ŝargas staciojn"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Neniuj rezultoj"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Bonvolu atendi…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Neniuj stacioj kongruas kun via serĉo"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Ne eblis ŝargi staciojn"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Fluo-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne ludas"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Elektu stacion"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufrado…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nun ludas"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Paŭzigita"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Rekonektas…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nun ludas"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/eo.po
+++ b/po/eo.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver daŭre ludas radion post kiam la fenestro estas fermita"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menuo"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Kanta historio"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Daŭrigi ludadon en la fono"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Pri Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Foliumi"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Preferatoj"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stacio-informo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stacioj ŝargitaj"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Eraro: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Reprodukteraro: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nun ludas: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Daŭrigas: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Nuligi Last.fm-aŭtorizadon"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Malkonektiĝi de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Konektiĝi al Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-aŭtorizado nuligita"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Malkonektita de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Konektiĝas al Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Malsukcesis konektiĝi al Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Donu aliron en via retumilo…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-aŭtorizado eltempiĝis"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Konektita al Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Malkovru pli ol 30 000 kontrolitajn radistaciojn el la tuta mondo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Neniu preferato"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Stelu staciojn dum foliumado por aldoni ilin ĉi tien"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Serĉi staciojn…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Ĉiuj lingvoj"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtri laŭ lingvo"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Ĉiuj landoj"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtri laŭ lando"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Neniuj stacioj"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ŝargas…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u el %d stacioj"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacioj: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ŝargas staciojn"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Neniuj rezultoj"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Bonvolu atendi…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Neniuj stacioj kongruas kun via serĉo"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Ne eblis ŝargi staciojn"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stacio"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Lando"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etikedoj"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Retejo"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeko"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrapido"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Fluo-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne ludas"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Elektu stacion"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufrado…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nun ludas"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Paŭzigita"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Rekonektas…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Serĉas en YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Serĉo malsukcesis: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Neniuj YouTube-rezultoj trovitaj"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Ĉiuj rezultoj nedisponeblaj"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Elŝutas: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Nuligita"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Elŝuto malsukcesis: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Konservita: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Elŝuti kanton"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Nuligi elŝuton"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ankoraŭ neniuj kantoj"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Kantoj aperos ĉi tie dum vi aŭskultas radiostaciojn"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ĵus nun"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "antaŭ %d minuto"
 msgstr[1] "antaŭ %d minutoj"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "antaŭ %d horo"
 msgstr[1] "antaŭ %d horoj"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/es.po
+++ b/po/es.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver sigue reproduciendo la radio después de cerrar la ventana"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historial de canciones"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Seguir reproduciendo en segundo plano"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Acerca de Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Información de la emisora"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d emisoras cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducción: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproduciendo: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reanudando: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorización de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conectar a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorización de Last.fm cancelada"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Conectando a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "No se pudo conectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Conceda acceso en su navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "La autorización de Last.fm ha expirado"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conectado a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Descubre más de 30.000 estaciones de radio verificadas de todo el mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sin favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca emisoras mientras exploras para añadirlas aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Buscar emisoras…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Todos los idiomas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar por idioma"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Todos los países"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Sin emisoras"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d emisoras"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Emisoras: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargando emisoras"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sin resultados"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Espere por favor…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ninguna emisora coincide con su búsqueda"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "No se pudieron cargar las emisoras"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Emisora"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sitio web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Códec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Tasa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del flujo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Sin reproducir"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selecciona una emisora"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Almacenando en búfer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Reproduciendo"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconectando…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Buscando en YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Búsqueda fallida: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "No se encontraron resultados en YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Todos los resultados no están disponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Descargando: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Descarga fallida: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Guardado: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Descargar canción"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancelar descarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Aún no hay canciones"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Las canciones aparecerán aquí mientras escuches estaciones de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ahora mismo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "hace %d min"
 msgstr[1] "hace %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "hace %d hora"
 msgstr[1] "hace %d horas"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/es.po
+++ b/po/es.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver sigue reproduciendo la radio después de cerrar la ventana"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historial de canciones"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Seguir reproduciendo en segundo plano"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Acerca de Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Información de la emisora"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d emisoras cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproducción: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproduciendo: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reanudando: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorización de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conectar a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorización de Last.fm cancelada"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Conectando a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "No se pudo conectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Conceda acceso en su navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "La autorización de Last.fm ha expirado"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conectado a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Descubre más de 30.000 estaciones de radio verificadas de todo el mundo"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca emisoras mientras exploras para añadirlas aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Buscar emisoras…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Todos los idiomas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar por idioma"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Todos los países"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Sin emisoras"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d emisoras"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Emisoras: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargando emisoras"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sin resultados"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Espere por favor…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ninguna emisora coincide con su búsqueda"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "No se pudieron cargar las emisoras"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL del flujo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Sin reproducir"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selecciona una emisora"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Almacenando en búfer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Reproduciendo"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconectando…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Reproduciendo"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/et.po
+++ b/po/et.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver jätkab raadio esitamist pärast akna sulgemist"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menüü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Lugude ajalugu"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Jätka esitamist taustal"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Teave Receiveri kohta"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Sirvi"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Lemmikud"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Jaama teave"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d jaama laaditud"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Viga: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Taasesituse viga: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Praegu mängib: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Jätkamine: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Tühista Last.fm autoriseeriminen"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Katkesta ühendus Last.fm-iga"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Ühenda Last.fm-iga"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autoriseeriminen tühistatud"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-iga ühendus katkestatud"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Ühendamine Last.fm-iga…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-iga ühendamine ebaõnnestus"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Andke juurdepääs oma brauseris…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autoriseerimise aeg on läbi"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ühendatud Last.fm-iga"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Avasta üle 30 000 kontrollitud raadiojaama üle maailma"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Lemmikuid pole"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Märgi jaamad sirvimisel tähega, et lisada need siia"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Otsi jaamu…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Kõik keeled"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtreeri keele järgi"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Kõik riigid"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtreeri riigi järgi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Jaamu pole"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laadimine…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d jaama"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Jaamad: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Jaamade laadimine"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Tulemusi pole"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Palun oodake…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ükski jaam ei vasta teie otsingule"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Jaamu ei õnnestunud laadida"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Jaam"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Riik"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Sildid"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Veebileht"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Koodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitikiirus"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Voo URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ei mängi"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Valige jaam"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Puhverdamine…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Praegu mängib"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Peatatud"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Taasühendamine…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Otsin YouTube'ist…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Otsing ebaõnnestus: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube'i tulemusi ei leitud"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Kõik tulemused pole saadaval"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Allalaadimine: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Tühistatud"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Allalaadimine ebaõnnestus: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvestatud: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Laadi laul alla"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Tühista allalaadimine"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Lugusid pole veel"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Lood ilmuvad siia, kui kuulad raadiojaamu"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Praegu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min tagasi"
 msgstr[1] "%d min tagasi"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d tund tagasi"
 msgstr[1] "%d tundi tagasi"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/et.po
+++ b/po/et.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver jätkab raadio esitamist pärast akna sulgemist"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menüü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Lugude ajalugu"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Jätka esitamist taustal"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Teave Receiveri kohta"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Sirvi"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Lemmikud"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Jaama teave"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d jaama laaditud"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Viga: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Taasesituse viga: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Praegu mängib: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Jätkamine: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Tühista Last.fm autoriseeriminen"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Katkesta ühendus Last.fm-iga"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Ühenda Last.fm-iga"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autoriseeriminen tühistatud"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-iga ühendus katkestatud"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Ühendamine Last.fm-iga…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-iga ühendamine ebaõnnestus"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Andke juurdepääs oma brauseris…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autoriseerimise aeg on läbi"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ühendatud Last.fm-iga"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Avasta üle 30 000 kontrollitud raadiojaama üle maailma"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Märgi jaamad sirvimisel tähega, et lisada need siia"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Otsi jaamu…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Kõik keeled"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtreeri keele järgi"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Kõik riigid"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtreeri riigi järgi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Jaamu pole"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laadimine…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d jaama"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Jaamad: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Jaamade laadimine"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Tulemusi pole"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Palun oodake…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ükski jaam ei vasta teie otsingule"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Jaamu ei õnnestunud laadida"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Voo URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ei mängi"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Valige jaam"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Puhverdamine…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Praegu mängib"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Peatatud"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Taasühendamine…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Praegu mängib"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/eu.po
+++ b/po/eu.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver-ek irratia erreproduzitzen jarraitzen du leihoa itxi ondoren"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menua"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Abestien historia"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Jarraitu erreproduzitzen atzeko planoan"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver-i buruz"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Gogokoak"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Irratia-informazioa"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d irrati kargatu dira"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Errorea: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erreprodukzio-errorea: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Orain jotzen: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Berrekiten: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Utzi Last.fm-ren baimena"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Deskonektatu Last.fm-etik"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Konektatu Last.fm-era"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-ren baimena bertan behera utzi da"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-etik deskonektatuta"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-era konektatzen…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ezin izan da Last.fm-era konektatu"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Eman sarbidea zure nabigatzailean…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-ren baimenaren denbora agortu da"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-era konektatuta"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Aurkitu mundu osoko 30.000 irrati-kate egiaztatutik gora"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Gogokorik ez"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Izartu irratiak arakatzen duzunean hemen gehitzeko"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Bilatu irratiak…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Hizkuntza guztiak"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Iragazi hizkuntzaren arabera"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Herrialde guztiak"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Iragazi herrialdez"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ez dago irratirik"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Kargatzen…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d irrati"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Irratiak: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Irratiak kargatzen"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Emaitzarik ez"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Itxaron mesedez…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ez dago zure bilaketarekin bat datorren irratirik"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Ezin izan dira irratiak kargatu"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Irratia"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Herrialdea"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiketak"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webgunea"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeka"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bit-emaria"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Jario URLa"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ez du jotzen"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Hautatu irrati bat"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufferean gordetzen…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Orain jotzen"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Geldituta"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Berriro konektatzen…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTuben bilatzen…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Bilaketak huts egin du: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ez da YouTube emaitzarik aurkitu"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Emaitza guztiak ez daude eskuragarri"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Deskargatzen: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Bertan behera utzi da"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Deskargak huts egin du: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Gordeta: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Deskargatu abestia"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Utzi deskarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ez dago abestirik oraindik"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Abestiak hemen agertuko dira irrati-kateak entzuten dituzunean"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Oraintxe"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "orain dela %d min"
 msgstr[1] "orain dela %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "orain dela %d ordu"
 msgstr[1] "orain dela %d ordu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/eu.po
+++ b/po/eu.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: eu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver-ek irratia erreproduzitzen jarraitzen du leihoa itxi ondoren"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menua"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Abestien historia"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Jarraitu erreproduzitzen atzeko planoan"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver-i buruz"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Arakatu"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Gogokoak"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Irratia-informazioa"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d irrati kargatu dira"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Errorea: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erreprodukzio-errorea: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Orain jotzen: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Berrekiten: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Utzi Last.fm-ren baimena"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Deskonektatu Last.fm-etik"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Konektatu Last.fm-era"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-ren baimena bertan behera utzi da"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-etik deskonektatuta"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-era konektatzen…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ezin izan da Last.fm-era konektatu"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Eman sarbidea zure nabigatzailean…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-ren baimenaren denbora agortu da"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-era konektatuta"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Aurkitu mundu osoko 30.000 irrati-kate egiaztatutik gora"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Izartu irratiak arakatzen duzunean hemen gehitzeko"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Bilatu irratiak…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Hizkuntza guztiak"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Iragazi hizkuntzaren arabera"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Herrialde guztiak"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Iragazi herrialdez"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ez dago irratirik"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Kargatzen…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d irrati"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Irratiak: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Irratiak kargatzen"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Emaitzarik ez"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Itxaron mesedez…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ez dago zure bilaketarekin bat datorren irratirik"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Ezin izan dira irratiak kargatu"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Jario URLa"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ez du jotzen"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Hautatu irrati bat"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufferean gordetzen…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Orain jotzen"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Geldituta"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Berriro konektatzen…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Orain jotzen"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fa.po
+++ b/po/fa.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver پس از بسته‌شدن پنجره به پخش رادیو ادامه می‌دهد"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "منو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "تاریخچهٔ آهنگ‌ها"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ادامهٔ پخش در پس‌زمینه"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "دربارهٔ Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "مرور"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "علاقه‌مندی‌ها"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "اطلاعات ایستگاه"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ایستگاه بارگذاری شد"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "خطا: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "خطای پخش: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "در حال پخش: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ادامه: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "لغو مجوز Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "قطع اتصال از Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "اتصال به Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "مجوز Last.fm لغو شد"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "اتصال از Last.fm قطع شد"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "در حال اتصال به Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "اتصال به Last.fm ناموفق بود"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "در مرورگرتان دسترسی بدهید…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "مهلت مجوز Last.fm به پایان رسید"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "به Last.fm متصل شد"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "بیش از ۳۰٬۰۰۰ ایستگاه رادیویی تأییدشده از سراسر جهان را کشف کنید"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "بدون علاقه‌مندی"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "هنگام مرور، ایستگاه‌ها را ستاره‌دار کنید تا اینجا اضافه شوند"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "جستجوی ایستگاه‌ها…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "همه زبان‌ها"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "فیلتر بر اساس زبان"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "همه کشورها"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "فیلتر بر اساس کشور"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ایستگاهی وجود ندارد"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "در حال بارگذاری…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u از %d ایستگاه"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ایستگاه‌ها: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "در حال بارگذاری ایستگاه‌ها"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "نتیجه‌ای یافت نشد"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "لطفاً صبر کنید…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "هیچ ایستگاهی با جستجوی شما مطابقت ندارد"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "بارگذاری ایستگاه‌ها ممکن نشد"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ایستگاه"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "کشور"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "برچسب‌ها"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "وب‌سایت"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کدک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "نرخ بیت"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "نشانی پخش"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "در حال پخش نیست"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "یک ایستگاه انتخاب کنید"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "در حال بافر…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "در حال پخش"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "متوقف"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "اتصال مجدد…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "جستجو در YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "جستجو ناموفق بود: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "نتیجه‌ای در YouTube یافت نشد"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "همه نتایج در دسترس نیستند"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "در حال دانلود: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "لغو شد"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "دانلود ناموفق بود: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ذخیره شد: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "دانلود آهنگ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "لغو دانلود"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "هنوز آهنگی نیست"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "هنگام گوش دادن به ایستگاه‌های رادیویی، آهنگ‌ها اینجا نمایش داده می‌شوند"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "همین الان"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d دقیقه پیش"
 msgstr[1] "%d دقیقه پیش"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ساعت پیش"
 msgstr[1] "%d ساعت پیش"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fa.po
+++ b/po/fa.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver پس از بسته‌شدن پنجره به پخش رادیو ادامه می‌دهد"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "منو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "تاریخچهٔ آهنگ‌ها"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ادامهٔ پخش در پس‌زمینه"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "دربارهٔ Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "مرور"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "علاقه‌مندی‌ها"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "اطلاعات ایستگاه"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ایستگاه بارگذاری شد"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "خطا: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "خطای پخش: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "در حال پخش: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ادامه: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "لغو مجوز Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "قطع اتصال از Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "اتصال به Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "مجوز Last.fm لغو شد"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "اتصال از Last.fm قطع شد"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "در حال اتصال به Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "اتصال به Last.fm ناموفق بود"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "در مرورگرتان دسترسی بدهید…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "مهلت مجوز Last.fm به پایان رسید"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "به Last.fm متصل شد"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "بیش از ۳۰٬۰۰۰ ایستگاه رادیویی تأییدشده از سراسر جهان را کشف کنید"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "هنگام مرور، ایستگاه‌ها را ستاره‌دار کنید تا اینجا اضافه شوند"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "جستجوی ایستگاه‌ها…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "همه زبان‌ها"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "فیلتر بر اساس زبان"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "همه کشورها"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "فیلتر بر اساس کشور"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ایستگاهی وجود ندارد"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "در حال بارگذاری…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u از %d ایستگاه"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ایستگاه‌ها: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "در حال بارگذاری ایستگاه‌ها"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "نتیجه‌ای یافت نشد"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "لطفاً صبر کنید…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "هیچ ایستگاهی با جستجوی شما مطابقت ندارد"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "بارگذاری ایستگاه‌ها ممکن نشد"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "نشانی پخش"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "در حال پخش نیست"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "یک ایستگاه انتخاب کنید"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "در حال بافر…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "در حال پخش"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "متوقف"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "اتصال مجدد…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "در حال پخش"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ff.po
+++ b/po/ff.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ff\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver ina jokka fijirde rajo ɓaawo nde henorde uddaa"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Dosol"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Daartol jimɗe"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Jokku fijde to ɓaawo"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Baɗte Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Yillo"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Cuɓaaɗi"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Humpito nokkuure"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Loowii jaaɓe %d"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Juumre: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Juumre nanngol: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ina nanga: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ina fuɗɗitoo: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Haɗu yamiroore Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Seŋ Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Jokkondiru e Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Yamiroore Last.fm haɗaama"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Ceŋaama e Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Jokkondirde e Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Horiima jokkondirde e Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Hokku keɓal e nder wanngorde maa…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Yamiroore Last.fm ɓuraama"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Jokkondiraama e Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Ɗiskov 30,000+ jaaɓnirɗe rajo ƴeewa e aduna oo fof"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Alaa cuɓaaɗi"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Hokku hoodere e nokkuuje nde njiya-ɗaa ngam ɓeydude ɗum ɗoo"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Yiylo jaaɓe…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Ɗemɗe Fof"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Seɗo e ɗemngal"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Leyɗeele fof"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Teetto e leydi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Alaa Jaaɓe"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ina loowa…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u e nder %d jaaɓe"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Jaaɓe: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ina Loowa Jaaɓe"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Alaa Njaltudi"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Tiiɗno muɲ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Alaa jaaɓe njahdaani e njiylu maa"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Horiima loowde jaaɓe"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Nokkuure"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Leydi"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Maande"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Lowre enternet"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitreyt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL maajango"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nanngaaka"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Suɓo jaaɓorgal"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ina loowa…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Ina nanga jooni"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Dartaama"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ina jokkitoo…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ina yiyloo YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Njiylu faaɗii: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Alaa njaltudi YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Njaltudi fof ngalaa"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ina aawta: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Haɗaama"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Aawtagol faaɗii: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Mooftaama: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Aawto jimol"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Haɗ aawtagol"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Alaa jimɗe tawaaɗe"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Jimɗe ngaran ɗoo so aɗa heɗii jaaɓnirɗe rajo"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Jooni"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d hojom battane"
 msgstr[1] "%d hojomaaji battane"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d waktu battane"
 msgstr[1] "%d waktuuji battane"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ff.po
+++ b/po/ff.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ff\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver ina jokka fijirde rajo ɓaawo nde henorde uddaa"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Dosol"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Daartol jimɗe"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Jokku fijde to ɓaawo"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Baɗte Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Yillo"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Cuɓaaɗi"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Humpito nokkuure"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Loowii jaaɓe %d"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Juumre: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Juumre nanngol: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ina nanga: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ina fuɗɗitoo: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Haɗu yamiroore Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Seŋ Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Jokkondiru e Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Yamiroore Last.fm haɗaama"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Ceŋaama e Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Jokkondirde e Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Horiima jokkondirde e Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Hokku keɓal e nder wanngorde maa…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Yamiroore Last.fm ɓuraama"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Jokkondiraama e Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Ɗiskov 30,000+ jaaɓnirɗe rajo ƴeewa e aduna oo fof"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Hokku hoodere e nokkuuje nde njiya-ɗaa ngam ɓeydude ɗum ɗoo"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Yiylo jaaɓe…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Ɗemɗe Fof"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Seɗo e ɗemngal"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Leyɗeele fof"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Teetto e leydi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Alaa Jaaɓe"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ina loowa…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u e nder %d jaaɓe"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Jaaɓe: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ina Loowa Jaaɓe"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Alaa Njaltudi"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Tiiɗno muɲ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Alaa jaaɓe njahdaani e njiylu maa"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Horiima loowde jaaɓe"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL maajango"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nanngaaka"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Suɓo jaaɓorgal"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ina loowa…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Ina nanga jooni"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Dartaama"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ina jokkitoo…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Ina nanga jooni"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fi.po
+++ b/po/fi.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver jatkaa radion toistoa, kun ikkuna suljetaan"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Valikko"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Kappalehistoria"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Jatka toistoa taustalla"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Tietoja – Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Suosikit"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Aseman tiedot"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d asemaa ladattu"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Virhe: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Toistovirhe: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nyt soi: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Jatketaan: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Peru Last.fm-valtuutus"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Katkaise yhteys Last.fm-palveluun"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Yhdistä Last.fm-palveluun"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-valtuutus peruutettu"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Yhteys Last.fm-palveluun katkaistu"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Yhdistetään Last.fm-palveluun…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Yhteyden muodostaminen Last.fm-palveluun epäonnistui"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Myönnä käyttöoikeus selaimessasi…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-valtuutus aikakatkaistiin"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Yhdistetty Last.fm-palveluun"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Löydä yli 30 000 vahvistettua radioasemaa ympäri maailmaa"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Lisää asemia suosikkeihin tähdellä selaamisen aikana"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Etsi asemia…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Kaikki kielet"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Suodata kielen mukaan"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Kaikki maat"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Suodata maan mukaan"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ei asemia"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ladataan…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d asemaa"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Asemat: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ladataan asemia"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ei tuloksia"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Odota hetki…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Yksikään asema ei vastaa hakuasi"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Asemia ei voitu ladata"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Virran URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ei toista"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Valitse asema"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Puskuroidaan…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nyt soi"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Tauolla"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Yhdistetään uudelleen…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nyt soi"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fi.po
+++ b/po/fi.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver jatkaa radion toistoa, kun ikkuna suljetaan"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Valikko"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Kappalehistoria"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Jatka toistoa taustalla"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Tietoja – Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Selaa"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Suosikit"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Aseman tiedot"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d asemaa ladattu"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Virhe: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Toistovirhe: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nyt soi: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Jatketaan: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Peru Last.fm-valtuutus"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Katkaise yhteys Last.fm-palveluun"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Yhdistä Last.fm-palveluun"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-valtuutus peruutettu"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Yhteys Last.fm-palveluun katkaistu"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Yhdistetään Last.fm-palveluun…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Yhteyden muodostaminen Last.fm-palveluun epäonnistui"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Myönnä käyttöoikeus selaimessasi…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-valtuutus aikakatkaistiin"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Yhdistetty Last.fm-palveluun"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Löydä yli 30 000 vahvistettua radioasemaa ympäri maailmaa"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ei suosikkeja"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Lisää asemia suosikkeihin tähdellä selaamisen aikana"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Etsi asemia…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Kaikki kielet"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Suodata kielen mukaan"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Kaikki maat"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Suodata maan mukaan"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ei asemia"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ladataan…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d asemaa"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Asemat: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ladataan asemia"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ei tuloksia"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Odota hetki…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Yksikään asema ei vastaa hakuasi"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Asemia ei voitu ladata"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Asema"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Maa"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tunnisteet"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Verkkosivu"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Pakkaustapa"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bittinopeus"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Virran URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ei toista"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Valitse asema"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Puskuroidaan…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nyt soi"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Tauolla"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Yhdistetään uudelleen…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Haetaan YouTubesta…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Haku epäonnistui: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube-tuloksia ei löytynyt"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Kaikki tulokset eivät ole saatavilla"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ladataan: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Peruutettu"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Lataus epäonnistui: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Tallennettu: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Lataa kappale"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Peruuta lataus"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ei vielä kappaleita"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Kappaleet näkyvät täällä kuunnellessasi radioasemia"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Juuri nyt"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min sitten"
 msgstr[1] "%d min sitten"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d tunti sitten"
 msgstr[1] "%d tuntia sitten"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fil.po
+++ b/po/fil.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fil\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Patuloy na nagpe-play ng radyo ang Receiver matapos isara ang window"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Kasaysayan ng Kanta"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Magpatuloy sa pag-play sa background"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Tungkol sa Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Mag-browse"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Mga Paborito"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Impormasyon ng Istasyon"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Na-load ang %d na istasyon"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error sa pag-play: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Pinapatugtog ngayon: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ipinagpapatuloy: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Kanselahin ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Idiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kumonekta sa Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Nakansela ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Nadiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Kumokonekta sa Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Hindi nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Magbigay ng access sa iyong browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Nag-expire ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Tumuklas ng 30,000+ na na-verify na istasyon ng radyo mula sa buong mundo"
@@ -115,64 +123,65 @@ msgstr "Walang paborito"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Lagyan ng bituin ang mga istasyon habang nagba-browse para idagdag dito"
+msgstr ""
+"Lagyan ng bituin ang mga istasyon habang nagba-browse para idagdag dito"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Maghanap ng mga istasyon…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Lahat ng wika"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "I-filter ayon sa wika"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Lahat ng bansa"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "I-filter ayon sa bansa"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Walang istasyon"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Naglo-load…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u sa %d na istasyon"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Mga istasyon: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Naglo-load ng mga istasyon"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Walang resulta"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Maghintay po…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Walang istasyong tumutugma sa iyong hinanap"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Hindi ma-load ang mga istasyon"
 
@@ -205,25 +214,29 @@ msgid "Stream URL"
 msgstr "Stream URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Hindi pinapatugtog"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Pumili ng istasyon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Nagba-buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Pinapatugtog ngayon"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Naka-pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Muling kumokonekta…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Pinapatugtog ngayon"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fil.po
+++ b/po/fil.po
@@ -3,315 +3,313 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fil\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Patuloy na nagpe-play ng radyo ang Receiver matapos isara ang window"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Kasaysayan ng Kanta"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Magpatuloy sa pag-play sa background"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Tungkol sa Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Mag-browse"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Mga Paborito"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Impormasyon ng Istasyon"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Na-load ang %d na istasyon"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error sa pag-play: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Pinapatugtog ngayon: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ipinagpapatuloy: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Kanselahin ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Idiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kumonekta sa Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Nakansela ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Nadiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Kumokonekta sa Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Hindi nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Magbigay ng access sa iyong browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Nag-expire ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Tumuklas ng 30,000+ na na-verify na istasyon ng radyo mula sa buong mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Walang paborito"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Lagyan ng bituin ang mga istasyon habang nagba-browse para idagdag dito"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Maghanap ng mga istasyon…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Lahat ng wika"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "I-filter ayon sa wika"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Lahat ng bansa"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "I-filter ayon sa bansa"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Walang istasyon"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Naglo-load…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u sa %d na istasyon"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Mga istasyon: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Naglo-load ng mga istasyon"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Walang resulta"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Maghintay po…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Walang istasyong tumutugma sa iyong hinanap"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Hindi ma-load ang mga istasyon"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Istasyon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Bansa"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Mga tag"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Website"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Hindi pinapatugtog"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Pumili ng istasyon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Nagba-buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Pinapatugtog ngayon"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Naka-pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Muling kumokonekta…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Naghahanap sa YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Nabigo ang paghahanap: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Walang nahanap na resulta sa YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Lahat ng resulta ay hindi available"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Dina-download: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Nakansela"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Nabigo ang download: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Na-save: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "I-download ang kanta"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Kanselahin ang download"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Wala pang mga kanta"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Lalabas dito ang mga kanta habang nakikinig ka ng mga istasyon ng radyo"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ngayon lang"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min ang nakalipas"
 msgstr[1] "%d min ang nakalipas"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d oras ang nakalipas"
 msgstr[1] "%d oras ang nakalipas"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fo.po
+++ b/po/fo.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver heldur fram at spæla útvarp eftir at vindeygað er afturlatið"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Valmynd"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Søgusøga"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Halt fram at spæla í bakgrundini"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Um Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Kaga"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Yndisligar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Støðupplýsingar"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d støð innlisin"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Villa: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Avspælingarvilla: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spælir nú: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Heldur áfram: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Avlýs Last.fm-góðkenning"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Slít sambandið við Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Bind til Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-góðkenning avlýst"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Sambandið við Last.fm slitið"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Bindur til Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ikki bar at binda til Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Gev atgongd í kaganum…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-góðkenning er útrunnin"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Bundin til Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Finn fleiri enn 30.000 váttaðar ljóðvarpssstøðir úr øllum heiminum"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Stjernu støðir meðan tú kagar fyri at leggja tær afturat her"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Leita eftir støðum…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Øll mál"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrera eftir máli"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Øll lond"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrera eftir landi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ongar støðir"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Innlesur…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d støðum"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Støðir: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Innlesur støðir"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Eingi úrslit"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vinarliga bíða…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ongar støðir samsvara leitini"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Fekk ikki innlisið støðir"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Streym-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Spælir ikki"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Vel eina støð"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Mellumgoymir…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Spælir nú"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Steðgað"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Endurtengjast…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Spælir nú"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fo.po
+++ b/po/fo.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver heldur fram at spæla útvarp eftir at vindeygað er afturlatið"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Valmynd"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Søgusøga"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Halt fram at spæla í bakgrundini"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Um Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Kaga"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Yndisligar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Støðupplýsingar"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d støð innlisin"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Villa: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Avspælingarvilla: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spælir nú: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Heldur áfram: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Avlýs Last.fm-góðkenning"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Slít sambandið við Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Bind til Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-góðkenning avlýst"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Sambandið við Last.fm slitið"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Bindur til Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ikki bar at binda til Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Gev atgongd í kaganum…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-góðkenning er útrunnin"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Bundin til Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Finn fleiri enn 30.000 váttaðar ljóðvarpssstøðir úr øllum heiminum"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ongar yndisligar"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Stjernu støðir meðan tú kagar fyri at leggja tær afturat her"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Leita eftir støðum…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Øll mál"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrera eftir máli"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Øll lond"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrera eftir landi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ongar støðir"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Innlesur…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d støðum"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Støðir: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Innlesur støðir"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Eingi úrslit"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vinarliga bíða…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ongar støðir samsvara leitini"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Fekk ikki innlisið støðir"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Støð"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Merki"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Heimasíða"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitferð"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Streym-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Spælir ikki"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Vel eina støð"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Mellumgoymir…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Spælir nú"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Steðgað"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Endurtengjast…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Leitar á YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Leiting miseydnaðist: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Eingi YouTube-úrslit fundin"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Øll úrslit ótøk"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Tekur niður: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Avlýst"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Niðurtøka miseydnaðist: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Goymt: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Tak niður sang"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Avlýs niðurtøku"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Eingin songur enn"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Songir koma fram her, meðan tú lurtar á ljóðvarpsstøðir"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Júst nú"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min síðan"
 msgstr[1] "%d min síðan"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d tími síðan"
 msgstr[1] "%d tímar síðan"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,314 +3,313 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver continue de diffuser la radio après la fermeture de la fenêtre"
+msgstr ""
+"Receiver continue de diffuser la radio après la fermeture de la fenêtre"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historique des chansons"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continuer la lecture en arrière-plan"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "À propos de Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoris"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Infos de la station"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stations chargées"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erreur : %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erreur de lecture : %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "En cours de lecture : %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprise : %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Annuler l'autorisation Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Se déconnecter de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Se connecter à Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorisation Last.fm annulée"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Déconnecté de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connexion à Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Échec de la connexion à Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Accordez l'accès dans votre navigateur…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "L'autorisation Last.fm a expiré"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connecté à Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Découvrez plus de 30 000 stations de radio vérifiées du monde entier"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Aucun favori"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Ajoutez des stations en favoris pendant la navigation pour les retrouver ici"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Rechercher des stations…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Toutes les langues"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrer par langue"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tous les pays"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrer par pays"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Aucune station"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Chargement…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u sur %d stations"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stations : %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Chargement des stations"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Aucun résultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Veuillez patienter…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Aucune station ne correspond à votre recherche"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Impossible de charger les stations"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Station"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Pays"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Étiquettes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Site web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Débit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL du flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Lecture arrêtée"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Sélectionnez une station"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Mise en mémoire tampon…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "En cours de lecture"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconnexion…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Recherche sur YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "La recherche a échoué : %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Aucun résultat YouTube trouvé"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tous les résultats sont indisponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Téléchargement : %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Annulé"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Échec du téléchargement : %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Enregistré : %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Télécharger la chanson"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Annuler le téléchargement"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Aucune chanson pour le moment"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Les chansons apparaîtront ici pendant que vous écoutez des stations de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "À l'instant"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "il y a %d min"
 msgstr[1] "il y a %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "il y a %d heure"
 msgstr[1] "il y a %d heures"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fr.po
+++ b/po/fr.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continue de diffuser la radio après la fermeture de la fenêtre"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historique des chansons"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continuer la lecture en arrière-plan"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "À propos de Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Parcourir"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoris"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Infos de la station"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stations chargées"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erreur : %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erreur de lecture : %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "En cours de lecture : %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprise : %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Annuler l'autorisation Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Se déconnecter de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Se connecter à Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorisation Last.fm annulée"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Déconnecté de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connexion à Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Échec de la connexion à Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Accordez l'accès dans votre navigateur…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "L'autorisation Last.fm a expiré"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connecté à Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Découvrez plus de 30 000 stations de radio vérifiées du monde entier"
 
@@ -114,64 +122,65 @@ msgstr "Aucun favori"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Ajoutez des stations en favoris pendant la navigation pour les retrouver ici"
+msgstr ""
+"Ajoutez des stations en favoris pendant la navigation pour les retrouver ici"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Rechercher des stations…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Toutes les langues"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrer par langue"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tous les pays"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrer par pays"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Aucune station"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Chargement…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u sur %d stations"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stations : %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Chargement des stations"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Aucun résultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Veuillez patienter…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Aucune station ne correspond à votre recherche"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Impossible de charger les stations"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL du flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Lecture arrêtée"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Sélectionnez une station"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Mise en mémoire tampon…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "En cours de lecture"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconnexion…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "En cours de lecture"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fur.po
+++ b/po/fur.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fur\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver al continue a riprodusi la radio dopo vê sierât il barcon"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menù"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Storic des cjançons"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continue a riprodusi in sotfont"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Informazions su Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Esplore"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Preferîts"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informazions de stazion"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stazions cjariadis"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erôr: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erôr di riproduzion: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "In riproduzion: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ripuartant: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anule la autorizazion di Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Disconetisi di Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conetisi a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizazion di Last.fm anulade"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Disconetût di Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Conession a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Impussibil conetisi a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dâ acès tal to navigadôr…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "La autorizazion di Last.fm e je scjadue"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conetût a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Scuvierç plui di 30.000 stazions radio verificadis di dut il mont"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nissun preferît"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Segnale stazions cu la stele intant che tu esploris par zontâlis culì"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cîr stazions…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Dutis lis lenghis"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtre par lenghe"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Ducj i paîs"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtre par paîs"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nissune stazion"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cjariant…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u di %d stazions"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stazions: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cjariant lis stazions"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nissun risultât"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Par plasê spiete…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nissune stazion e corispuint ae tô ricercje"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "No si è podût cjariâ lis stazions"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stazion"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Paîs"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etichetes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sît web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL dal flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "No in riproduzion"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selezione une stazion"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Daûr a memorizâ tal buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "In riproduzion"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "In pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Riconetant…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Cirînt su YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Ricercje falide: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nissun risultât YouTube cjatât"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Ducj i risultâts no disponibii"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Discjamant: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Anulât"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Discjamament falît: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvât: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Discjame la cjanson"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anule il discjamament"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ancjemò nissune cjanzon"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Lis cjançons a compararan chi intant che tu scoltis stazions radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Juste cumò"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min fa"
 msgstr[1] "%d min fa"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ore fa"
 msgstr[1] "%d oris fa"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fur.po
+++ b/po/fur.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fur\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver al continue a riprodusi la radio dopo vê sierât il barcon"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menù"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Storic des cjançons"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continue a riprodusi in sotfont"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Informazions su Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Esplore"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Preferîts"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informazions de stazion"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stazions cjariadis"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erôr: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erôr di riproduzion: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "In riproduzion: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ripuartant: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anule la autorizazion di Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Disconetisi di Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conetisi a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizazion di Last.fm anulade"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Disconetût di Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Conession a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Impussibil conetisi a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dâ acès tal to navigadôr…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "La autorizazion di Last.fm e je scjadue"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conetût a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Scuvierç plui di 30.000 stazions radio verificadis di dut il mont"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Segnale stazions cu la stele intant che tu esploris par zontâlis culì"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cîr stazions…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Dutis lis lenghis"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtre par lenghe"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Ducj i paîs"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtre par paîs"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nissune stazion"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cjariant…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u di %d stazions"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stazions: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cjariant lis stazions"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nissun risultât"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Par plasê spiete…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nissune stazion e corispuint ae tô ricercje"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "No si è podût cjariâ lis stazions"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL dal flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "No in riproduzion"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selezione une stazion"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Daûr a memorizâ tal buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "In riproduzion"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "In pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Riconetant…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "In riproduzion"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/fy.po
+++ b/po/fy.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: fy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver bliuwt radio ôfspyljen neidat it finster sletten is"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Lietsjeshistoarje"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Trochgean mei ôfspyljen op de eftergrûn"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Oer Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Blêdzje"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stjoerderynformaasje"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stjoerders laden"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Flater: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ôfspylflater: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "No oan it spyljen: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Fierder gean: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-machtiging annulearje"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Ferbining mei Last.fm ferbrekke"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Ferbine mei Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-machtiging annulearre"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Ferbining mei Last.fm ferbrutsen"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Ferbine mei Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Koe gjin ferbining meitsje mei Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Jou tagong yn jo browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-machtiging ferrûn"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ferbûn mei Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Untdek mear as 30.000 ferifiearre radiostasjes fan oer de hiele wrâld"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Gjin favoriten"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Markearje stjoerders mei in stjer by it blêdzjen om se hjir ta te foegjen"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stjoerders sykje…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle talen"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filterje op taal"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle lannen"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filterje op lân"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Gjin stjoerders"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Lade…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u fan %d stjoerders"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stjoerders: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stjoerders lade"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Gjin resultaten"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Efkes wachtsje…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Gjin stjoerders passe by jo sykopdracht"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Koe stjoerders net lade"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stjoerder"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Lân"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Labels"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webside"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitsnelheid"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Net oan it spyljen"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selektearje in stjoerder"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Oan it bufferjen…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "No oan it spyljen"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Skoft"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Opnij ferbine…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Sykje op YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Sykopdracht mislearre: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Gjin YouTube-resultaten fûn"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultaten net beskikber"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ynlade: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Annulearre"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Ynlade mislearre: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Bewarre: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Ferske ynlade"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Ynlade annulearje"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Noch gjin lietsjes"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Lietsjes ferskine hjir as jo nei radiostasjes harkje"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Krekt"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min lyn"
 msgstr[1] "%d min lyn"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d oere lyn"
 msgstr[1] "%d oeren lyn"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/fy.po
+++ b/po/fy.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: fy\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver bliuwt radio ôfspyljen neidat it finster sletten is"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Lietsjeshistoarje"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Trochgean mei ôfspyljen op de eftergrûn"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Oer Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Blêdzje"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stjoerderynformaasje"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stjoerders laden"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Flater: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ôfspylflater: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "No oan it spyljen: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Fierder gean: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-machtiging annulearje"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Ferbining mei Last.fm ferbrekke"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Ferbine mei Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-machtiging annulearre"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Ferbining mei Last.fm ferbrutsen"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Ferbine mei Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Koe gjin ferbining meitsje mei Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Jou tagong yn jo browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-machtiging ferrûn"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ferbûn mei Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Untdek mear as 30.000 ferifiearre radiostasjes fan oer de hiele wrâld"
 
@@ -114,64 +122,65 @@ msgstr "Gjin favoriten"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Markearje stjoerders mei in stjer by it blêdzjen om se hjir ta te foegjen"
+msgstr ""
+"Markearje stjoerders mei in stjer by it blêdzjen om se hjir ta te foegjen"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stjoerders sykje…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle talen"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filterje op taal"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle lannen"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filterje op lân"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Gjin stjoerders"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Lade…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u fan %d stjoerders"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stjoerders: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stjoerders lade"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Gjin resultaten"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Efkes wachtsje…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Gjin stjoerders passe by jo sykopdracht"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Koe stjoerders net lade"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Net oan it spyljen"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selektearje in stjoerder"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Oan it bufferjen…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "No oan it spyljen"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Skoft"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Opnij ferbine…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "No oan it spyljen"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ga.po
+++ b/po/ga.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ga\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : "
 "4);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Leanann Receiver ag seinm raidió tar éis an fhuinneog a dhúnadh"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Roghchlár"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Stair na nAmhrán"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Lean ag seinm sa chúlra"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Maidir le Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Brabhsáil"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Ceanáin"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Eolas faoin stáisiún"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stáisiún luchtaithe"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Earráid: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Earráid athsheinnte: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Á sheinm anois: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ag atosú: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cealaigh údarú Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Dícheangail ó Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Ceangail le Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Cealaithe údarú Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Díchiangailte ó Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Ag ceangal le Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Theip ar cheangal le Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Tabhair rochtain i do bhrabhsálaí…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Chuaigh údarú Last.fm in éag"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ceangailte le Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Aimsigh 30,000+ stáisiún raidió fíoraithe ó gach cearn den domhan"
 
@@ -115,64 +123,65 @@ msgstr "Gan ceanáin"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Cuir réalta le stáisiúin agus tú ag brabhsáil chun iad a chur leis anseo"
+msgstr ""
+"Cuir réalta le stáisiúin agus tú ag brabhsáil chun iad a chur leis anseo"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cuardaigh stáisiúin…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Gach teanga"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Scag de réir teanga"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Gach tír"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Scag de réir tíre"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Gan stáisiúin"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ag luchtú…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u as %d stáisiún"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stáisiúin: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stáisiúin á luchtú"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Gan torthaí"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Fan le do thoil…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Níl aon stáisiún ag teacht le do chuardach"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Níorbh fhéidir stáisiúin a luchtú"
 
@@ -205,25 +214,29 @@ msgid "Stream URL"
 msgstr "URL na sraithe"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Gan seinm"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Roghnaigh stáisiún"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Á mhaolánú…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Á sheinm anois"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Ar sos"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ag athcheangal…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Á sheinm anois"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ga.po
+++ b/po/ga.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ga\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,293 +11,291 @@ msgstr ""
 "Plural-Forms: nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : "
 "4);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Leanann Receiver ag seinm raidió tar éis an fhuinneog a dhúnadh"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Roghchlár"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Stair na nAmhrán"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Lean ag seinm sa chúlra"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Maidir le Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Brabhsáil"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Ceanáin"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Eolas faoin stáisiún"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stáisiún luchtaithe"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Earráid: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Earráid athsheinnte: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Á sheinm anois: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ag atosú: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cealaigh údarú Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Dícheangail ó Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Ceangail le Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Cealaithe údarú Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Díchiangailte ó Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Ag ceangal le Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Theip ar cheangal le Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Tabhair rochtain i do bhrabhsálaí…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Chuaigh údarú Last.fm in éag"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ceangailte le Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Aimsigh 30,000+ stáisiún raidió fíoraithe ó gach cearn den domhan"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Gan ceanáin"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Cuir réalta le stáisiúin agus tú ag brabhsáil chun iad a chur leis anseo"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cuardaigh stáisiúin…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Gach teanga"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Scag de réir teanga"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Gach tír"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Scag de réir tíre"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Gan stáisiúin"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ag luchtú…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u as %d stáisiún"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stáisiúin: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stáisiúin á luchtú"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Gan torthaí"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Fan le do thoil…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Níl aon stáisiún ag teacht le do chuardach"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Níorbh fhéidir stáisiúin a luchtú"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stáisiún"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Tír"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Clibeanna"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Suíomh gréasáin"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Ráta giotán"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL na sraithe"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Gan seinm"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Roghnaigh stáisiún"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Á mhaolánú…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Á sheinm anois"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Ar sos"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ag athcheangal…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ag cuardach ar YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Theip ar an gcuardach: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Níor aimsíodh torthaí YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Gach toradh gan fáil"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ag íoslódáil: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cealaithe"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Theip ar an íoslódáil: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Sábháilte: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Íoslódáil amhrán"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cealaigh íoslódáil"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Gan Amhráin Fós"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Beidh amhráin le feiceáil anseo agus tú ag éisteacht le stáisiúin raidió"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Díreach anois"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -307,7 +305,7 @@ msgstr[2] "%d nóim ó shin"
 msgstr[3] "%d nóim ó shin"
 msgstr[4] "%d nóim ó shin"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -317,7 +315,7 @@ msgstr[2] "%d uair ó shin"
 msgstr[3] "%d uair ó shin"
 msgstr[4] "%d uair ó shin"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/gd.po
+++ b/po/gd.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: gd\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : "
 "(n>2 && n<20) ? 2 : 3;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Cumaidh Receiver a' cluich rèidio às dèidh don uinneig a bhith dùinte"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Clàr-taice"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Eachdraidh nan òran"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Cùm a' cluich sa chùlraidh"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Mu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Brabhsaich"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Annsachdan"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Fiosrachadh an stèisein"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Chaidh %d stèisean a luchdachadh"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Mearachd: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Mearachd cluiche: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ga chluich an-dràsta: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ag ath-thòiseachadh: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Sguir de ùghdarrachadh Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Dì-cheangail bho Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Ceangail ri Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Chaidh ùghdarrachadh Last.fm a sgur"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Air dì-cheangal bho Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "A' ceangal ri Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Cha b' urrainn ceangal ri Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Thoir cead sa bhrabhsair agad…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Dh'fhalbh ùine ùghdarrachadh Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ceangailte ri Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Lorg còrr is 30,000 stèisean rèidio dearbhte bho air feadh an t-saoghail"
@@ -116,64 +124,66 @@ msgstr "Gun annsachdan"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Cuir rionnag air stèiseanan fhad 's a bhios tu a' brabhsadh gus an cur ris an-seo"
+msgstr ""
+"Cuir rionnag air stèiseanan fhad 's a bhios tu a' brabhsadh gus an cur ris "
+"an-seo"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Lorg stèiseanan…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "A h-uile cànan"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Criathraich a rèir cànain"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Gach dùthaich"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Criathraich a rèir dùthaich"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Gun stèisean"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "A’ luchdachadh…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u à %d stèisean"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stèiseanan: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "A’ luchdachadh stèiseanan"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Gun toraidhean"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Fuirich ort…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Chan eil stèisean a’ freagairt ris an lorg agad"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Cha b’ urrainn stèiseanan a luchdachadh"
 
@@ -206,25 +216,29 @@ msgid "Stream URL"
 msgstr "URL an t-sruth"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Chan eil e ga chluich"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Tagh stèisean"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "A' bufaireadh…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Ga chluich an-dràsta"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Air stad"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ag ath-cheangal…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Ga chluich an-dràsta"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/gd.po
+++ b/po/gd.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: gd\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,295 +11,293 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : "
 "(n>2 && n<20) ? 2 : 3;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Cumaidh Receiver a' cluich rèidio às dèidh don uinneig a bhith dùinte"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Clàr-taice"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Eachdraidh nan òran"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Cùm a' cluich sa chùlraidh"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Mu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Brabhsaich"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Annsachdan"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Fiosrachadh an stèisein"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Chaidh %d stèisean a luchdachadh"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Mearachd: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Mearachd cluiche: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ga chluich an-dràsta: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ag ath-thòiseachadh: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Sguir de ùghdarrachadh Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Dì-cheangail bho Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Ceangail ri Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Chaidh ùghdarrachadh Last.fm a sgur"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Air dì-cheangal bho Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "A' ceangal ri Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Cha b' urrainn ceangal ri Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Thoir cead sa bhrabhsair agad…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Dh'fhalbh ùine ùghdarrachadh Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ceangailte ri Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Lorg còrr is 30,000 stèisean rèidio dearbhte bho air feadh an t-saoghail"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Gun annsachdan"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Cuir rionnag air stèiseanan fhad 's a bhios tu a' brabhsadh gus an cur ris "
 "an-seo"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Lorg stèiseanan…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "A h-uile cànan"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Criathraich a rèir cànain"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Gach dùthaich"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Criathraich a rèir dùthaich"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Gun stèisean"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "A’ luchdachadh…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u à %d stèisean"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stèiseanan: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "A’ luchdachadh stèiseanan"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Gun toraidhean"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Fuirich ort…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Chan eil stèisean a’ freagairt ris an lorg agad"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Cha b’ urrainn stèiseanan a luchdachadh"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stèisean"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Dùthaich"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tagaichean"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Làrach-lìn"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Reat bhiodan"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL an t-sruth"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Chan eil e ga chluich"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Tagh stèisean"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "A' bufaireadh…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Ga chluich an-dràsta"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Air stad"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ag ath-cheangal…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "A’ lorg air YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Dh’fhàillig an lorg: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Cha deach toraidhean YouTube a lorg"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Chan eil toradh sam bith ri fhaighinn"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ga luchdachadh a-nuas: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Air a chur dheth"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Dh’fhàillig an luchdachadh: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Air a shàbhaladh: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Luchdaich a-nuas òran"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cuir dheth an luchdachadh"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Chan eil òran ann fhathast"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Nochdaidh òrain an seo fhad 's a bhios tu ag èisteachd ri stèiseanan rèidio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "An-dràsta"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -308,7 +306,7 @@ msgstr[1] "%d mhion air ais"
 msgstr[2] "%d mion air ais"
 msgstr[3] "%d mion air ais"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -317,7 +315,7 @@ msgstr[1] "%d uair air ais"
 msgstr[2] "%d uairean air ais"
 msgstr[3] "%d uair air ais"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/gl.po
+++ b/po/gl.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver segue reproducindo a radio despois de pechar a xanela"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historial de cancións"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Seguir reproducindo en segundo plano"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Sobre Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Información da emisora"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d emisoras cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erro de reprodución: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproducindo: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Retomando: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar a autorización de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conectar a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorización de Last.fm cancelada"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Conectando a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Non se puido conectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Conceda acceso no seu navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "A autorización de Last.fm caducou"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conectado a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descobre máis de 30.000 estacións de radio verificadas de todo o mundo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca emisoras mentres exploras para engadilas aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Buscar emisoras…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Todas as linguas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar por lingua"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Todos os países"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Sen emisoras"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d emisoras"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Emisoras: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargando emisoras"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sen resultados"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Agarde, por favor…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ningunha emisora coincide coa súa busca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Non se puideron cargar as emisoras"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL do fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Non está reproducindo"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleccione unha emisora"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Almacenando no búfer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Reproducindo"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconectando…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Reproducindo"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/gl.po
+++ b/po/gl.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: gl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver segue reproducindo a radio despois de pechar a xanela"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historial de cancións"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Seguir reproducindo en segundo plano"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Sobre Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Información da emisora"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d emisoras cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erro de reprodución: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproducindo: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Retomando: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar a autorización de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conectar a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorización de Last.fm cancelada"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Conectando a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Non se puido conectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Conceda acceso no seu navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "A autorización de Last.fm caducou"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conectado a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descobre máis de 30.000 estacións de radio verificadas de todo o mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sen favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca emisoras mentres exploras para engadilas aquí"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Buscar emisoras…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Todas as linguas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar por lingua"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Todos os países"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Sen emisoras"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargando…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d emisoras"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Emisoras: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargando emisoras"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sen resultados"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Agarde, por favor…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ningunha emisora coincide coa súa busca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Non se puideron cargar as emisoras"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Emisora"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sitio web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Códec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL do fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Non está reproducindo"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleccione unha emisora"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Almacenando no búfer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Reproducindo"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconectando…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Buscando en YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "A busca fallou: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Non se atoparon resultados en YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Todos os resultados non dispoñibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Descargando: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "A descarga fallou: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Gardado: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Descargar canción"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancelar descarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Aínda non hai cancións"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "As cancións aparecerán aquí mentres escoitas estacións de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Agora mesmo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "hai %d min"
 msgstr[1] "hai %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "hai %d hora"
 msgstr[1] "hai %d horas"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/gu.po
+++ b/po/gu.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: gu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "વિન્ડો બંધ થયા પછી પણ Receiver રેડિયો વગાડવાનું ચાલુ રાખે છે"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "મેનુ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ગીત ઇતિહાસ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "પૃષ્ઠભૂમિમાં વગાડવાનું ચાલુ રાખો"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver વિશે"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "બ્રાઉઝ કરો"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "પસંદગીના"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "સ્ટેશનની માહિતી"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d સ્ટેશનો લોડ થયા"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ભૂલ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "પ્લેબેક ભૂલ: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "હવે વાગી રહ્યું છે: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ફરી શરૂ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm અધિકૃતતા રદ કરો"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm થી ડિસ્કનેક્ટ કરો"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm સાથે જોડાઓ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm અધિકૃતતા રદ થઈ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm થી ડિસ્કનેક્ટ થયું"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm સાથે જોડાઈ રહ્યું છે…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm સાથે જોડાવામાં નિષ્ફળ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "તમારા બ્રાઉઝરમાં ઍક્સેસ આપો…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm અધિકૃતતાનો સમય પૂરો થયો"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm સાથે જોડાયેલ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "સમગ્ર વિશ્વમાંથી 30,000+ ચકાસાયેલ રેડિયો સ્ટેશનો શોધો"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "કોઈ પસંદગીના નથી"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "અહીં ઉમેરવા માટે બ્રાઉઝ કરતી વખતે સ્ટેશનોને સ્ટાર કરો"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "સ્ટેશનો શોધો…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "બધી ભાષાઓ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ભાષા પ્રમાણે ફિલ્ટર કરો"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "બધા દેશો"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "દેશ પ્રમાણે ફિલ્ટર"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "કોઈ સ્ટેશન નથી"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "લોડ થઈ રહ્યું છે…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d સ્ટેશનો"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "સ્ટેશનો: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "સ્ટેશનો લોડ થઈ રહ્યાં છે"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "કોઈ પરિણામ નથી"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "કૃપા કરીને રાહ જુઓ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "તમારી શોધ સાથે કોઈ સ્ટેશન મેળ ખાતું નથી"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "સ્ટેશનો લોડ થઈ શક્યા નહીં"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "સ્ટેશન"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "દેશ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ટૅગ્સ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "વેબસાઇટ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "કોડેક"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "બિટરેટ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "સ્ટ્રીમ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "વાગી રહ્યું નથી"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "એક સ્ટેશન પસંદ કરો"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "બફર થઈ રહ્યું છે…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "હવે વાગી રહ્યું છે"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "થોભેલું"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ફરી જોડાઈ રહ્યું છે…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube પર શોધી રહ્યા છીએ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "શોધ નિષ્ફળ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "કોઈ YouTube પરિણામ મળ્યું નથી"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "બધા પરિણામો અનુપલબ્ધ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ડાઉનલોડ થઈ રહ્યું છે: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "રદ કરાયું"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ડાઉનલોડ નિષ્ફળ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "સાચવ્યું: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ગીત ડાઉનલોડ કરો"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ડાઉનલોડ રદ કરો"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "હજી કોઈ ગીતો નથી"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "તમે રેડિયો સ્ટેશનો સાંભળો ત્યારે ગીતો અહીં દેખાશે"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "હમણાં"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d મિનિટ પહેલાં"
 msgstr[1] "%d મિનિટ પહેલાં"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d કલાક પહેલાં"
 msgstr[1] "%d કલાક પહેલાં"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/gu.po
+++ b/po/gu.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: gu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "વિન્ડો બંધ થયા પછી પણ Receiver રેડિયો વગાડવાનું ચાલુ રાખે છે"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "મેનુ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ગીત ઇતિહાસ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "પૃષ્ઠભૂમિમાં વગાડવાનું ચાલુ રાખો"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver વિશે"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "બ્રાઉઝ કરો"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "પસંદગીના"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "સ્ટેશનની માહિતી"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d સ્ટેશનો લોડ થયા"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ભૂલ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "પ્લેબેક ભૂલ: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "હવે વાગી રહ્યું છે: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ફરી શરૂ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm અધિકૃતતા રદ કરો"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm થી ડિસ્કનેક્ટ કરો"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm સાથે જોડાઓ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm અધિકૃતતા રદ થઈ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm થી ડિસ્કનેક્ટ થયું"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm સાથે જોડાઈ રહ્યું છે…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm સાથે જોડાવામાં નિષ્ફળ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "તમારા બ્રાઉઝરમાં ઍક્સેસ આપો…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm અધિકૃતતાનો સમય પૂરો થયો"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm સાથે જોડાયેલ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "સમગ્ર વિશ્વમાંથી 30,000+ ચકાસાયેલ રેડિયો સ્ટેશનો શોધો"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "અહીં ઉમેરવા માટે બ્રાઉઝ કરતી વખતે સ્ટેશનોને સ્ટાર કરો"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "સ્ટેશનો શોધો…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "બધી ભાષાઓ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ભાષા પ્રમાણે ફિલ્ટર કરો"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "બધા દેશો"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "દેશ પ્રમાણે ફિલ્ટર"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "કોઈ સ્ટેશન નથી"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "લોડ થઈ રહ્યું છે…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d સ્ટેશનો"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "સ્ટેશનો: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "સ્ટેશનો લોડ થઈ રહ્યાં છે"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "કોઈ પરિણામ નથી"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "કૃપા કરીને રાહ જુઓ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "તમારી શોધ સાથે કોઈ સ્ટેશન મેળ ખાતું નથી"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "સ્ટેશનો લોડ થઈ શક્યા નહીં"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "સ્ટ્રીમ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "વાગી રહ્યું નથી"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "એક સ્ટેશન પસંદ કરો"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "બફર થઈ રહ્યું છે…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "હવે વાગી રહ્યું છે"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "થોભેલું"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ફરી જોડાઈ રહ્યું છે…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "હવે વાગી રહ્યું છે"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/gv.po
+++ b/po/gv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: gv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,292 +11,290 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1) ? 0 : (n%10==2) ? 1 : (n%20==0) ? "
 "2 : 3;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Ta Receiver freayll er cloie radio lurg da'n uinnag ve jeight"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Fwirran"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Shennaghys ny garraghyn"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Freill er cloie 'sy chooylrey"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Mychione Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Ronsaghey"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Ynmuinyn"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Fys stashoon"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stashoon laadrit"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fallo: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Fallo cloie: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Cloie nish: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Goll er oai: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Scuirr jeh barrantys Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Giarr veih Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kiangle rish Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Barrantys Last.fm er ny scuirr"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Giarrit veih Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Kiangley rish Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Cha dod kiangley rish Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Cur roshtyn ayns dty vrowsar…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Hie barrantys Last.fm harrish traa"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Kianglt rish Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Fow magh 30,000+ stashoonyn raidio feerit veih mygeayrt y theihll"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Gyn ynmuinyn"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Cur rollage er stashoonyn choud as t'ou ronsaghey dy chur ad ayns shoh"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Shir stashoonyn…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Dy chooilley hengey"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Sheshagh rere chengey"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Dy chooilley heer"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Sheelaghey rere çheer"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Gyn stashoon"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laadey…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u jeh %d stashoon"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stashoonyn: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Laadey stashoonyn"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Gyn eiyrtys"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Fuirree my sailt…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Cha nel stashoon erbee coardail rish yn shirrey ayd"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Cha voddagh stashoonyn ve laadrit"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stashoon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Çheer"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Cowraghyn"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Ynnyd-eggey"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Biorane"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL yn trooan"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Cha nel cloie"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Reih stashoon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufferal…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Cloie nish"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Scuirrit"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Kiangley reesht…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Shirrey er YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Ren y shirrey failleil: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Cha row eiyrtys YouTube ry-gheddyn"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Ta dy chooilley eiyrtys gyn cosney"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Laadey neose: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Dollit magh"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Ren y laadey failleil: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Sauailit: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Laad neose arrane"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Dolley magh laadey"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Cha nel arraneyn foast"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Hig arrane kionfenish ayns shoh myr t'ou geaishtagh rish stashoonyn raidio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Nish hene"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -305,7 +303,7 @@ msgstr[1] "%d vinnidyn er dy henney"
 msgstr[2] "%d vinnidyn er dy henney"
 msgstr[3] "%d vinnidyn er dy henney"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -314,7 +312,7 @@ msgstr[1] "%d ooryn er dy henney"
 msgstr[2] "%d ooryn er dy henney"
 msgstr[3] "%d ooryn er dy henney"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/gv.po
+++ b/po/gv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: gv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1) ? 0 : (n%10==2) ? 1 : (n%20==0) ? "
 "2 : 3;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Ta Receiver freayll er cloie radio lurg da'n uinnag ve jeight"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Fwirran"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Shennaghys ny garraghyn"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Freill er cloie 'sy chooylrey"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Mychione Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Ronsaghey"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Ynmuinyn"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Fys stashoon"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stashoon laadrit"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fallo: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Fallo cloie: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Cloie nish: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Goll er oai: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Scuirr jeh barrantys Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Giarr veih Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kiangle rish Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Barrantys Last.fm er ny scuirr"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Giarrit veih Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Kiangley rish Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Cha dod kiangley rish Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Cur roshtyn ayns dty vrowsar…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Hie barrantys Last.fm harrish traa"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Kianglt rish Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Fow magh 30,000+ stashoonyn raidio feerit veih mygeayrt y theihll"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Cur rollage er stashoonyn choud as t'ou ronsaghey dy chur ad ayns shoh"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Shir stashoonyn…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Dy chooilley hengey"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Sheshagh rere chengey"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Dy chooilley heer"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Sheelaghey rere çheer"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Gyn stashoon"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laadey…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u jeh %d stashoon"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stashoonyn: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Laadey stashoonyn"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Gyn eiyrtys"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Fuirree my sailt…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Cha nel stashoon erbee coardail rish yn shirrey ayd"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Cha voddagh stashoonyn ve laadrit"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL yn trooan"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Cha nel cloie"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Reih stashoon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufferal…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Cloie nish"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Scuirrit"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Kiangley reesht…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Cloie nish"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/he.po
+++ b/po/he.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver ממשיך לנגן רדיו לאחר סגירת החלון"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "תפריט"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "היסטוריית שירים"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "המשך נגינה ברקע"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "אודות Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "עיון"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "מועדפים"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "פרטי תחנה"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "נטענו %d תחנות"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "שגיאה: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "שגיאת השמעה: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "מושמע כעת: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "חוזר: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "בטל הרשאת Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "התנתק מ-Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "התחבר ל-Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "הרשאת Last.fm בוטלה"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "התנתקת מ-Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "מתחבר ל-Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "ההתחברות ל-Last.fm נכשלה"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "אפשר גישה בדפדפן שלך…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "הרשאת Last.fm פגה"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "מחובר ל-Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "גלה מעל 30,000 תחנות רדיו מאומתות מרחבי העולם"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "סמנו תחנות בכוכב בזמן הגלישה כדי להוסיף אותן לכאן"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "חיפוש תחנות…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "כל השפות"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "סינון לפי שפה"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "כל המדינות"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "סינון לפי מדינה"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "אין תחנות"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "טוען…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u מתוך %d תחנות"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "תחנות: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "טוען תחנות"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "אין תוצאות"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "נא להמתין…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "אין תחנות התואמות לחיפוש שלך"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "לא ניתן לטעון תחנות"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "כתובת שידור"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "לא מושמע"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "בחר תחנה"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ממלא מאגר…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "מושמע כעת"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "מושהה"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "מתחבר מחדש…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "מושמע כעת"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/he.po
+++ b/po/he.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver ממשיך לנגן רדיו לאחר סגירת החלון"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "תפריט"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "היסטוריית שירים"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "המשך נגינה ברקע"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "אודות Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "עיון"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "מועדפים"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "פרטי תחנה"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "נטענו %d תחנות"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "שגיאה: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "שגיאת השמעה: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "מושמע כעת: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "חוזר: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "בטל הרשאת Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "התנתק מ-Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "התחבר ל-Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "הרשאת Last.fm בוטלה"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "התנתקת מ-Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "מתחבר ל-Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "ההתחברות ל-Last.fm נכשלה"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "אפשר גישה בדפדפן שלך…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "הרשאת Last.fm פגה"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "מחובר ל-Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "גלה מעל 30,000 תחנות רדיו מאומתות מרחבי העולם"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "אין מועדפים"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "סמנו תחנות בכוכב בזמן הגלישה כדי להוסיף אותן לכאן"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "חיפוש תחנות…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "כל השפות"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "סינון לפי שפה"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "כל המדינות"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "סינון לפי מדינה"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "אין תחנות"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "טוען…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u מתוך %d תחנות"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "תחנות: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "טוען תחנות"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "אין תוצאות"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "נא להמתין…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "אין תחנות התואמות לחיפוש שלך"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "לא ניתן לטעון תחנות"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "תחנה"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "מדינה"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "תגיות"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "אתר אינטרנט"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "קודק"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "קצב סיביות"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "כתובת שידור"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "לא מושמע"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "בחר תחנה"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ממלא מאגר…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "מושמע כעת"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "מושהה"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "מתחבר מחדש…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "מחפש ב-YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "החיפוש נכשל: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "לא נמצאו תוצאות YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "כל התוצאות אינן זמינות"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "מוריד: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "בוטל"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ההורדה נכשלה: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "נשמר: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "הורד שיר"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "בטל הורדה"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "אין עדיין שירים"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "שירים יופיעו כאן בזמן שתאזין לתחנות רדיו"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "עכשיו"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "לפני %d דקה"
 msgstr[1] "לפני %d דקות"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "לפני %d שעה"
 msgstr[1] "לפני %d שעות"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/hi.po
+++ b/po/hi.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "विंडो बंद होने के बाद भी Receiver रेडियो बजाता रहता है"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "मेन्यू"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "गाना इतिहास"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "पृष्ठभूमि में चलाते रहें"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver के बारे में"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ब्राउज़ करें"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "पसंदीदा"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "स्टेशन जानकारी"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d اسٹیشنز لوڈ ہو گئے"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "غلطی: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک کی غلطی: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ابھی چل رہا ہے: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "دوبارہ شروع ہو رہا ہے: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द करें"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm से डिस्कनेक्ट करें"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm से कनेक्ट करें"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द हुआ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm से डिस्कनेक्ट हुआ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm से कनेक्ट हो रहा है…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm से कनेक्ट नहीं हो पाया"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "अपने ब्राउज़र में एक्सेस दें…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरण का समय समाप्त"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm से कनेक्ट हुआ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "दुनिया भर से 30,000+ सत्यापित रेडियो स्टेशन खोजें"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "यहाँ जोड़ने के लिए ब्राउज़ करते समय स्टेशनों को स्टार करें"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "اسٹیشنز تلاش کریں..."
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "تمام زبانیں"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "زبان کے لحاظ سے فلٹر کریں"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "सभी देश"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "देश के अनुसार फ़िल्टर"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "کوئی اسٹیشن نہیں"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "لوڈ ہو رہا ہے..."
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%d میں سے %u اسٹیشنز"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "اسٹیشنز: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "اسٹیشنز لوڈ ہو رہے ہیں"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "کوئی نتائج نہیں"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "براہ کرم انتظار کریں..."
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "آپ کی تلاش سے کوئی اسٹیشن میل نہیں کھاتا"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "اسٹیشنز لوڈ نہیں ہو سکے"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "स्ट्रीम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "نہیں چل رہا"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ایک اسٹیشن منتخب کریں"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "बफ़र हो रहा है…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ابھی چل رہا ہے"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "موقوف"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "फिर से कनेक्ट हो रहा है…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ابھی چل رہا ہے"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/hi.po
+++ b/po/hi.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: hi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "विंडो बंद होने के बाद भी Receiver रेडियो बजाता रहता है"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "मेन्यू"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "गाना इतिहास"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "पृष्ठभूमि में चलाते रहें"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver के बारे में"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ब्राउज़ करें"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "पसंदीदा"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "स्टेशन जानकारी"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d اسٹیشنز لوڈ ہو گئے"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "غلطی: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک کی غلطی: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ابھی چل رہا ہے: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "دوبارہ شروع ہو رہا ہے: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द करें"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm से डिस्कनेक्ट करें"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm से कनेक्ट करें"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द हुआ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm से डिस्कनेक्ट हुआ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm से कनेक्ट हो रहा है…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm से कनेक्ट नहीं हो पाया"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "अपने ब्राउज़र में एक्सेस दें…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरण का समय समाप्त"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm से कनेक्ट हुआ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "दुनिया भर से 30,000+ सत्यापित रेडियो स्टेशन खोजें"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "कोई पसंदीदा नहीं"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "यहाँ जोड़ने के लिए ब्राउज़ करते समय स्टेशनों को स्टार करें"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "اسٹیشنز تلاش کریں..."
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "تمام زبانیں"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "زبان کے لحاظ سے فلٹر کریں"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "सभी देश"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "देश के अनुसार फ़िल्टर"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "کوئی اسٹیشن نہیں"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "لوڈ ہو رہا ہے..."
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%d میں سے %u اسٹیشنز"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "اسٹیشنز: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "اسٹیشنز لوڈ ہو رہے ہیں"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "کوئی نتائج نہیں"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "براہ کرم انتظار کریں..."
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "آپ کی تلاش سے کوئی اسٹیشن میل نہیں کھاتا"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "اسٹیشنز لوڈ نہیں ہو سکے"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "स्टेशन"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "देश"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "टैग"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "कोडेक"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "बिटरेट"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "स्ट्रीम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "نہیں چل رہا"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ایک اسٹیشن منتخب کریں"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "बफ़र हो रहा है…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ابھی چل رہا ہے"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "موقوف"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "फिर से कनेक्ट हो रहा है…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube पर खोज रहे हैं…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "खोज विफल: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "कोई YouTube परिणाम नहीं मिला"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "सभी परिणाम अनुपलब्ध हैं"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "डाउनलोड हो रहा है: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "रद्द"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "डाउनलोड विफल: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "सहेja gaya: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "गाना डाउनलोड करें"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "डाउनलोड रद्द करें"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "अभी तक कोई गाने नहीं"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "रेडियो स्टेशन सुनते समय गाने यहाँ दिखाई देंगे"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "अभी"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d मिनट पहले"
 msgstr[1] "%d मिनट पहले"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d घंटा पहले"
 msgstr[1] "%d घंटे पहले"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/hr.po
+++ b/po/hr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver nastavlja reproducirati radio nakon zatvaranja prozora"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Izbornik"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Povijest pjesama"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Nastavi reprodukciju u pozadini"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Podaci o stanici"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Učitano %d postaja"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Pogreška: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Pogreška reprodukcije: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sada svira: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nastavlja se: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Otkaži autorizaciju za Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Prekini vezu s Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Poveži se s Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizacija za Last.fm otkazana"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Veza s Last.fm prekinuta"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Povezivanje s Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Povezivanje s Last.fm nije uspjelo"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dozvolite pristup u svom pregledniku…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizacija za Last.fm je istekla"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Povezan s Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Otkrijte 30.000+ provjerenih radio postaja iz cijeloga svijeta"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nema favorita"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Označite stanice zvjezdicom tijekom pregledavanja da ih dodate ovdje"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Pretraži postaje…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Svi jezici"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Sve zemlje"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtriraj po zemlji"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nema postaja"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Učitavanje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d postaja"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Postaje: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Učitavanje postaja"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nema rezultata"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Molimo pričekajte…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nijedna postaja ne odgovara vašem pretraživanju"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nije moguće učitati postaje"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stanica"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Zemlja"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Web-stranica"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Brzina prijenosa"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL streama"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne svira"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Odaberite postaju"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Punjenje međuspremnika…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Sada svira"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ponovna povezivanja…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Pretraživanje YouTubea…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Pretraživanje neuspjelo: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nisu pronađeni YouTube rezultati"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Svi rezultati nedostupni"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Preuzimanje: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Otkazano"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Preuzimanje neuspjelo: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Spremljeno: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Preuzmi pjesmu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Otkaži preuzimanje"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Još nema pjesama"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Pjesme će se pojaviti ovdje dok slušate radio postaje"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Upravo sada"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "prije %d minutu"
 msgstr[1] "prije %d minute"
 msgstr[2] "prije %d minuta"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "prije %d sat"
 msgstr[1] "prije %d sata"
 msgstr[2] "prije %d sati"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/hr.po
+++ b/po/hr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver nastavlja reproducirati radio nakon zatvaranja prozora"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Izbornik"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Povijest pjesama"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Nastavi reprodukciju u pozadini"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Podaci o stanici"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Učitano %d postaja"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Pogreška: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Pogreška reprodukcije: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sada svira: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nastavlja se: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Otkaži autorizaciju za Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Prekini vezu s Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Poveži se s Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizacija za Last.fm otkazana"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Veza s Last.fm prekinuta"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Povezivanje s Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Povezivanje s Last.fm nije uspjelo"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dozvolite pristup u svom pregledniku…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizacija za Last.fm je istekla"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Povezan s Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Otkrijte 30.000+ provjerenih radio postaja iz cijeloga svijeta"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Označite stanice zvjezdicom tijekom pregledavanja da ih dodate ovdje"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Pretraži postaje…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Svi jezici"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Sve zemlje"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtriraj po zemlji"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nema postaja"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Učitavanje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d postaja"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Postaje: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Učitavanje postaja"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nema rezultata"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Molimo pričekajte…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nijedna postaja ne odgovara vašem pretraživanju"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nije moguće učitati postaje"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL streama"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne svira"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Odaberite postaju"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Punjenje međuspremnika…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Sada svira"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ponovna povezivanja…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Sada svira"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ht.po
+++ b/po/ht.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ht\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver kontinye jwe radyo apre fenèt la fèmen"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Istwa chante yo"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Kontinye jwe an background"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Konsènan Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Navige"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Prefere"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Enfòmasyon estasyon"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estasyon chaje"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erè: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erè lekti: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ap jwe kounye a: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ap rekòmanse: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anile otorizasyon Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Dekonekte de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Konekte ak Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Otorizasyon Last.fm anile"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Dekonekte de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Koneksyon ak Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Pa rive konekte ak Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Bay aksè nan navigatè ou…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Otorizasyon Last.fm ekspire"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Konekte ak Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dekouvri plis pase 30 000 estasyon radyo verifye nan mond lan"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Pa gen prefere"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Mete etwal sou estasyon pandan w ap navige pou ajoute yo isit la"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Chèche estasyon…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Tout lang"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtre pa lang"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tout peyi"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtre pa peyi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Pa gen estasyon"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ap chaje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u nan %d estasyon"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estasyon: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ap chaje estasyon"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Pa gen rezilta"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Tanpri tann…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Pa gen estasyon ki matche ak rechèch ou a"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Pa t kapab chaje estasyon yo"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Estasyon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Peyi"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etikèt"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sit entènèt"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodèk"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL difizyon"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Pa ap jwe"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Chwazi yon estasyon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ap chaje…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Ap jwe kounye a"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "An poz"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ap rekonekte…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ap chèche sou YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Rechèch echwe: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Pa jwenn rezilta YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tout rezilta pa disponib"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ap telechaje: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Anile"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Telechajman echwe: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Anrejistre: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Telechaje chante"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anile telechajman"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Pa gen chante ankò"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Chante yo ap parèt isit la pandan w ap koute estasyon radyo yo"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Kounye a"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min de sa"
 msgstr[1] "%d min de sa"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d èdtan de sa"
 msgstr[1] "%d èdtan de sa"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ht.po
+++ b/po/ht.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ht\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver kontinye jwe radyo apre fenèt la fèmen"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Istwa chante yo"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Kontinye jwe an background"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Konsènan Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Navige"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Prefere"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Enfòmasyon estasyon"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estasyon chaje"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erè: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erè lekti: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ap jwe kounye a: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ap rekòmanse: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anile otorizasyon Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Dekonekte de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Konekte ak Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Otorizasyon Last.fm anile"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Dekonekte de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Koneksyon ak Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Pa rive konekte ak Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Bay aksè nan navigatè ou…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Otorizasyon Last.fm ekspire"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Konekte ak Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dekouvri plis pase 30 000 estasyon radyo verifye nan mond lan"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Mete etwal sou estasyon pandan w ap navige pou ajoute yo isit la"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Chèche estasyon…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Tout lang"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtre pa lang"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tout peyi"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtre pa peyi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Pa gen estasyon"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ap chaje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u nan %d estasyon"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estasyon: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ap chaje estasyon"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Pa gen rezilta"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Tanpri tann…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Pa gen estasyon ki matche ak rechèch ou a"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Pa t kapab chaje estasyon yo"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL difizyon"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Pa ap jwe"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Chwazi yon estasyon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ap chaje…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Ap jwe kounye a"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "An poz"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ap rekonekte…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Ap jwe kounye a"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/hu.po
+++ b/po/hu.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "A Receiver az ablak bezárása után is folytatja a rádió lejátszását"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Dalok előzményei"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Lejátszás folytatása a háttérben"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "A Receiver névjegye"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Böngészés"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Kedvencek"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Állomás adatai"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d állomás betöltve"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Hiba: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Lejátszási hiba: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Most játszik: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Folytatás: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm engedélyezés visszavonása"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Lecsatlakozás a Last.fm-ről"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Csatlakozás a Last.fm-hez"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm engedélyezés visszavonva"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Lecsatlakozva a Last.fm-ről"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Csatlakozás a Last.fm-hez…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nem sikerült csatlakozni a Last.fm-hez"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Adjon hozzáférést a böngészőjében…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm engedélyezés időtúllépés"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Csatlakozva a Last.fm-hez"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Fedezzen fel 30 000+ ellenőrzött rádióállomást a világ minden tájáról"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nincsenek kedvencek"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Csillagozzon meg állomásokat böngészés közben, hogy ide kerüljenek"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Állomások keresése…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Minden nyelv"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Szűrés nyelv szerint"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Minden ország"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Szűrés ország szerint"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nincsenek állomások"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Betöltés…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d állomás"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Állomások: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Állomások betöltése"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nincs találat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Kérem, várjon…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nincs a keresésnek megfelelő állomás"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nem sikerült betölteni az állomásokat"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Állomás"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ország"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Címkék"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Weboldal"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitráta"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nem játszik"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Válasszon állomást"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Pufferelés…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Most játszik"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Szüneteltetve"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Újracsatlakozás…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Keresés a YouTube-on…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "A keresés sikertelen: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nincs találat a YouTube-on"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Minden találat elérhetetlen"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Letöltés: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Megszakítva"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "A letöltés sikertelen: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Mentve: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Dal letöltése"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Letöltés megszakítása"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Még nincsenek dalok"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "A dalok itt jelennek meg, miközben rádióállomásokat hallgat"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Most"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d perce"
 msgstr[1] "%d perce"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d órája"
 msgstr[1] "%d órája"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/hu.po
+++ b/po/hu.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "A Receiver az ablak bezárása után is folytatja a rádió lejátszását"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Dalok előzményei"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Lejátszás folytatása a háttérben"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "A Receiver névjegye"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Böngészés"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Kedvencek"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Állomás adatai"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d állomás betöltve"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Hiba: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Lejátszási hiba: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Most játszik: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Folytatás: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm engedélyezés visszavonása"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Lecsatlakozás a Last.fm-ről"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Csatlakozás a Last.fm-hez"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm engedélyezés visszavonva"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Lecsatlakozva a Last.fm-ről"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Csatlakozás a Last.fm-hez…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nem sikerült csatlakozni a Last.fm-hez"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Adjon hozzáférést a böngészőjében…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm engedélyezés időtúllépés"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Csatlakozva a Last.fm-hez"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Fedezzen fel 30 000+ ellenőrzött rádióállomást a világ minden tájáról"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Csillagozzon meg állomásokat böngészés közben, hogy ide kerüljenek"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Állomások keresése…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Minden nyelv"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Szűrés nyelv szerint"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Minden ország"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Szűrés ország szerint"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nincsenek állomások"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Betöltés…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d állomás"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Állomások: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Állomások betöltése"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nincs találat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Kérem, várjon…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nincs a keresésnek megfelelő állomás"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nem sikerült betölteni az állomásokat"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Stream URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nem játszik"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Válasszon állomást"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Pufferelés…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Most játszik"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Szüneteltetve"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Újracsatlakozás…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Most játszik"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ia.po
+++ b/po/ia.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver continua a reproducer le radio post le clausura del fenestra"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historia de cantos"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continuar a reproducer in fundo"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "A proposito de Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Foliar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Info del station"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationes cargate"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproduction: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nunc reproduce: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprendente: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancellar le autorisation de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Disconnecter de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Connecter a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorisation de Last.fm cancellate"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Disconnectite de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connecter a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Impossibile connecter a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Concede accesso in tu navigator…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Le autorisation de Last.fm ha expirate"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connectite a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Discoperi plus de 30.000 stationes de radio verificate de tote le mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nulle favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marca stationes con stellas durante le navigation pro adder los hic"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cercar stationes…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Tote le linguas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar per lingua"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tote le paises"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar per pais"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nulle stationes"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargante…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d stationes"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationes: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargante le stationes"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nulle resultatos"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Per favor attende…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nulle stationes corresponde a tu recerca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Non poteva cargar le stationes"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Station"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Pais"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquettas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sito web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Velocitate de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Non reproduce"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selige un station"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Immagazinage in buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nunc reproduce"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconnectante…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Cercante in YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Recerca fallite: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nulle resultatos YouTube trovate"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tote le resultatos indisponibile"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Discargante: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancellate"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Discarga fallite: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvate: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Discargar le canto"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancellar le discarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nulle cantos ancora"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Le cantos apparera hic durante que tu ascolta stationes de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Justo ora"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min retro"
 msgstr[1] "%d min retro"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d hora retro"
 msgstr[1] "%d horas retro"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ia.po
+++ b/po/ia.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ia\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continua a reproducer le radio post le clausura del fenestra"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historia de cantos"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continuar a reproducer in fundo"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "A proposito de Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Foliar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Info del station"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationes cargate"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de reproduction: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nunc reproduce: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprendente: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancellar le autorisation de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Disconnecter de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Connecter a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorisation de Last.fm cancellate"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Disconnectite de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connecter a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Impossibile connecter a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Concede accesso in tu navigator…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Le autorisation de Last.fm ha expirate"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connectite a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Discoperi plus de 30.000 stationes de radio verificate de tote le mundo"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marca stationes con stellas durante le navigation pro adder los hic"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cercar stationes…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Tote le linguas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar per lingua"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tote le paises"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar per pais"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nulle stationes"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargante…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d stationes"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationes: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargante le stationes"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nulle resultatos"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Per favor attende…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nulle stationes corresponde a tu recerca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Non poteva cargar le stationes"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL del fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Non reproduce"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selige un station"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Immagazinage in buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nunc reproduce"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconnectante…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nunc reproduce"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/id.po
+++ b/po/id.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver terus memutar radio setelah jendela ditutup"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Riwayat Lagu"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Tetap memutar di latar belakang"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Tentang Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Jelajahi"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorit"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Info stasiun"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasiun dimuat"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Kesalahan: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Kesalahan pemutaran: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sedang diputar: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Melanjutkan: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Batalkan otorisasi Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Putuskan dari Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Hubungkan ke Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Otorisasi Last.fm dibatalkan"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Terputus dari Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Menghubungkan ke Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Gagal terhubung ke Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Berikan akses di browser Anda…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Otorisasi Last.fm kedaluwarsa"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Terhubung ke Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Temukan 30.000+ stasiun radio terverifikasi dari seluruh dunia"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Tidak ada favorit"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Beri bintang pada stasiun saat menjelajah untuk menambahkannya di sini"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cari stasiun…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Semua bahasa"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filter berdasarkan bahasa"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Semua negara"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filter berdasarkan negara"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Tidak ada stasiun"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Memuat…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u dari %d stasiun"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasiun: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Memuat stasiun"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Tidak ada hasil"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Mohon tunggu…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Tidak ada stasiun yang cocok dengan pencarian Anda"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Tidak dapat memuat stasiun"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stasiun"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Negara"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tag"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Situs web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL streaming"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Tidak memutar"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Pilih stasiun"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Menyangga…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Sedang diputar"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Dijeda"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Menghubungkan kembali…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Mencari di YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Pencarian gagal: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Tidak ada hasil YouTube ditemukan"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Semua hasil tidak tersedia"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Mengunduh: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Dibatalkan"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Unduhan gagal: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Disimpan: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Unduh lagu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Batalkan unduhan"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Belum Ada Lagu"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Lagu akan muncul di sini saat Anda mendengarkan stasiun radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Baru saja"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d menit lalu"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d jam lalu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/id.po
+++ b/po/id.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver terus memutar radio setelah jendela ditutup"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Riwayat Lagu"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Tetap memutar di latar belakang"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Tentang Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Jelajahi"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorit"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Info stasiun"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasiun dimuat"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Kesalahan: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Kesalahan pemutaran: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sedang diputar: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Melanjutkan: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Batalkan otorisasi Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Putuskan dari Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Hubungkan ke Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Otorisasi Last.fm dibatalkan"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Terputus dari Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Menghubungkan ke Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Gagal terhubung ke Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Berikan akses di browser Anda…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Otorisasi Last.fm kedaluwarsa"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Terhubung ke Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Temukan 30.000+ stasiun radio terverifikasi dari seluruh dunia"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Beri bintang pada stasiun saat menjelajah untuk menambahkannya di sini"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cari stasiun…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Semua bahasa"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filter berdasarkan bahasa"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Semua negara"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filter berdasarkan negara"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Tidak ada stasiun"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Memuat…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u dari %d stasiun"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasiun: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Memuat stasiun"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Tidak ada hasil"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Mohon tunggu…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Tidak ada stasiun yang cocok dengan pencarian Anda"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Tidak dapat memuat stasiun"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL streaming"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Tidak memutar"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Pilih stasiun"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Menyangga…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Sedang diputar"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Dijeda"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Menghubungkan kembali…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Sedang diputar"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ie.po
+++ b/po/ie.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ie\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continua reproducter li radio pos que li fenestre es cludet"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historie de cansones"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continuar reproducter in fond"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Pri Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Foliar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorites"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Information del station"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationes cargar"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erró: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erró de reproduction: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nu ludente: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Continuante: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anullar li autorisatión de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconnecte se de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Connecte se a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorisatión de Last.fm anullat"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectet de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connecter a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ne possibil connecter a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Da accesse in tui navigator…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Li autorisatión de Last.fm ha expirat"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connectet a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descovri plu quam 30.000 stationes de radio verificat del tot munde"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Stellation stiones durant navigation por adjunter les ci"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Serchar stationes…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Omni lingues"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar per lingue"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Omni landes"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar per land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Null stationes"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargante…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d stationes"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationes: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargante stationes"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Null resultates"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ples atender…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Null stationes conveni a vor sercha"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Ne posset cargar stationes"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL del fluvie"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne ludente"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selecter un station"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufferante…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nu ludente"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pausat"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconnectente…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nu ludente"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ie.po
+++ b/po/ie.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ie\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver continua reproducter li radio pos que li fenestre es cludet"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historie de cansones"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continuar reproducter in fond"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Pri Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Foliar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorites"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Information del station"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationes cargar"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erró: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erró de reproduction: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nu ludente: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Continuante: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anullar li autorisatión de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconnecte se de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Connecte se a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorisatión de Last.fm anullat"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectet de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connecter a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ne possibil connecter a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Da accesse in tui navigator…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Li autorisatión de Last.fm ha expirat"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connectet a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descovri plu quam 30.000 stationes de radio verificat del tot munde"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Null favorit"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Stellation stiones durant navigation por adjunter les ci"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Serchar stationes…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Omni lingues"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar per lingue"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Omni landes"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar per land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Null stationes"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargante…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d stationes"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationes: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargante stationes"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Null resultates"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ples atender…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Null stationes conveni a vor sercha"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Ne posset cargar stationes"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Station"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquettes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Loc web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Rapiditá de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del fluvie"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne ludente"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selecter un station"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufferante…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nu ludente"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pausat"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconnectente…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Serchante in YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Sercha fallit: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Null resultates YouTube trovat"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Omni resultates indisponibil"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Descargante: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Anullat"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Descarga fallit: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Conservat: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Descargar cante"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anullar descarga"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ancor null cansones"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Li cansones va apparer ci durant que tu ascolta stationes de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Yust nu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min ante"
 msgstr[1] "%d min ante"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d hora ante"
 msgstr[1] "%d horas ante"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/io.po
+++ b/po/io.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: io\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver duras plear la radio pos klozo dil fenestro"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menuo"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Kanto-historio"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Durez plear en fono"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Pri Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Foliumar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorizati"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informo pri staciono"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stacioni kargita"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Eroro: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Reprodukto-eroro: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nun ludas: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Durigas: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cesigez Last.fm-autorizeso"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Deskonektesar de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Konektesar a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorizeso cesigita"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Deskonektita de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Konektesas a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ne sucesis konektesar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Donez aceso en vua navigilo…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorizeso eltempiĝis"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Konektita a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Deskovrez plu kam 30 000 verifikita radiostacioni de la tota mondo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nula favorizato"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Stelizez stacioni dum foliumado por adjuntar li hike"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Serchar stacioni…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Omna lingui"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar segun linguo"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Omna landi"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar segun lando"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nula stacioni"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Kargante…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d stacioni"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacioni: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Karganta stacioni"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nula rezulti"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Voluntez vartar…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nula staciono konformas a vua sercho"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Ne povis kargar la stacioni"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Staciono"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Lando"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiketi"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Retosituo"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeko"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrapido"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Fluo-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne ludas"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selektez staciono"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufrado…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nun ludas"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pauzita"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Rikonektante…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Serchante en YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Sercho faliis: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nula YouTube-rezulti trovita"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Omna rezulti nedisponibl"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Deskargante: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cesita"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Deskargo faliis: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvita: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Deskargar kansono"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cesez deskargo"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ankore nula kanti"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Kanti aparecos hike dum vu askoltas radiostacionon"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Jus nun"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "ante %d minuti"
 msgstr[1] "ante %d minuti"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "ante %d hori"
 msgstr[1] "ante %d hori"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/io.po
+++ b/po/io.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: io\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver duras plear la radio pos klozo dil fenestro"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menuo"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Kanto-historio"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Durez plear en fono"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Pri Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Foliumar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorizati"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informo pri staciono"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stacioni kargita"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Eroro: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Reprodukto-eroro: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nun ludas: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Durigas: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cesigez Last.fm-autorizeso"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Deskonektesar de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Konektesar a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorizeso cesigita"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Deskonektita de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Konektesas a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ne sucesis konektesar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Donez aceso en vua navigilo…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorizeso eltempiĝis"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Konektita a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Deskovrez plu kam 30 000 verifikita radiostacioni de la tota mondo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Stelizez stacioni dum foliumado por adjuntar li hike"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Serchar stacioni…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Omna lingui"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar segun linguo"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Omna landi"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar segun lando"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nula stacioni"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Kargante…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d stacioni"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacioni: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Karganta stacioni"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nula rezulti"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Voluntez vartar…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nula staciono konformas a vua sercho"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Ne povis kargar la stacioni"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Fluo-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne ludas"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selektez staciono"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufrado…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nun ludas"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pauzita"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Rikonektante…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nun ludas"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/is.po
+++ b/po/is.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n%10!=1 || n%100==11);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver heldur áfram að spila útvarp eftir að glugganum er lokað"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Valmynd"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Lagasaga"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Halda áfram að spila í bakgrunni"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Um Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Vafra"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Eftirlæti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Upplýsingar um stöð"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stöðvar hlaðnar"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Villa: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspilunarvilla: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Í spilun: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Held áfram: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Hætta við Last.fm-heimild"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Aftengja frá Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Tengja við Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-heimild afturkölluð"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Aftengt frá Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Tengist Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ekki tókst að tengjast Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Veittu aðgang í vafranum þínum…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-heimild rann út"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Tengt við Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Uppgötvaðu yfir 30.000 staðfestar útvarpsstöðvar um allan heim"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Merktu stöðvar með stjörnu á meðan þú vafrar til að bæta þeim hér"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Leita að stöðvum…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Öll tungumál"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Sía eftir tungumáli"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Öll lönd"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Sía eftir landi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Engar stöðvar"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Hleður…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u af %d stöðvum"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stöðvar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Hleður stöðvar"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Engar niðurstöður"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vinsamlegast bíðið…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Engar stöðvar passa við leitina"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Gat ekki hlaðið stöðvum"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Straums-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ekki í spilun"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Veldu stöð"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Les í biðminni…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Í spilun"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Í bið"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Endurtengist…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Í spilun"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/is.po
+++ b/po/is.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n%10!=1 || n%100==11);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver heldur áfram að spila útvarp eftir að glugganum er lokað"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Valmynd"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Lagasaga"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Halda áfram að spila í bakgrunni"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Um Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Vafra"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Eftirlæti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Upplýsingar um stöð"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stöðvar hlaðnar"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Villa: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspilunarvilla: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Í spilun: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Held áfram: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Hætta við Last.fm-heimild"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Aftengja frá Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Tengja við Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-heimild afturkölluð"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Aftengt frá Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Tengist Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ekki tókst að tengjast Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Veittu aðgang í vafranum þínum…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-heimild rann út"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Tengt við Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Uppgötvaðu yfir 30.000 staðfestar útvarpsstöðvar um allan heim"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Engin eftirlæti"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Merktu stöðvar með stjörnu á meðan þú vafrar til að bæta þeim hér"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Leita að stöðvum…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Öll tungumál"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Sía eftir tungumáli"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Öll lönd"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Sía eftir landi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Engar stöðvar"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Hleður…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u af %d stöðvum"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stöðvar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Hleður stöðvar"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Engar niðurstöður"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vinsamlegast bíðið…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Engar stöðvar passa við leitina"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Gat ekki hlaðið stöðvum"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stöð"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Merki"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Vefur"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Merkjamál"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitahraði"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Straums-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ekki í spilun"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Veldu stöð"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Les í biðminni…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Í spilun"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Í bið"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Endurtengist…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Leitar á YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Leit mistókst: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Engar YouTube-niðurstöður fundust"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Allar niðurstöður ótiltækar"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Sæki: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Hætt við"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Niðurhal mistókst: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Vistað: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Sækja lag"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Hætta við niðurhal"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Engin lög ennþá"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Lög birtast hér á meðan þú hlustar á útvarpsstöðvar"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Rétt í þessu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "fyrir %d mín"
 msgstr[1] "fyrir %d mín"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "fyrir %d klukkustund"
 msgstr[1] "fyrir %d klukkustundum"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/it.po
+++ b/po/it.po
@@ -3,312 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver continua a riprodurre la radio dopo la chiusura della finestra"
+msgstr ""
+"Receiver continua a riprodurre la radio dopo la chiusura della finestra"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Cronologia brani"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continua la riproduzione in background"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Informazioni su Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Esplora"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Preferiti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informazioni stazione"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stazioni caricate"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Errore di riproduzione: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "In riproduzione: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ripresa: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Annulla autorizzazione Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Disconnetti da Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Connetti a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizzazione Last.fm annullata"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Disconnesso da Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connessione a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Connessione a Last.fm non riuscita"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Concedi l'accesso nel tuo browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizzazione Last.fm scaduta"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connesso a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Scopri oltre 30.000 stazioni radio verificate da tutto il mondo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nessun preferito"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Aggiungi stazioni ai preferiti durante la navigazione per trovarle qui"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cerca stazioni…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Tutte le lingue"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtra per lingua"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tutti i paesi"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtra per paese"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nessuna stazione"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Caricamento…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u di %d stazioni"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stazioni: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Caricamento stazioni"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nessun risultato"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Attendere…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nessuna stazione corrisponde alla ricerca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Impossibile caricare le stazioni"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stazione"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Paese"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etichette"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sito web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del flusso"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Non in riproduzione"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleziona una stazione"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buffering in corso…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "In riproduzione"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Riconnessione…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ricerca su YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Ricerca fallita: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nessun risultato trovato su YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tutti i risultati non disponibili"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Scaricamento: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Annullato"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download fallito: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvato: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Scarica brano"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Annulla download"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nessun brano ancora"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "I brani appariranno qui mentre ascolti le stazioni radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Adesso"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min fa"
 msgstr[1] "%d min fa"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ora fa"
 msgstr[1] "%d ore fa"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/it.po
+++ b/po/it.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continua a riprodurre la radio dopo la chiusura della finestra"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Cronologia brani"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continua la riproduzione in background"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Informazioni su Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Esplora"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Preferiti"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informazioni stazione"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stazioni caricate"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Errore: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Errore di riproduzione: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "In riproduzione: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ripresa: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Annulla autorizzazione Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Disconnetti da Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Connetti a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizzazione Last.fm annullata"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Disconnesso da Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connessione a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Connessione a Last.fm non riuscita"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Concedi l'accesso nel tuo browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizzazione Last.fm scaduta"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connesso a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Scopri oltre 30.000 stazioni radio verificate da tutto il mondo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Aggiungi stazioni ai preferiti durante la navigazione per trovarle qui"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cerca stazioni…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Tutte le lingue"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtra per lingua"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tutti i paesi"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtra per paese"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nessuna stazione"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Caricamento…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u di %d stazioni"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stazioni: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Caricamento stazioni"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nessun risultato"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Attendere…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nessuna stazione corrisponde alla ricerca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Impossibile caricare le stazioni"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL del flusso"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Non in riproduzione"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleziona una stazione"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buffering in corso…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "In riproduzione"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Riconnessione…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "In riproduzione"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ja.po
+++ b/po/ja.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ウィンドウを閉じても Receiver はラジオの再生を続けます"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "メニュー"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "再生履歴"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "バックグラウンドで再生を続ける"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver について"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "お気に入り"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ステーション情報"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d 局を読み込みました"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "エラー: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "再生エラー: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "再生中: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "再開中: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm の認証をキャンセル"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm から切断"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm に接続"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm の認証がキャンセルされました"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm から切断されました"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm に接続中…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm への接続に失敗しました"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ブラウザでアクセスを許可してください…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm の認証がタイムアウトしました"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm に接続しました"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "世界中の 30,000 以上の認証済みラジオ局を発見しましょう"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "お気に入りなし"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "閲覧中にステーションにスターを付けてここに追加"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ラジオ局を検索…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "すべての言語"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "言語で絞り込み"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "すべての国"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "国で絞り込み"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "該当なし"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "読み込み中…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 局"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "局数: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "局を読み込んでいます"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "結果がありません"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "お待ちください…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "検索条件に一致する局はありません"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "局を読み込めませんでした"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ステーション"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "国"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "タグ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ウェブサイト"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "コーデック"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ビットレート"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ストリームURL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "停止中"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "局を選択してください"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "バッファ中…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "再生中"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "一時停止"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "再接続中…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTubeを検索中…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "検索に失敗しました: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTubeの結果が見つかりません"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "すべての結果が利用できません"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ダウンロード中: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "キャンセルされました"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ダウンロードに失敗しました: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "保存しました: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "曲をダウンロード"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ダウンロードをキャンセル"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "まだ曲がありません"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ラジオ局を聴いていると、ここに曲が表示されます"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "たった今"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d 分前"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d 時間前"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ja.po
+++ b/po/ja.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ウィンドウを閉じても Receiver はラジオの再生を続けます"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "メニュー"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "再生履歴"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "バックグラウンドで再生を続ける"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver について"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "閲覧"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "お気に入り"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ステーション情報"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d 局を読み込みました"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "エラー: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "再生エラー: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "再生中: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "再開中: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm の認証をキャンセル"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm から切断"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm に接続"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm の認証がキャンセルされました"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm から切断されました"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm に接続中…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm への接続に失敗しました"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ブラウザでアクセスを許可してください…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm の認証がタイムアウトしました"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm に接続しました"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "世界中の 30,000 以上の認証済みラジオ局を発見しましょう"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "閲覧中にステーションにスターを付けてここに追加"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ラジオ局を検索…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "すべての言語"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "言語で絞り込み"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "すべての国"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "国で絞り込み"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "該当なし"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "読み込み中…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 局"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "局数: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "局を読み込んでいます"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "結果がありません"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "お待ちください…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "検索条件に一致する局はありません"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "局を読み込めませんでした"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ストリームURL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "停止中"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "局を選択してください"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "バッファ中…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "再生中"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "一時停止"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "再接続中…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "再生中"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ka.po
+++ b/po/ka.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ka\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ფანჯრის დახურვის შემდეგაც Receiver აგრძელებს რადიოს დაკვრას"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "მენიუ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "სიმღერების ისტორია"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ფონურ რეჟიმში დაკვრის გაგრძელება"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver-ის შესახებ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "დათვალიერება"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "რჩეულები"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "სადგურის ინფორმაცია"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ჩაიტვირთა %d სადგური"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "შეცდომა: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "დაკვრის შეცდომა: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ახლა უკრავს: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ბრუნდება: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ავტორიზაციის გაუქმება"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-თან კავშირის გაწყვეტა"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-თან დაკავშირება"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ავტორიზაცია გაუქმებულია"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-თან კავშირი გაწყვეტილია"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-თან დაკავშირება…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-თან დაკავშირება ვერ მოხერხდა"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "მიეცით წვდომა თქვენს ბრაუზერში…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ავტორიზაციის დრო ამოიწურა"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "დაკავშირებულია Last.fm-თან"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "აღმოაჩინეთ 30,000-ზე მეტი ვერიფიცირებული რადიოსადგური მთელი მსოფლიოდან"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "რჩეულები არ არის"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "დათვალიერებისას მონიშნეთ სადგურები ვარსკვლავით აქ დასამატებლად"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "სადგურების ძიება…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ყველა ენა"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ენის მიხედვით გაფილტვრა"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ყველა ქვეყანა"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "გაფილტვრა ქვეყნის მიხედვით"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "სადგურები არ არის"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "იტვირთება…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d სადგური"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "სადგურები: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "სადგურები იტვირთება"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "შედეგები არ არის"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "გთხოვთ მოიცადოთ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "თქვენი ძიებისთვის სადგურები ვერ მოიძებნა"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "სადგურების ჩატვირთვა ვერ მოხერხდა"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "სადგური"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ქვეყანა"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ტეგები"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ვებსაიტი"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "კოდეკი"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ბიტრეითი"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "სტრიმის URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "არ უკრავს"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "აირჩიეთ სადგური"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ბუფერიზაცია…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ახლა უკრავს"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "შეჩერებულია"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ხელახალი დაკავშირება…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-ზე ძიება…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ძიება ვერ შესრულდა: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube შედეგები ვერ მოიძებნა"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ყველა შედეგი მიუწვდომელია"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ჩამოიტვირთება: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "გაუქმებულია"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ჩამოტვირთვა ვერ შესრულდა: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "შენახულია: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "სიმღერის ჩამოტვირთვა"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ჩამოტვირთვის გაუქმება"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ჯერ სიმღერები არ არის"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "სიმღერები აქ გამოჩნდება რადიოსადგურების მოსმენისას"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ახლახანს"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d წუთის წინ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d საათის წინ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ka.po
+++ b/po/ka.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ka\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ფანჯრის დახურვის შემდეგაც Receiver აგრძელებს რადიოს დაკვრას"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "მენიუ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "სიმღერების ისტორია"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ფონურ რეჟიმში დაკვრის გაგრძელება"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver-ის შესახებ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "დათვალიერება"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "რჩეულები"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "სადგურის ინფორმაცია"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ჩაიტვირთა %d სადგური"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "შეცდომა: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "დაკვრის შეცდომა: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ახლა უკრავს: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ბრუნდება: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ავტორიზაციის გაუქმება"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-თან კავშირის გაწყვეტა"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-თან დაკავშირება"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ავტორიზაცია გაუქმებულია"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-თან კავშირი გაწყვეტილია"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-თან დაკავშირება…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-თან დაკავშირება ვერ მოხერხდა"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "მიეცით წვდომა თქვენს ბრაუზერში…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ავტორიზაციის დრო ამოიწურა"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "დაკავშირებულია Last.fm-თან"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "აღმოაჩინეთ 30,000-ზე მეტი ვერიფიცირებული რადიოსადგური მთელი მსოფლიოდან"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "დათვალიერებისას მონიშნეთ სადგურები ვარსკვლავით აქ დასამატებლად"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "სადგურების ძიება…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ყველა ენა"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ენის მიხედვით გაფილტვრა"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ყველა ქვეყანა"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "გაფილტვრა ქვეყნის მიხედვით"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "სადგურები არ არის"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "იტვირთება…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d სადგური"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "სადგურები: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "სადგურები იტვირთება"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "შედეგები არ არის"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "გთხოვთ მოიცადოთ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "თქვენი ძიებისთვის სადგურები ვერ მოიძებნა"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "სადგურების ჩატვირთვა ვერ მოხერხდა"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "სტრიმის URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "არ უკრავს"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "აირჩიეთ სადგური"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ბუფერიზაცია…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ახლა უკრავს"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "შეჩერებულია"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ხელახალი დაკავშირება…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ახლა უკრავს"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/kg.po
+++ b/po/kg.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: kg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver ke landa kubula radio na nima ya kukanga fenetre"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Nkutu ya banzembo"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Landa kubula na nsadulu ya nima"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Na ntualani ya Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Tala"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Biyingi"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Nsangu ya stasyo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Bisika %d me buka"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Mfunu: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Mfunu ya kwikila: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ke kwikila: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ke vutuka: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Katula ndingila ya Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Katula mu Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kangama na Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Ndingila ya Last.fm ekatulami"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Ekatulami mu Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Kukangama na Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ekokaki ve kukangama na Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Pesa ndingila mu navigateur na nge…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Ntangu ya ndingila ya Last.fm esili"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ekangamani na Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Mona stasio ya radio 30 000+ ya ntete kuvuka mu nza mvimba"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Biyingi ve ko"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Tula mbwetete na stasyo tango otali mpo na kubakisa yango awa"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Sosa bisika…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Ndinga Yonso"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Seka na ndinga"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Mikili nyonso"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Pona nkili"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Bisika Ve Ko"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ke buka…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u na %d bisika"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Bisika: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ke Buka Bisika"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Mbundu Ve Ko"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Zinga…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Bisika ve ko na nsosa yo"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Ka lenda buka bisika ve ko"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stasyo"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Nkili"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Bilembo"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Nkutu ya Internet"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeki"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ya flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ke Kwikila Ve Ko"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Sola kisika"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ke buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Ke kwikila"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Telamene"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ke kangama diaka…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ke sosa YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Nsosa me bwa: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Mbundu ya YouTube ve ko"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Mbundu yonso ve ko"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ke kumisa: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Me katula"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Kukumisa me bwa: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Me bika: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Kumisa nkunga"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Katula kukumisa"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nzembo mosi nkutu ve"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Banzembo bakwiza awa ntangu otela stasio ya radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Buna kaka"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "miniti %d ya nkutu"
 msgstr[1] "miniti %d ya nkutu"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "ngonga %d ya nkutu"
 msgstr[1] "ngonga %d ya nkutu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/kg.po
+++ b/po/kg.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: kg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver ke landa kubula radio na nima ya kukanga fenetre"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Nkutu ya banzembo"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Landa kubula na nsadulu ya nima"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Na ntualani ya Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Tala"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Biyingi"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Nsangu ya stasyo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Bisika %d me buka"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Mfunu: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Mfunu ya kwikila: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ke kwikila: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ke vutuka: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Katula ndingila ya Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Katula mu Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kangama na Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Ndingila ya Last.fm ekatulami"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Ekatulami mu Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Kukangama na Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ekokaki ve kukangama na Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Pesa ndingila mu navigateur na nge…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Ntangu ya ndingila ya Last.fm esili"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ekangamani na Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Mona stasio ya radio 30 000+ ya ntete kuvuka mu nza mvimba"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Tula mbwetete na stasyo tango otali mpo na kubakisa yango awa"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Sosa bisika…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Ndinga Yonso"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Seka na ndinga"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Mikili nyonso"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Pona nkili"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Bisika Ve Ko"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ke buka…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u na %d bisika"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Bisika: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ke Buka Bisika"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Mbundu Ve Ko"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Zinga…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Bisika ve ko na nsosa yo"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Ka lenda buka bisika ve ko"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL ya flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ke Kwikila Ve Ko"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Sola kisika"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ke buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Ke kwikila"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Telamene"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ke kangama diaka…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Ke kwikila"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/kk.po
+++ b/po/kk.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: kk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Терезе жабылғаннан кейін Receiver радионы ойнатуды жалғастырады"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Мәзір"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Ән тарихы"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Фонда ойнатуды жалғастыру"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver туралы"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Шолу"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Таңдаулылар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Станция ақпараты"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция жүктелді"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Қате: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ойнату қатесі: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Қазір ойналуда: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Жалғастыру: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm авторизациясын болдырмау"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-нен ажырату"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ге қосылу"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm авторизациясы болдырылмады"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-нен ажыратылды"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ге қосылуда…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ге қосылу сәтсіз"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Браузеріңізде рұқсат беріңіз…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm авторизациясының уақыты бітті"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ге қосылды"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Бүкіл әлемнен 30 000+ расталған радиостансаларды табыңыз"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Мұнда қосу үшін шолу кезінде станцияларды жұлдызшамен белгілеңіз"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Станцияларды іздеу…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Барлық тілдер"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Тіл бойынша сүзу"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Барлық елдер"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Ел бойынша сүзу"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Станциялар жоқ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Жүктелуде…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станциялар: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Станциялар жүктелуде"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Нәтижелер жоқ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Күте тұрыңыз…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Іздеуіңізге сәйкес станция табылмады"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Станцияларды жүктеу мүмкін болмады"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Ағын URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ойнатылмайды"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Станцияны таңдаңыз"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферлеу…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Қазір ойналуда"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Кідіртілді"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Қайта қосылуда…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Қазір ойналуда"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/kk.po
+++ b/po/kk.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: kk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Терезе жабылғаннан кейін Receiver радионы ойнатуды жалғастырады"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Мәзір"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Ән тарихы"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Фонда ойнатуды жалғастыру"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver туралы"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Шолу"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Таңдаулылар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Станция ақпараты"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция жүктелді"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Қате: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ойнату қатесі: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Қазір ойналуда: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Жалғастыру: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm авторизациясын болдырмау"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-нен ажырату"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ге қосылу"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm авторизациясы болдырылмады"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-нен ажыратылды"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ге қосылуда…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ге қосылу сәтсіз"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Браузеріңізде рұқсат беріңіз…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm авторизациясының уақыты бітті"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ге қосылды"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Бүкіл әлемнен 30 000+ расталған радиостансаларды табыңыз"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Таңдаулылар жоқ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Мұнда қосу үшін шолу кезінде станцияларды жұлдызшамен белгілеңіз"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Станцияларды іздеу…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Барлық тілдер"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Тіл бойынша сүзу"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Барлық елдер"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Ел бойынша сүзу"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Станциялар жоқ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Жүктелуде…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станциялар: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Станциялар жүктелуде"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Нәтижелер жоқ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Күте тұрыңыз…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Іздеуіңізге сәйкес станция табылмады"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Станцияларды жүктеу мүмкін болмады"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станция"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ел"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Тегтер"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрейт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Ағын URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ойнатылмайды"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Станцияны таңдаңыз"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферлеу…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Қазір ойналуда"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Кідіртілді"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Қайта қосылуда…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-тен іздеу…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Іздеу сәтсіз: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube нәтижелері табылмады"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Барлық нәтижелер қол жетімсіз"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Жүктелуде: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Болдырмау"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Жүктеу сәтсіз: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Сақталды: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Әнді жүктеу"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Жүктеуді болдырмау"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Әзірге ән жоқ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Радиостансаларды тыңдаған кезде әндер осында пайда болады"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Жаңа ғана"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d мин бұрын"
 msgstr[1] "%d мин бұрын"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d сағат бұрын"
 msgstr[1] "%d сағат бұрын"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/kk@latin.po
+++ b/po/kk@latin.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: kk@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Tereze jabılğan soñ Receiver radionı oinatwdı jalğastıradı"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Mäzir"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Än tarıhy"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Fonda oinatwdı jalğastırw"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver turaly"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Şolw"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Tañdawlylar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stantsiya aqparaty"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stantsııa júkteldi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Qate: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oınatu qatesi: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Qazir oınaluda: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Jalǵastyru: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm avtorızasıasyn boldyrmau"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-nen ajyratý"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ge qosylý"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm avtorızasıasy boldyrylmady"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-nen ajyratyldy"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ge qosylyda…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ge qosylý sätsiz"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Braýzeriñizde ruqsat beriñiz…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm avtorızasıasynyñ ýaqyty bitti"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ge qosyldy"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Bükil älemnen 30 000+ rastalğan radıostansalardy tabyñyz"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Mında qosw üşin şolw kezinde stantsiyalardy juldyzşamen belgileñiz"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stantsııalardy izdeu…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Barlyq tilder"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Til boıynsha súzu"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Barlyq elder"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "El boiynşa süzw"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stantsııalar joq"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Júktelude…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stantsııa"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stantsııalar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stantsııalar júktelude"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nátıjeler joq"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Kúte turyńyz…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Izdeuińizge sáıkes stantsııa tabylmady"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stantsııalardy júkteu múmkin bolmady"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Ağyn URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Oınatylmaıdy"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stantsııany tańdańyz"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buferleý…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Qazir oınaluda"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Kidirtildi"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Qaıta qosyluda…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Qazir oınaluda"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/kk@latin.po
+++ b/po/kk@latin.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: kk@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Tereze jabılğan soñ Receiver radionı oinatwdı jalğastıradı"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Mäzir"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Än tarıhy"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Fonda oinatwdı jalğastırw"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver turaly"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Şolw"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Tañdawlylar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stantsiya aqparaty"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stantsııa júkteldi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Qate: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oınatu qatesi: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Qazir oınaluda: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Jalǵastyru: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm avtorızasıasyn boldyrmau"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-nen ajyratý"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ge qosylý"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm avtorızasıasy boldyrylmady"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-nen ajyratyldy"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ge qosylyda…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ge qosylý sätsiz"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Braýzeriñizde ruqsat beriñiz…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm avtorızasıasynyñ ýaqyty bitti"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ge qosyldy"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Bükil älemnen 30 000+ rastalğan radıostansalardy tabyñyz"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Tañdawlylar joq"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Mında qosw üşin şolw kezinde stantsiyalardy juldyzşamen belgileñiz"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stantsııalardy izdeu…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Barlyq tilder"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Til boıynsha súzu"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Barlyq elder"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "El boiynşa süzw"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stantsııalar joq"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Júktelude…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stantsııa"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stantsııalar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stantsııalar júktelude"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nátıjeler joq"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Kúte turyńyz…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Izdeuińizge sáıkes stantsııa tabylmady"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stantsııalardy júkteu múmkin bolmady"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stantsiya"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "El"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tegter"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Veb-sait"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitreit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Ağyn URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Oınatylmaıdy"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stantsııany tańdańyz"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buferleý…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Qazir oınaluda"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Kidirtildi"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Qaıta qosyluda…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-ten izdeu…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Izdeu sátsiz: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube nátıjeleri tabylmady"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Barlyq nátıjeler qol jetimsiz"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Júktelude: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Boldyrmau"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Júkteu sátsiz: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saqtaldy: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Ándi júkteu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Júkteudi boldyrmau"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Äzirge än joq"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Radıostansalardy tyñdağan kezde änder osynda paida bolady"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Jaña ğana"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d mın buryn"
 msgstr[1] "%d mın buryn"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d sağat buryn"
 msgstr[1] "%d sağat buryn"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/km.po
+++ b/po/km.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: km\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver បន្តចាក់វិទ្យុបន្ទាប់ពីបិទផ្ទាំងវីនដូ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ម៉ឺនុយ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ប្រវត្តិបទចម្រៀង"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "បន្តចាក់នៅផ្ទៃខាងក្រោយ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "អំពី Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "រុករក"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ចំណូលចិត្ត"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ព័ត៌មានស្ថានីយ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "បានផ្ទុក %d ស្ថានីយ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "កំហុស: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "កំហុសក្នុងការចាក់: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "កំពុងចាក់: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "កំពុងបន្ត: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "បោះបង់ការអនុញ្ញាត Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "ផ្តាច់ពី Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "ភ្ជាប់ទៅ Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "ការអនុញ្ញាត Last.fm ត្រូវបានបោះបង់"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "បានផ្តាច់ពី Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "កំពុងភ្ជាប់ទៅ Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "មិនអាចភ្ជាប់ទៅ Last.fm បានទេ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ផ្តល់សិទ្ធិចូលក្នុងកម្មវិធីរុករកររបស់អ្នក…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "ការអនុញ្ញាត Last.fm បានផុតកំណត់"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "បានភ្ជាប់ទៅ Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ស្វែងរកស្ថានីយ៍វិទ្យុ 30,000+ ដែលបានផ្ទៀងផ្ទាត់ពីជុំវិញពិភពលោក"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "គ្មានចំណូលចិត្ត"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ដាក់ផ្កាយលើស្ថានីយខណៈពេលរុករកដើម្បីបន្ថែមវានៅទីនេះ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ស្វែងរកស្ថានីយ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ភាសាទាំងអស់"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ត្រងតាមភាសា"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "គ្រប់ប្រទេស"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ច្រោះតាមប្រទេស"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "គ្មានស្ថានីយ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "កំពុងផ្ទុក…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ក្នុង %d ស្ថានីយ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ស្ថានីយ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "កំពុងផ្ទុកស្ថានីយ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "គ្មានលទ្ធផល"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "សូមរង់ចាំ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "គ្មានស្ថានីយត្រូវនឹងការស្វែងរករបស់អ្នក"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "មិនអាចផ្ទុកស្ថានីយបាន"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ស្ថានីយ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ប្រទេស"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ស្លាក"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "គេហទំព័រ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "កូឌិក"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "អត្រាប៊ីត"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ស្ទ្រីម"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "មិនកំពុងចាក់"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ជ្រើសរើសស្ថានីយ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "កំពុងបណ្ដោះ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "កំពុងចាក់"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ផ្អាក"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "កំពុងភ្ជាប់ឡើងវិញ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "កំពុងស្វែងរក YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ការស្វែងរកបានបរាជ័យ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "រកមិនឃើញលទ្ធផល YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "លទ្ធផលទាំងអស់មិនអាចប្រើបាន"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "កំពុងទាញយក: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "បានបោះបង់"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ការទាញយកបានបរាជ័យ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "បានរក្សាទុក: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ទាញយកបទចម្រៀង"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "បោះបង់ការទាញយក"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "មិនទាន់មានបទចម្រៀង"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "បទចម្រៀងនឹងបង្ហាញនៅទីនេះពេលអ្នកស្តាប់ស្ថានីយ៍វិទ្យុ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ឥឡូវ​នេះ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d នាទីមុន"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ម៉ោងមុន"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/km.po
+++ b/po/km.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: km\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver បន្តចាក់វិទ្យុបន្ទាប់ពីបិទផ្ទាំងវីនដូ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ម៉ឺនុយ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ប្រវត្តិបទចម្រៀង"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "បន្តចាក់នៅផ្ទៃខាងក្រោយ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "អំពី Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "រុករក"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ចំណូលចិត្ត"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ព័ត៌មានស្ថានីយ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "បានផ្ទុក %d ស្ថានីយ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "កំហុស: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "កំហុសក្នុងការចាក់: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "កំពុងចាក់: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "កំពុងបន្ត: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "បោះបង់ការអនុញ្ញាត Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "ផ្តាច់ពី Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "ភ្ជាប់ទៅ Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "ការអនុញ្ញាត Last.fm ត្រូវបានបោះបង់"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "បានផ្តាច់ពី Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "កំពុងភ្ជាប់ទៅ Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "មិនអាចភ្ជាប់ទៅ Last.fm បានទេ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ផ្តល់សិទ្ធិចូលក្នុងកម្មវិធីរុករកររបស់អ្នក…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "ការអនុញ្ញាត Last.fm បានផុតកំណត់"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "បានភ្ជាប់ទៅ Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ស្វែងរកស្ថានីយ៍វិទ្យុ 30,000+ ដែលបានផ្ទៀងផ្ទាត់ពីជុំវិញពិភពលោក"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ដាក់ផ្កាយលើស្ថានីយខណៈពេលរុករកដើម្បីបន្ថែមវានៅទីនេះ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ស្វែងរកស្ថានីយ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ភាសាទាំងអស់"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ត្រងតាមភាសា"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "គ្រប់ប្រទេស"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ច្រោះតាមប្រទេស"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "គ្មានស្ថានីយ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "កំពុងផ្ទុក…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ក្នុង %d ស្ថានីយ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ស្ថានីយ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "កំពុងផ្ទុកស្ថានីយ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "គ្មានលទ្ធផល"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "សូមរង់ចាំ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "គ្មានស្ថានីយត្រូវនឹងការស្វែងរករបស់អ្នក"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "មិនអាចផ្ទុកស្ថានីយបាន"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL ស្ទ្រីម"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "មិនកំពុងចាក់"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ជ្រើសរើសស្ថានីយ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "កំពុងបណ្ដោះ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "កំពុងចាក់"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ផ្អាក"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "កំពុងភ្ជាប់ឡើងវិញ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "កំពុងចាក់"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/kn.po
+++ b/po/kn.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: kn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ವಿಂಡೋ ಮುಚ್ಚಿದ ನಂತರವೂ Receiver ರೇಡಿಯೋ ಪ್ಲೇ ಮಾಡುವುದನ್ನು ಮುಂದುವರಿಸುತ್ತದೆ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ಮೆನು"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ಹಾಡಿನ ಇತಿಹಾಸ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ಹಿನ್ನೆಲೆಯಲ್ಲಿ ಪ್ಲೇ ಮಾಡುವುದನ್ನು ಮುಂದುವರಿಸಿ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver ಕುರಿತು"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ಬ್ರೌಸ್ ಮಾಡಿ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ಮೆಚ್ಚಿನವು"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ಕೇಂದ್ರ ಮಾಹಿತಿ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ಕೇಂದ್ರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗಿದೆ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ದೋಷ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ಪ್ಲೇಬ್ಯಾಕ್ ದೋಷ: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ಈಗ ನುಡಿಸಲಾಗುತ್ತಿದೆ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ಮುಂದುವರಿಸಲಾಗುತ್ತಿದೆ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ಅಧಿಕಾರ ರದ್ದುಮಾಡಿ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ನಿಂದ ಸಂಪರ್ಕ ಕಡಿತಗೊಳಿಸಿ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಿ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ಅಧಿಕಾರ ರದ್ದಾಗಿದೆ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ನಿಂದ ಸಂಪರ್ಕ ಕಡಿತಗೊಂಡಿದೆ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಲು ವಿಫಲವಾಗಿದೆ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ನಿಮ್ಮ ಬ್ರೌಸರ್‌ನಲ್ಲಿ ಪ್ರವೇಶ ನೀಡಿ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ಅಧಿಕಾರದ ಸಮಯ ಮೀರಿದೆ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಲಾಗಿದೆ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ಪ್ರಪಂಚದಾದ್ಯಂತ 30,000+ ಪರಿಶೀಲಿಸಿದ ರೇಡಿಯೋ ಕೇಂದ್ರಗಳನ್ನು ಅನ್ವೇಷಿಸಿ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ಇಲ್ಲಿ ಸೇರಿಸಲು ಬ್ರೌಸ್ ಮಾಡುವಾಗ ಕೇಂದ್ರಗಳಿಗೆ ನಕ್ಷತ್ರ ಗುರುತು ಮಾಡಿ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ಕೇಂದ್ರಗಳನ್ನು ಹುಡುಕಿ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ಎಲ್ಲಾ ಭಾಷೆಗಳು"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ಭಾಷೆಯ ಮೂಲಕ ಫಿಲ್ಟರ್ ಮಾಡಿ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ಎಲ್ಲಾ ದೇಶಗಳು"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ದೇಶದ ಪ್ರಕಾರ ಫಿಲ್ಟರ್"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ಯಾವುದೇ ಕೇಂದ್ರಗಳಿಲ್ಲ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ಲೋಡ್ ಆಗುತ್ತಿದೆ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ಕೇಂದ್ರಗಳು"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ಕೇಂದ್ರಗಳು: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ಕೇಂದ್ರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ಯಾವುದೇ ಫಲಿತಾಂಶಗಳಿಲ್ಲ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ದಯವಿಟ್ಟು ಕಾಯಿರಿ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ನಿಮ್ಮ ಹುಡುಕಾಟಕ್ಕೆ ಯಾವುದೇ ಕೇಂದ್ರ ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ಕೇಂದ್ರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗಲಿಲ್ಲ"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ಸ್ಟ್ರೀಮ್ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ನುಡಿಸಲಾಗುತ್ತಿಲ್ಲ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ಒಂದು ಕೇಂದ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಿ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ಬಫರ್ ಆಗುತ್ತಿದೆ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ಈಗ ನುಡಿಸಲಾಗುತ್ತಿದೆ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ವಿರಾಮ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ಮರು ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ಈಗ ನುಡಿಸಲಾಗುತ್ತಿದೆ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/kn.po
+++ b/po/kn.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: kn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ವಿಂಡೋ ಮುಚ್ಚಿದ ನಂತರವೂ Receiver ರೇಡಿಯೋ ಪ್ಲೇ ಮಾಡುವುದನ್ನು ಮುಂದುವರಿಸುತ್ತದೆ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ಮೆನು"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ಹಾಡಿನ ಇತಿಹಾಸ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ಹಿನ್ನೆಲೆಯಲ್ಲಿ ಪ್ಲೇ ಮಾಡುವುದನ್ನು ಮುಂದುವರಿಸಿ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver ಕುರಿತು"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ಬ್ರೌಸ್ ಮಾಡಿ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ಮೆಚ್ಚಿನವು"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ಕೇಂದ್ರ ಮಾಹಿತಿ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ಕೇಂದ್ರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗಿದೆ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ದೋಷ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ಪ್ಲೇಬ್ಯಾಕ್ ದೋಷ: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ಈಗ ನುಡಿಸಲಾಗುತ್ತಿದೆ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ಮುಂದುವರಿಸಲಾಗುತ್ತಿದೆ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ಅಧಿಕಾರ ರದ್ದುಮಾಡಿ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ನಿಂದ ಸಂಪರ್ಕ ಕಡಿತಗೊಳಿಸಿ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಿ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ಅಧಿಕಾರ ರದ್ದಾಗಿದೆ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ನಿಂದ ಸಂಪರ್ಕ ಕಡಿತಗೊಂಡಿದೆ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಲು ವಿಫಲವಾಗಿದೆ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ನಿಮ್ಮ ಬ್ರೌಸರ್‌ನಲ್ಲಿ ಪ್ರವೇಶ ನೀಡಿ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ಅಧಿಕಾರದ ಸಮಯ ಮೀರಿದೆ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ಗೆ ಸಂಪರ್ಕಿಸಲಾಗಿದೆ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ಪ್ರಪಂಚದಾದ್ಯಂತ 30,000+ ಪರಿಶೀಲಿಸಿದ ರೇಡಿಯೋ ಕೇಂದ್ರಗಳನ್ನು ಅನ್ವೇಷಿಸಿ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ಮೆಚ್ಚಿನವು ಇಲ್ಲ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ಇಲ್ಲಿ ಸೇರಿಸಲು ಬ್ರೌಸ್ ಮಾಡುವಾಗ ಕೇಂದ್ರಗಳಿಗೆ ನಕ್ಷತ್ರ ಗುರುತು ಮಾಡಿ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ಕೇಂದ್ರಗಳನ್ನು ಹುಡುಕಿ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ಎಲ್ಲಾ ಭಾಷೆಗಳು"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ಭಾಷೆಯ ಮೂಲಕ ಫಿಲ್ಟರ್ ಮಾಡಿ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ಎಲ್ಲಾ ದೇಶಗಳು"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ದೇಶದ ಪ್ರಕಾರ ಫಿಲ್ಟರ್"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ಯಾವುದೇ ಕೇಂದ್ರಗಳಿಲ್ಲ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ಲೋಡ್ ಆಗುತ್ತಿದೆ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ಕೇಂದ್ರಗಳು"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ಕೇಂದ್ರಗಳು: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ಕೇಂದ್ರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ಯಾವುದೇ ಫಲಿತಾಂಶಗಳಿಲ್ಲ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ದಯವಿಟ್ಟು ಕಾಯಿರಿ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ನಿಮ್ಮ ಹುಡುಕಾಟಕ್ಕೆ ಯಾವುದೇ ಕೇಂದ್ರ ಹೊಂದಿಕೆಯಾಗುವುದಿಲ್ಲ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ಕೇಂದ್ರಗಳನ್ನು ಲೋಡ್ ಮಾಡಲಾಗಲಿಲ್ಲ"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ಕೇಂದ್ರ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ದೇಶ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ಟ್ಯಾಗ್‌ಗಳು"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ವೆಬ್‌ಸೈಟ್"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ಕೊಡೆಕ್"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ಬಿಟ್‌ರೇಟ್"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ಸ್ಟ್ರೀಮ್ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ನುಡಿಸಲಾಗುತ್ತಿಲ್ಲ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ಒಂದು ಕೇಂದ್ರವನ್ನು ಆಯ್ಕೆಮಾಡಿ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ಬಫರ್ ಆಗುತ್ತಿದೆ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ಈಗ ನುಡಿಸಲಾಗುತ್ತಿದೆ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ವಿರಾಮ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ಮರು ಸಂಪರ್ಕಿಸಲಾಗುತ್ತಿದೆ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube ನಲ್ಲಿ ಹುಡುಕಲಾಗುತ್ತಿದೆ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ಹುಡುಕಾಟ ವಿಫಲ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ಫಲಿತಾಂಶಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ಎಲ್ಲಾ ಫಲಿತಾಂಶಗಳು ಲಭ್ಯವಿಲ್ಲ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ಡೌನ್‌ಲೋಡ್ ಆಗುತ್ತಿದೆ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ರದ್ದುಮಾಡಲಾಗಿದೆ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ಡೌನ್‌ಲೋಡ್ ವಿಫಲ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ಉಳಿಸಲಾಗಿದೆ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ಹಾಡು ಡೌನ್‌ಲೋಡ್ ಮಾಡಿ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ಡೌನ್‌ಲೋಡ್ ರದ್ದುಮಾಡಿ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ಇನ್ನೂ ಹಾಡುಗಳಿಲ್ಲ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ನೀವು ರೇಡಿಯೋ ಕೇಂದ್ರಗಳನ್ನು ಕೇಳುತ್ತಿರುವಾಗ ಹಾಡುಗಳು ಇಲ್ಲಿ ಕಾಣಿಸಿಕೊಳ್ಳುತ್ತವೆ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ಈಗಷ್ಟೇ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d ನಿಮಿಷದ ಹಿಂದೆ"
 msgstr[1] "%d ನಿಮಿಷಗಳ ಹಿಂದೆ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ಗಂಟೆಯ ಹಿಂದೆ"
 msgstr[1] "%d ಗಂಟೆಗಳ ಹಿಂದೆ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "창을 닫아도 Receiver는 계속 라디오를 재생합니다"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "메뉴"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "재생 기록"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "백그라운드에서 계속 재생"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver 정보"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "둘러보기"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "즐겨찾기"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "방송국 정보"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "방송국 %d개 로드됨"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "오류: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "재생 오류: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "재생 중: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "다시 시작: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm 인증 취소"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm 연결 끊기"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm에 연결"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 인증이 취소되었습니다"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm 연결이 끊어졌습니다"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm에 연결 중…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm에 연결하지 못했습니다"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "브라우저에서 액세스를 허용하세요…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 인증 시간이 초과되었습니다"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm에 연결되었습니다"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "전 세계 30,000개 이상의 인증된 라디오 방송국을 찾아보세요"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "둘러보면서 방송국에 별표를 눌러 여기에 추가하세요"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "방송국 검색…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "모든 언어"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "언어별 필터"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "모든 국가"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "국가별 필터"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "방송국 없음"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "로드 중…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 방송국"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "방송국: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "방송국 로드 중"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "결과 없음"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "잠시 기다려주세요…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "검색 결과와 일치하는 방송국이 없습니다"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "방송국을 로드할 수 없습니다"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "스트림 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "재생 중 아님"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "방송국 선택"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "버퍼링 중…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "현재 재생 중"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "일시 중지됨"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "다시 연결 중…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "현재 재생 중"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ko.po
+++ b/po/ko.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "창을 닫아도 Receiver는 계속 라디오를 재생합니다"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "메뉴"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "재생 기록"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "백그라운드에서 계속 재생"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver 정보"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "둘러보기"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "즐겨찾기"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "방송국 정보"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "방송국 %d개 로드됨"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "오류: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "재생 오류: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "재생 중: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "다시 시작: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm 인증 취소"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm 연결 끊기"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm에 연결"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 인증이 취소되었습니다"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm 연결이 끊어졌습니다"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm에 연결 중…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm에 연결하지 못했습니다"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "브라우저에서 액세스를 허용하세요…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 인증 시간이 초과되었습니다"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm에 연결되었습니다"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "전 세계 30,000개 이상의 인증된 라디오 방송국을 찾아보세요"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "즐겨찾기 없음"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "둘러보면서 방송국에 별표를 눌러 여기에 추가하세요"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "방송국 검색…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "모든 언어"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "언어별 필터"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "모든 국가"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "국가별 필터"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "방송국 없음"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "로드 중…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 방송국"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "방송국: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "방송국 로드 중"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "결과 없음"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "잠시 기다려주세요…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "검색 결과와 일치하는 방송국이 없습니다"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "방송국을 로드할 수 없습니다"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "방송국"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "국가"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "태그"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "웹사이트"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "코덱"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "비트레이트"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "스트림 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "재생 중 아님"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "방송국 선택"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "버퍼링 중…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "현재 재생 중"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "일시 중지됨"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "다시 연결 중…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube 검색 중…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "검색 실패: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube 결과를 찾을 수 없습니다"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "모든 결과를 사용할 수 없습니다"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "다운로드 중: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "취소됨"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "다운로드 실패: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "저장됨: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "곡 다운로드"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "다운로드 취소"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "아직 노래가 없습니다"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "라디오 방송국을 들으면 여기에 노래가 표시됩니다"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "방금"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d분 전"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d시간 전"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ks.po
+++ b/po/ks.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ks\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver وِنڈو بند گژھنہ پتہٕ تہِ راڈیو بجاوان رۄزان چھُ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "مینیو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "گانَہ تاریخ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "پسؠ منظر منز بجاوان رۄزِو"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver بارَتھ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "براؤز کریو"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "پسندیٖدہٕ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "سٹیشن معلومات"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d سٹیشن لوٗڈ بیٖ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "غَلطی: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک غَلطی: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ہُن چلان: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "مُکررہ شروع: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm اجازت منسوخ کرِو"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm سٕتٕ ڈسکنیکٹ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm سٕتٕ کنیکٹ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm اجازت منسوخ بوٚو"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm سٕتٕ ڈسکنیکٹ بوٚو"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm سٕتٕ کنیکٹ بوزان…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm سٕتٕ کنیکٹ ہیوٚ نہٕ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "پننٕ براؤزرَس مَنٕ اجازت دِو…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm اجازتُک وَکت ختم بوٚو"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm سٕتٕ کنیکٹ بوٚو"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "دُنیا بَرَس 30,000+ تصدیق شُدہ ریڈیو اسٹیشن دریافت کرِو"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "یتھ شامل کرنہٕ خاطرٕ براؤز کرتھ وقت سٹیشنن کھ ستارہٕ لگاو"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "سٹیشن لَبہِ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ساری زبانہٕ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "زبانہٕ مُطابق فلٹر"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "تمام مُلک"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "مُلک مُطابق فلٹر"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "کانٛہہِ سٹیشن نَتھ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "لوٗڈ بونٛ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d سٹیشن"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "سٹیشن: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "سٹیشن لوٗڈ بونٛ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "کانٛہہِ نَتیٖجہٕ نَتھ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "مہربانی کٔرِتھ اِنتظار کٔرِو…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "تُہنٛدِ لَبنَس تہٕ کانٛہہِ سٹیشن نہٕ مِلیٖ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "سٹیشن لوٗڈ ہیٖ نہٕ سَکی"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "سٹریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "نہٕ چلان"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "اَکھ سٹیشن چُنو"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "بفر گژھان…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ہُن چلان"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "رُکیٖ ہَوٕ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "پونہٕ جوٗڑنٛ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ہُن چلان"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ks.po
+++ b/po/ks.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ks\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver وِنڈو بند گژھنہ پتہٕ تہِ راڈیو بجاوان رۄزان چھُ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "مینیو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "گانَہ تاریخ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "پسؠ منظر منز بجاوان رۄزِو"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver بارَتھ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "براؤز کریو"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "پسندیٖدہٕ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "سٹیشن معلومات"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d سٹیشن لوٗڈ بیٖ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "غَلطی: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک غَلطی: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ہُن چلان: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "مُکررہ شروع: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm اجازت منسوخ کرِو"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm سٕتٕ ڈسکنیکٹ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm سٕتٕ کنیکٹ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm اجازت منسوخ بوٚو"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm سٕتٕ ڈسکنیکٹ بوٚو"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm سٕتٕ کنیکٹ بوزان…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm سٕتٕ کنیکٹ ہیوٚ نہٕ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "پننٕ براؤزرَس مَنٕ اجازت دِو…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm اجازتُک وَکت ختم بوٚو"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm سٕتٕ کنیکٹ بوٚو"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "دُنیا بَرَس 30,000+ تصدیق شُدہ ریڈیو اسٹیشن دریافت کرِو"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "کانہہ پسندیٖدہٕ نہٕ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "یتھ شامل کرنہٕ خاطرٕ براؤز کرتھ وقت سٹیشنن کھ ستارہٕ لگاو"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "سٹیشن لَبہِ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ساری زبانہٕ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "زبانہٕ مُطابق فلٹر"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "تمام مُلک"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "مُلک مُطابق فلٹر"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "کانٛہہِ سٹیشن نَتھ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "لوٗڈ بونٛ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d سٹیشن"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "سٹیشن: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "سٹیشن لوٗڈ بونٛ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "کانٛہہِ نَتیٖجہٕ نَتھ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "مہربانی کٔرِتھ اِنتظار کٔرِو…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "تُہنٛدِ لَبنَس تہٕ کانٛہہِ سٹیشن نہٕ مِلیٖ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "سٹیشن لوٗڈ ہیٖ نہٕ سَکی"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "سٹیشن"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "مُلک"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ٹیگ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ویب سایٹ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کوڈیک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "بِٹ رییٹ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "سٹریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "نہٕ چلان"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "اَکھ سٹیشن چُنو"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "بفر گژھان…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ہُن چلان"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "رُکیٖ ہَوٕ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "پونہٕ جوٗڑنٛ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube مَنٛز لَبنٛ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "لَبنَس ناکام: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube نَتیٖجہٕ نہٕ مِلی"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "سارٕ نَتیٖجہٕ دَستیاب نَتھ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ڈاؤنلوٗڈ بونٛ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "مَنسوٗخ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ڈاؤنلوٗڈ ناکام: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "محفوظ بیٖ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "گانہٕ ڈاؤنلوٗڈ کٔرِو"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ڈاؤنلوٗڈ مَنسوٗخ کٔرِو"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ابہِ تام کانہٕ گانہٕ نہٕ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ریڈیو اسٹیشن بوزنَوَن ٲسٕتھ گانہٕ یتھ ظاہر گَچھن"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ابہِ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d منٹ پیٹھ"
 msgstr[1] "%d منٹ پیٹھ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d گَنٹہٕ پیٹھ"
 msgstr[1] "%d گَنٹہٕ پیٹھ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ku.po
+++ b/po/ku.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ku\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver piştî girtina paceyê berdewam dike radyoyê lê bide"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menû"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Dîroka stranan"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Di paşxaneyê de lêdanê bidomîne"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Der barê Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Bigere"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Bijare"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Agahdariya stasyonê"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasyon hatin barkirin"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Çewtî: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Çewtiya lêdanê: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Niha tê lêdan: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Berdewamkirin: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Destûra Last.fm betal bike"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Ji Last.fm veqetîne"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Bi Last.fm ve girêbide"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Destûra Last.fm hat betalkirin"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Ji Last.fm hat veqetandin"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Bi Last.fm ve tê girêdan…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Bi Last.fm ve girêdan têk çû"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Di geroka xwe da destûrê bide…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Destûra Last.fm qediya"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Bi Last.fm ve girêdayî"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Zêdetirî 30,000 stasyonên radyoyê yên pejirandî ji çar aliyên cîhanê keşf "
@@ -119,61 +127,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Ji bo lê zêdekirinê dema ku hûn digerîn stasyonan bi stêrk nîşan bikin"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Li stasyonan bigere…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Hemû ziman"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Li gorî zimanî parzûn bike"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Hemû welat"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Li gorî welat parzûn bike"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Tu stasyon tune"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Tê barkirin…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ji %d stasyonan"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasyon: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stasyon tên barkirin"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Tu encam tune"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ji kerema xwe bisekine…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Tu stasyon bi lêgerîna te re li hev nayê"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stasyon nehatin barkirin"
 
@@ -206,25 +214,29 @@ msgid "Stream URL"
 msgstr "URL-ya weşanê"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nalêde"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stasyonekê hilbijêre"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Tê tamponkirin…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Niha tê lêdan"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Sekinî"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ji nû ve girêdan…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Niha tê lêdan"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ku.po
+++ b/po/ku.po
@@ -3,315 +3,313 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ku\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver piştî girtina paceyê berdewam dike radyoyê lê bide"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menû"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Dîroka stranan"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Di paşxaneyê de lêdanê bidomîne"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Der barê Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Bigere"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Bijare"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Agahdariya stasyonê"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasyon hatin barkirin"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Çewtî: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Çewtiya lêdanê: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Niha tê lêdan: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Berdewamkirin: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Destûra Last.fm betal bike"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Ji Last.fm veqetîne"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Bi Last.fm ve girêbide"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Destûra Last.fm hat betalkirin"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Ji Last.fm hat veqetandin"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Bi Last.fm ve tê girêdan…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Bi Last.fm ve girêdan têk çû"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Di geroka xwe da destûrê bide…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Destûra Last.fm qediya"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Bi Last.fm ve girêdayî"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Zêdetirî 30,000 stasyonên radyoyê yên pejirandî ji çar aliyên cîhanê keşf "
 "bikin"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Bijare tune"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Ji bo lê zêdekirinê dema ku hûn digerîn stasyonan bi stêrk nîşan bikin"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Li stasyonan bigere…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Hemû ziman"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Li gorî zimanî parzûn bike"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Hemû welat"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Li gorî welat parzûn bike"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Tu stasyon tune"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Tê barkirin…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ji %d stasyonan"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasyon: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stasyon tên barkirin"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Tu encam tune"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ji kerema xwe bisekine…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Tu stasyon bi lêgerîna te re li hev nayê"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stasyon nehatin barkirin"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stasyon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Welat"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etîket"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Malpera"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Rêjeya bit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL-ya weşanê"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nalêde"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stasyonekê hilbijêre"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Tê tamponkirin…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Niha tê lêdan"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Sekinî"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ji nû ve girêdan…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Li YouTube tê gerîn…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Lêgerîn neserkeft: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Tu encamên YouTube nehatin dîtin"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Hemû encam berdest nînin"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Tê daxistin: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Hat betalkirin"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Daxistin neserkeft: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Hat tomarkirin: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Stranê daxîne"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Daxistinê betal bike"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Hîn tu stran tune"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Dema ku hûn guhdariya stasyonên radyoyê dikin stran dê li vir xuya bibin"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Niha"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d deq berê"
 msgstr[1] "%d deq berê"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d saet berê"
 msgstr[1] "%d saet berê"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ky.po
+++ b/po/ky.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ky\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Терезе жабылгандан кийин да Receiver радиону ойнотууну улантат"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Ыр тарыхы"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Фондо ойнотууну улантуу"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver жөнүндө"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Карап чыгуу"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Тандалмалар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Станция маалыматы"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция жүктөлдү"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Ката: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ойнотуу катасы: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Азыр ойнолууда: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Улантуу: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm уруксатын жокко чыгаруу"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm менен ажыратуу"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm менен туташуу"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm уруксаты жокко чыгарылды"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm менен ажыратылды"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm менен туташууда…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm менен туташуу ишке ашпады"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Браузериңизде уруксат бериңиз…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm уруксатынын убактысы бүттү"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm менен туташты"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Дүйнө жүзүндө 30 000+ текшерилген радиостанцияны табыңыз"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Тандалмалар жок"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Бул жерге кошуу үчүн карап чыгууда станцияларды жылдызча менен белгилеңиз"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Станцияларды издөö…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Бардык тилдер"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Тил боюнча чыпкалоо"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Бардык өлкөлөр"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Өлкө боюнча чыпкалоо"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Станциялар жок"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Жүктөлүүдö…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станциялар: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Станциялар жүктөлүүдö"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Жыйынтыктар жок"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Сураныч, күтө туруңуз…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Издөöңүзгö ылайык станция табылган жок"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Станцияларды жүктöö мүмкүн болбоду"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станция"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Өлкө"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Тегдер"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрейт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Агым URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ойнотулбайт"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Станция тандаңыз"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферлөө…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Азыр ойнолууда"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Тыным"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Кайра туташууда…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-тан издöö…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Издöö ийгиликсиз: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube жыйынтыктары табылган жок"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Бардык жыйынтыктар жеткиликсиз"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Жүктöлүүдö: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Жокко чыгарылды"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Жүктöö ийгиликсиз: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Сакталды: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Ырды жүктöп алуу"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Жүктöөнү жокко чыгаруу"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Азырынча ырлар жок"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Радиостанцияларды угуп жатканыңызда ырлар бул жерде пайда болот"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Жаңы эле"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d мүн. мурун"
 msgstr[1] "%d мүн. мурун"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d саат мурун"
 msgstr[1] "%d саат мурун"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ky.po
+++ b/po/ky.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ky\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Терезе жабылгандан кийин да Receiver радиону ойнотууну улантат"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Ыр тарыхы"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Фондо ойнотууну улантуу"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver жөнүндө"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Карап чыгуу"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Тандалмалар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Станция маалыматы"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция жүктөлдү"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Ката: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ойнотуу катасы: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Азыр ойнолууда: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Улантуу: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm уруксатын жокко чыгаруу"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm менен ажыратуу"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm менен туташуу"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm уруксаты жокко чыгарылды"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm менен ажыратылды"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm менен туташууда…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm менен туташуу ишке ашпады"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Браузериңизде уруксат бериңиз…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm уруксатынын убактысы бүттү"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm менен туташты"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Дүйнө жүзүндө 30 000+ текшерилген радиостанцияны табыңыз"
 
@@ -114,64 +122,65 @@ msgstr "Тандалмалар жок"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Бул жерге кошуу үчүн карап чыгууда станцияларды жылдызча менен белгилеңиз"
+msgstr ""
+"Бул жерге кошуу үчүн карап чыгууда станцияларды жылдызча менен белгилеңиз"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Станцияларды издөö…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Бардык тилдер"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Тил боюнча чыпкалоо"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Бардык өлкөлөр"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Өлкө боюнча чыпкалоо"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Станциялар жок"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Жүктөлүүдö…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станциялар: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Станциялар жүктөлүүдö"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Жыйынтыктар жок"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Сураныч, күтө туруңуз…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Издөöңүзгö ылайык станция табылган жок"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Станцияларды жүктöö мүмкүн болбоду"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "Агым URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ойнотулбайт"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Станция тандаңыз"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферлөө…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Азыр ойнолууда"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Тыным"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Кайра туташууда…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Азыр ойнолууда"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/la.po
+++ b/po/la.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: la\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver radiophonium reddere pergit postquam fenestra clausa est"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Tabula"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historia cantionum"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Perge reddere in scaena secunda"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "De Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Perlustrare"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Electa"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informationes stationis"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationes oneratae"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error lusionis: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nunc ludit: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Resumens: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Abrogare auctoritatem Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Disiungere a Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Coniungere ad Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Auctoritas Last.fm abrogata est"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Disiunctum a Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Coniungitur ad Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Non potuit coniungere ad Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Da accessum in navigatro tuo…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Auctoritas Last.fm exspiravit"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Coniunctum ad Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Inveni plus quam 30.000 stationes radiophonicos confirmatos ex toto mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nulla electa"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Stella adde stationibus dum perlustras ut eas hic addas"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Quaere stationes…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Omnes linguae"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtra per linguam"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Omnes nationes"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtra per nationem"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nullae stationes"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Onerans…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ex %d stationibus"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationes: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stationes onerantur"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nulli eventus"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Quaeso exspecta…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nullae stationes quaestioni tuae conveniunt"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stationes onerari non potuerunt"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Statio"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Natio"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Signa"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Pagina interretialis"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Celeritas bitorum"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL fluminis"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Non ludit"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Elige stationem"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Praeparatur…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nunc ludit"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Intermissum"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconnectens…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "In YouTube quaerens…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Quaestio defecit: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nulli eventus YouTube inventi"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Omnes eventus non praesto"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Deponens: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Rescissum"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Depositio defecit: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Servatum: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Cantum depone"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Depositionem rescinde"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nullae cantiones adhuc"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Cantiones hic apparebunt dum stationes radiophonicos audis"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Modo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d minutum ante"
 msgstr[1] "%d minuta ante"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d horam ante"
 msgstr[1] "%d horas ante"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/la.po
+++ b/po/la.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: la\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver radiophonium reddere pergit postquam fenestra clausa est"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Tabula"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historia cantionum"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Perge reddere in scaena secunda"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "De Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Perlustrare"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Electa"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informationes stationis"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationes oneratae"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error lusionis: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nunc ludit: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Resumens: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Abrogare auctoritatem Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Disiungere a Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Coniungere ad Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Auctoritas Last.fm abrogata est"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Disiunctum a Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Coniungitur ad Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Non potuit coniungere ad Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Da accessum in navigatro tuo…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Auctoritas Last.fm exspiravit"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Coniunctum ad Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Inveni plus quam 30.000 stationes radiophonicos confirmatos ex toto mundo"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Stella adde stationibus dum perlustras ut eas hic addas"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Quaere stationes…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Omnes linguae"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtra per linguam"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Omnes nationes"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtra per nationem"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nullae stationes"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Onerans…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ex %d stationibus"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationes: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stationes onerantur"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nulli eventus"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Quaeso exspecta…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nullae stationes quaestioni tuae conveniunt"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stationes onerari non potuerunt"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL fluminis"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Non ludit"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Elige stationem"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Praeparatur…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nunc ludit"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Intermissum"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconnectens…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nunc ludit"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/lg.po
+++ b/po/lg.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: lg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver eyongera okukuba leediyo oluvannyuma lw'okuggalawo eddirisa"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Ebyafaayo by'ennyimba"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Yongera okukuba mu mbiriizi"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Ebikwata ku Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Lambula"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Ebyoyagala"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Amawulire g'ekitundu"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Sitesi %d zitikkiddwa"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Ensobi: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ensobi mu kuzannya: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Kati ezannyibwa: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Eddirayo: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Sazaamu olukusa lwa Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Kwawukana ne Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kwegatta ne Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Olukusa lwa Last.fm lusaziddwa"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Oyawukanye ne Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Kwegatta ne Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Tekisobose kwegatta ne Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Wa olukusa mu browser yo…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Obudde bw'olukusa lwa Last.fm buweddeko"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Weetasse ne Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Zuula ddala sitesoni z'eddiyyo 30,000+ ezikakasiddwa okuva mu nsi yonna"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Tewali byoyagala"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Teeka emmunyeenye ku bitundu nga olambula okubigattako wano"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Noonya sitesi…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Ennimi Zonna"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Yungula mu lulimi"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Ensi zonna"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Gonza olw'ensi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Tewali Sitesi"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Kitikkibwa…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u mu %d sitesi"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Sitesi: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Sitesi Zitikkibwa"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Tewali Bivudde"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Mwezikewo…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Tewali sitesi zikwatagana n'ekyanoonyebwa"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Tekyasobodde kutikka sitesi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Ekitundu"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ensi"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Obubonero"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Omukutu"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeeki"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Omugendo gwa biti"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL y'okukulukuta"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Tezannyibwa"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Londa sitesi"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Kitereka…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Kati ezannyibwa"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Kiyimiriziddwa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Kuddamu okuyunga…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Kunoonyeza YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Okunoonya kugaanye: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Tewali bivudde mu YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Bivudde byonna tebifunika"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Kidawunilooda: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Kisaziddwamu"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Okudawunilooda kugaanye: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Kiseveddwa: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Dawunilooda oluyimba"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Sazaamu okudawunilooda"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Tewali nnyimba nnaku"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Ennyimba zijja kulabika wano ng'owuliriza sitesoni z'eddiyyo"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Kaakano"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "eddakiika %d emabega"
 msgstr[1] "eddakiika %d emabega"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "essaawa %d emabega"
 msgstr[1] "essaawa %d emabega"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/lg.po
+++ b/po/lg.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: lg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver eyongera okukuba leediyo oluvannyuma lw'okuggalawo eddirisa"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Ebyafaayo by'ennyimba"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Yongera okukuba mu mbiriizi"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Ebikwata ku Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Lambula"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Ebyoyagala"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Amawulire g'ekitundu"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Sitesi %d zitikkiddwa"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Ensobi: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ensobi mu kuzannya: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Kati ezannyibwa: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Eddirayo: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Sazaamu olukusa lwa Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Kwawukana ne Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kwegatta ne Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Olukusa lwa Last.fm lusaziddwa"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Oyawukanye ne Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Kwegatta ne Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Tekisobose kwegatta ne Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Wa olukusa mu browser yo…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Obudde bw'olukusa lwa Last.fm buweddeko"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Weetasse ne Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Zuula ddala sitesoni z'eddiyyo 30,000+ ezikakasiddwa okuva mu nsi yonna"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Teeka emmunyeenye ku bitundu nga olambula okubigattako wano"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Noonya sitesi…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Ennimi Zonna"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Yungula mu lulimi"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Ensi zonna"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Gonza olw'ensi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Tewali Sitesi"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Kitikkibwa…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u mu %d sitesi"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Sitesi: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Sitesi Zitikkibwa"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Tewali Bivudde"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Mwezikewo…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Tewali sitesi zikwatagana n'ekyanoonyebwa"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Tekyasobodde kutikka sitesi"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL y'okukulukuta"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Tezannyibwa"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Londa sitesi"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Kitereka…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Kati ezannyibwa"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Kiyimiriziddwa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Kuddamu okuyunga…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Kati ezannyibwa"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/li.po
+++ b/po/li.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: li\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver blijf radio aafspele nao 't sluten van 't vinster"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Leedjeshistorie"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Blief aafspele op d'n achtergrond"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Euver Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Bekieke"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriete"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Zenderinfo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stations gelaaje"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Aafspeel-fout: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Noe aan 't speule: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wier verdergaon: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-autorisatie annulere"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Verbinjing mit Last.fm verbräke"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Verbinje mit Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisatie geannuleerd"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Verbinjing mit Last.fm verbraoke"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Verbinje mit Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kós gein verbinjing make mit Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Gaef toegank in diene browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisatie verlope"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Verbónje mit Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Óntdek mieë es 30.000 geverifieerde radiostations oet de ganse welt"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Gein favoriete"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Markeer zenders mit 'n stèr tiedes 't bekieke om ze hie toe te voege"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stations zeuke…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle taoле"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filter op taol"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle lande"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filter op land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Gein stations"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u van %d stations"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stations: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stations laje"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Gein resultate"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Effe wachte…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Gein stations passe bie dien zeukopdracht"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kos stations neet laje"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Zender"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Labels"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Websiet"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitsnelheid"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Neet aan 't speule"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Kees 'n station"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Aan 't bufferen…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Noe aan 't speule"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Gepauzeerdj"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Opnuuj verbinje…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Zeuke op YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Zeuke mislök: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Gein YouTube-resultate gevonde"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultate neet besjikbaar"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Downloade: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Geannuleerdj"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download mislök: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Opgeslaage: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Leedje downloade"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Download annulere"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nog gein leedjes"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Leedjes versjiene hie es se nao radiostations lústere"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Zonet"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min. geleie"
 msgstr[1] "%d min. geleie"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d oer geleie"
 msgstr[1] "%d oer geleie"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/li.po
+++ b/po/li.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: li\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver blijf radio aafspele nao 't sluten van 't vinster"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Leedjeshistorie"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Blief aafspele op d'n achtergrond"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Euver Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Bekieke"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriete"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Zenderinfo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stations gelaaje"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Aafspeel-fout: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Noe aan 't speule: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wier verdergaon: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-autorisatie annulere"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Verbinjing mit Last.fm verbräke"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Verbinje mit Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisatie geannuleerd"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Verbinjing mit Last.fm verbraoke"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Verbinje mit Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kós gein verbinjing make mit Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Gaef toegank in diene browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisatie verlope"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Verbónje mit Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Óntdek mieë es 30.000 geverifieerde radiostations oet de ganse welt"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Markeer zenders mit 'n stèr tiedes 't bekieke om ze hie toe te voege"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stations zeuke…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle taoле"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filter op taol"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle lande"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filter op land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Gein stations"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u van %d stations"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stations: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stations laje"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Gein resultate"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Effe wachte…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Gein stations passe bie dien zeukopdracht"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kos stations neet laje"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Neet aan 't speule"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Kees 'n station"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Aan 't bufferen…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Noe aan 't speule"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Gepauzeerdj"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Opnuuj verbinje…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Noe aan 't speule"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/lo.po
+++ b/po/lo.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: lo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver ຫຼິ້ນວິທະຍຸຕໍ່ໄປຫຼັງຈາກປິດໜ້າຕ່າງ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ເມນູ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ປະຫວັດເພງ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ຫຼິ້ນຕໍ່ໃນພື້ນຫຼັງ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "ກ່ຽວກັບ Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ຊອກຫາ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ລາຍການໂປດ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ຂໍ້ມູນສະຖານີ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ໂຫລດ %d ສະຖານີແລ້ວ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ຜິດພາດ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ຜິດພາດໃນການຫຼິ້ນ: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ກຳລັງຫຼິ້ນ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ສືບຕໍ່: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "ຍົກເລີກການອະນຸຍາດ Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "ຕັດການເຊື່ອມຕໍ່ຈາກ Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "ເຊື່ອມຕໍ່ກັບ Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "ການອະນຸຍາດ Last.fm ຖືກຍົກເລີກແລ້ວ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "ຕັດການເຊື່ອມຕໍ່ຈາກ Last.fm ແລ້ວ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "ກຳລັງເຊື່ອມຕໍ່ກັບ Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "ເຊື່ອມຕໍ່ກັບ Last.fm ບໍ່ສຳເລັດ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ໃຫ້ສິດເຂົ້າເຖິງໃນບຣາວເຊີຂອງທ່ານ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "ການອະນຸຍາດ Last.fm ໝົດເວລາ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "ເຊື່ອມຕໍ່ກັບ Last.fm ແລ້ວ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ຄົ້ນພົບ 30,000+ ສະຖານີວິທະຍຸທີ່ຢືນຢັນແລ້ວຈາກທົ່ວໂລກ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ບໍ່ມີລາຍການໂປດ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ໃສ່ດາວໃຫ້ສະຖານີຂະນະຊອກຫາເພື່ອເພີ່ມໃສ່ນີ້"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ຊອກຫາສະຖານີ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ທຸກພາສາ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ກອງຕາມພາສາ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ທຸກປະເທດ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ກັ່ນຕອງຕາມປະເທດ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ບໍ່ມີສະຖານີ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ກຳລັງໂຫລດ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ຈາກ %d ສະຖານີ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ສະຖານີ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ກຳລັງໂຫລດສະຖານີ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ບໍ່ມີຜົນ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ກະລຸນາລໍຖ້າ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ບໍ່ມີສະຖານີທີ່ກົງກັບການຊອກຫາຂອງທ່ານ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ບໍ່ສາມາດໂຫລດສະຖານີໄດ້"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ສະຖານີ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ປະເທດ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ປ້າຍ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ເວັບໄຊ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ໂຄເດັກ"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ບິດເຣດ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ສະຕຣີມ"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ບໍ່ໄດ້ຫຼິ້ນ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ເລືອກສະຖານີ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ກຳລັງບັຟເຟີ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ກຳລັງຫຼິ້ນ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ຢຸດຊົ່ວຄາວ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ກຳລັງເຊື່ອมຕໍ່ຄືນ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "ກຳລັງຊອກຫາ YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ການຊອກຫາລົ້ມເຫລວ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "ບໍ່ພົບຜົນ YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ຜົນທັງໝົດບໍ່ສາມາດໃຊ້ໄດ້"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ກຳລັງດາວໂຫລດ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ຍົກເລີກແລ້ວ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ດາວໂຫລດລົ້ມເຫລວ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ບັນທຶກແລ້ວ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ດາວໂຫລດເພງ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ຍົກເລີກດາວໂຫລດ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ຍັງບໍ່ມີເພງ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ເພງຈະປາກົດຢູ່ນີ້ເມື່ອທ່ານຟັງສະຖານີວິທະຍຸ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ຫາກໍ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d ນາທີກ່ອນ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ຊົ່ວໂມງກ່ອນ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/lo.po
+++ b/po/lo.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: lo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver ຫຼິ້ນວິທະຍຸຕໍ່ໄປຫຼັງຈາກປິດໜ້າຕ່າງ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ເມນູ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ປະຫວັດເພງ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ຫຼິ້ນຕໍ່ໃນພື້ນຫຼັງ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "ກ່ຽວກັບ Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ຊອກຫາ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ລາຍການໂປດ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ຂໍ້ມູນສະຖານີ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ໂຫລດ %d ສະຖານີແລ້ວ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ຜິດພາດ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ຜິດພາດໃນການຫຼິ້ນ: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ກຳລັງຫຼິ້ນ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ສືບຕໍ່: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "ຍົກເລີກການອະນຸຍາດ Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "ຕັດການເຊື່ອມຕໍ່ຈາກ Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "ເຊື່ອມຕໍ່ກັບ Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "ການອະນຸຍາດ Last.fm ຖືກຍົກເລີກແລ້ວ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "ຕັດການເຊື່ອມຕໍ່ຈາກ Last.fm ແລ້ວ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "ກຳລັງເຊື່ອມຕໍ່ກັບ Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "ເຊື່ອມຕໍ່ກັບ Last.fm ບໍ່ສຳເລັດ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ໃຫ້ສິດເຂົ້າເຖິງໃນບຣາວເຊີຂອງທ່ານ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "ການອະນຸຍາດ Last.fm ໝົດເວລາ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "ເຊື່ອມຕໍ່ກັບ Last.fm ແລ້ວ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ຄົ້ນພົບ 30,000+ ສະຖານີວິທະຍຸທີ່ຢືນຢັນແລ້ວຈາກທົ່ວໂລກ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ໃສ່ດາວໃຫ້ສະຖານີຂະນະຊອກຫາເພື່ອເພີ່ມໃສ່ນີ້"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ຊອກຫາສະຖານີ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ທຸກພາສາ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ກອງຕາມພາສາ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ທຸກປະເທດ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ກັ່ນຕອງຕາມປະເທດ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ບໍ່ມີສະຖານີ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ກຳລັງໂຫລດ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ຈາກ %d ສະຖານີ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ສະຖານີ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ກຳລັງໂຫລດສະຖານີ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ບໍ່ມີຜົນ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ກະລຸນາລໍຖ້າ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ບໍ່ມີສະຖານີທີ່ກົງກັບການຊອກຫາຂອງທ່ານ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ບໍ່ສາມາດໂຫລດສະຖານີໄດ້"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL ສະຕຣີມ"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ບໍ່ໄດ້ຫຼິ້ນ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ເລືອກສະຖານີ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ກຳລັງບັຟເຟີ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ກຳລັງຫຼິ້ນ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ຢຸດຊົ່ວຄາວ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ກຳລັງເຊື່ອมຕໍ່ຄືນ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ກຳລັງຫຼິ້ນ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/lt.po
+++ b/po/lt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver toliau groja radiją uždarius langą"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meniu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Dainų istorija"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Tęsti grojimą fone"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Apie Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Mėgstami"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stoties informacija"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Įkelta stočių: %d"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Klaida: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Atkūrimo klaida: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Dabar groja: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Tęsiama: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Atšaukti Last.fm autorizaciją"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Atsijungti nuo Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Prisijungti prie Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autorizacija atšaukta"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Atsijungta nuo Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Jungiamasi prie Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nepavyko prisijungti prie Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Suteikite prieigą savo naršyklėje…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autorizacijos laikas baigėsi"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Prisijungta prie Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Atraskite daugiau nei 30 000 patikrintų radijo stočių iš viso pasaulio"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nėra mėgstamų"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Naršydami pažymėkite stotis žvaigždute, kad pridėtumėte jas čia"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Ieškoti stočių…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Visos kalbos"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtruoti pagal kalbą"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Visos šalys"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtruoti pagal šalį"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stočių nėra"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Įkeliama…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u iš %d stočių"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stotys: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Įkeliamos stotys"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Rezultatų nėra"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Palaukite…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nerasta stočių pagal paiešką"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nepavyko įkelti stočių"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stotis"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Šalis"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Žymos"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Svetainė"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodekas"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Pralaidumas"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Srauto URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Negroja"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Pasirinkite stotį"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buferizuojama…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Dabar groja"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pristabdyta"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Jungiamasi iš naujo…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ieškoma YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Paieška nepavyko: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube rezultatų nerasta"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Visi rezultatai nepasiekiami"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Atsisiunčiama: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Atšaukta"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Atsisiuntimas nepavyko: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Išsaugota: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Atsisiųsti dainą"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Atšaukti atsisiuntimą"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Kol kas dainų nėra"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Dainos bus rodomos čia klausantis radijo stočių"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ką tik"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "prieš %d min."
 msgstr[1] "prieš %d min."
 msgstr[2] "prieš %d min."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "prieš %d val."
 msgstr[1] "prieš %d val."
 msgstr[2] "prieš %d val."
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/lt.po
+++ b/po/lt.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "(n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver toliau groja radiją uždarius langą"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meniu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Dainų istorija"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Tęsti grojimą fone"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Apie Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Naršyti"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Mėgstami"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stoties informacija"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Įkelta stočių: %d"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Klaida: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Atkūrimo klaida: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Dabar groja: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Tęsiama: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Atšaukti Last.fm autorizaciją"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Atsijungti nuo Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Prisijungti prie Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autorizacija atšaukta"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Atsijungta nuo Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Jungiamasi prie Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nepavyko prisijungti prie Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Suteikite prieigą savo naršyklėje…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autorizacijos laikas baigėsi"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Prisijungta prie Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Atraskite daugiau nei 30 000 patikrintų radijo stočių iš viso pasaulio"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Naršydami pažymėkite stotis žvaigždute, kad pridėtumėte jas čia"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Ieškoti stočių…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Visos kalbos"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtruoti pagal kalbą"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Visos šalys"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtruoti pagal šalį"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stočių nėra"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Įkeliama…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u iš %d stočių"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stotys: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Įkeliamos stotys"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Rezultatų nėra"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Palaukite…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nerasta stočių pagal paiešką"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nepavyko įkelti stočių"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "Srauto URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Negroja"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Pasirinkite stotį"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buferizuojama…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Dabar groja"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pristabdyta"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Jungiamasi iš naujo…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Dabar groja"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/lv.po
+++ b/po/lv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==0 || (n%100>=11 && n%100<=19) ? 0 : "
 "n%10==1 && n%100!=11 ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver turpina atskaņot radio pēc loga aizvēršanas"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Izvēlne"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Dziesmu vēsture"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Turpināt atskaņošanu fonā"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Par Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Pārlūkot"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Izlase"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stacijas informācija"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Ielādētas %d stacijas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Kļūda: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Atskaņošanas kļūda: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Tagad atskaņo: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Atsākšana: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Atcelt Last.fm autorizāciju"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Atvienoties no Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Pieslēgties Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autorizācija atcelta"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Atvienots no Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Pieslēdzas Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Neizdevās pieslēgties Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Piešķiriet piekļuvi savā pārlūkā…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autorizācijai iestājās noildze"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Pieslēgts Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Atklājiet vairāk nekā 30 000 pārbaudītu radiostaciju no visas pasaules"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nav izlases"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Pārlūkojot atzīmējiet stacijas ar zvaigznīti, lai pievienotu tās šeit"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Meklēt stacijas…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Visas valodas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrēt pēc valodas"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Visas valstis"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrēt pēc valsts"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nav staciju"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ielādē…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u no %d stacijām"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacijas: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ielādē stacijas"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nav rezultātu"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Lūdzu, uzgaidiet…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Neviena stacija neatbilst meklējumam"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Neizdevās ielādēt stacijas"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stacija"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Valsts"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Birkas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Tīmekļa vietne"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeks"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitu pārraides ātrums"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Straumes URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Neatskaņo"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Izvēlieties staciju"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Notiek buferēšana…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Tagad atskaņo"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Apturēts"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Atkārtoti savienojas…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Meklē YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Meklēšana neizdevās: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube rezultāti nav atrasti"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Visi rezultāti nav pieejami"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Lejupielādē: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Atcelts"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Lejupielāde neizdevās: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saglabāts: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Lejupielādēt dziesmu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Atcelt lejupielādi"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Pagaidām nav dziesmu"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Dziesmas parādīsies šeit, klausoties radiostacijas"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Tikko"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "pirms %d min."
 msgstr[1] "pirms %d min."
 msgstr[2] "pirms %d min."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "pirms %d stundas"
 msgstr[1] "pirms %d stundām"
 msgstr[2] "pirms %d stundām"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/lv.po
+++ b/po/lv.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==0 || (n%100>=11 && n%100<=19) ? 0 : "
 "n%10==1 && n%100!=11 ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver turpina atskaņot radio pēc loga aizvēršanas"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Izvēlne"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Dziesmu vēsture"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Turpināt atskaņošanu fonā"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Par Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Pārlūkot"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Izlase"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stacijas informācija"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Ielādētas %d stacijas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Kļūda: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Atskaņošanas kļūda: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Tagad atskaņo: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Atsākšana: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Atcelt Last.fm autorizāciju"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Atvienoties no Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Pieslēgties Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm autorizācija atcelta"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Atvienots no Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Pieslēdzas Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Neizdevās pieslēgties Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Piešķiriet piekļuvi savā pārlūkā…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm autorizācijai iestājās noildze"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Pieslēgts Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Atklājiet vairāk nekā 30 000 pārbaudītu radiostaciju no visas pasaules"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Pārlūkojot atzīmējiet stacijas ar zvaigznīti, lai pievienotu tās šeit"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Meklēt stacijas…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Visas valodas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrēt pēc valodas"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Visas valstis"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrēt pēc valsts"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nav staciju"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ielādē…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u no %d stacijām"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacijas: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ielādē stacijas"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nav rezultātu"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Lūdzu, uzgaidiet…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Neviena stacija neatbilst meklējumam"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Neizdevās ielādēt stacijas"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "Straumes URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Neatskaņo"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Izvēlieties staciju"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Notiek buferēšana…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Tagad atskaņo"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Apturēts"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Atkārtoti savienojas…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Tagad atskaņo"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/mai.po
+++ b/po/mai.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: mai\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "विंडो बन्न भेलाक बादो Receiver रेडियो बजबैत रहैत अछि"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "मेनू"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "गीत इतिहास"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "पृष्ठभूमिमे बजबैत रहू"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver बारे मे"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ब्राउज करू"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "पसंदीदा"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "स्टेशनक जानकारी"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d स्टेशन लोड भेल"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "त्रुटि: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "प्लेबैक त्रुटि: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "एखन बाजि रहल अछि: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "फेर शुरू: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द करू"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm सँ डिस्कनेक्ट करू"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm सँ कनेक्ट करू"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द भेल"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm सँ डिस्कनेक्ट भेल"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm सँ कनेक्ट भऽ रहल अछि…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm सँ कनेक्ट नहिं भऽ सकल"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "अपन ब्राउज़र मे एक्सेस दिअ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरणक समय समाप्त"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm सँ कनेक्ट भेल"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "दुनिया भरि सँ 30,000+ सत्यापित रेडियो स्टेशन खोजू"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "एतय जोड़बा लेल ब्राउज करैत काल स्टेशनकेँ स्टार करू"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "स्टेशन खोजू…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "सभ भाषा"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "भाषा अनुसार फ़िल्टर करू"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "सब देश"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "देशक अनुसार फ़िल्टर"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "कोनो स्टेशन नहि"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "लोड भ' रहल अछि…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d स्टेशन"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "स्टेशन: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "स्टेशन लोड भ' रहल अछि"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "कोनो परिणाम नहि"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "कृपया प्रतीक्षा करू…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "अहाँक खोज सँ कोनो स्टेशन नहि मिललैक"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "स्टेशन लोड नहि भ' सकलैक"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "स्ट्रीम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "नहि बाजि रहल"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "एकटा स्टेशन चुनू"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "बफर भ' रहल अछि…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "एखन बाजि रहल अछि"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "रुकल"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "फेर जुड़ि रहल अछि…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "एखन बाजि रहल अछि"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/mai.po
+++ b/po/mai.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: mai\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "विंडो बन्न भेलाक बादो Receiver रेडियो बजबैत रहैत अछि"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "मेनू"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "गीत इतिहास"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "पृष्ठभूमिमे बजबैत रहू"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver बारे मे"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ब्राउज करू"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "पसंदीदा"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "स्टेशनक जानकारी"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d स्टेशन लोड भेल"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "त्रुटि: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "प्लेबैक त्रुटि: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "एखन बाजि रहल अछि: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "फेर शुरू: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द करू"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm सँ डिस्कनेक्ट करू"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm सँ कनेक्ट करू"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द भेल"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm सँ डिस्कनेक्ट भेल"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm सँ कनेक्ट भऽ रहल अछि…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm सँ कनेक्ट नहिं भऽ सकल"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "अपन ब्राउज़र मे एक्सेस दिअ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरणक समय समाप्त"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm सँ कनेक्ट भेल"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "दुनिया भरि सँ 30,000+ सत्यापित रेडियो स्टेशन खोजू"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "कोनो पसंदीदा नहि"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "एतय जोड़बा लेल ब्राउज करैत काल स्टेशनकेँ स्टार करू"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "स्टेशन खोजू…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "सभ भाषा"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "भाषा अनुसार फ़िल्टर करू"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "सब देश"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "देशक अनुसार फ़िल्टर"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "कोनो स्टेशन नहि"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "लोड भ' रहल अछि…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d स्टेशन"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "स्टेशन: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "स्टेशन लोड भ' रहल अछि"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "कोनो परिणाम नहि"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "कृपया प्रतीक्षा करू…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "अहाँक खोज सँ कोनो स्टेशन नहि मिललैक"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "स्टेशन लोड नहि भ' सकलैक"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "स्टेशन"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "देश"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "टैग"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "कोडेक"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "बिटरेट"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "स्ट्रीम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "नहि बाजि रहल"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "एकटा स्टेशन चुनू"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "बफर भ' रहल अछि…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "एखन बाजि रहल अछि"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "रुकल"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "फेर जुड़ि रहल अछि…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube पर खोजि रहल अछि…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "खोज विफल: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "कोनो YouTube परिणाम नहि भेटल"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "सभ परिणाम अनुपलब्ध"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "डाउनलोड भ' रहल अछि: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "रद्द भेल"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "डाउनलोड विफल: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "सुरक्षित: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "गीत डाउनलोड करू"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "डाउनलोड रद्द करू"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "अखन धरि कोनो गाना नहिं"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "रेडियो स्टेशन सुनैत काल गाना एतय देखाय"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "अखने"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d मिनट पहिने"
 msgstr[1] "%d मिनट पहिने"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d घंटा पहिने"
 msgstr[1] "%d घंटा पहिने"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,1 +1,6 @@
-i18n.gettext(meson.project_name(), preset: 'glib')
+# --add-location=file keeps the source file in comments but drops the volatile
+# line numbers, so routine source edits no longer churn every .po file.
+i18n.gettext(meson.project_name(),
+  preset: 'glib',
+  args: ['--add-location=file'],
+)

--- a/po/mk.po
+++ b/po/mk.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n%10!=1 || n%100==11);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver продолжува да пушта радио по затворањето на прозорецот"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Мени"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Историја на песни"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Продолжи со пуштање во заднина"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "За Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Прелистај"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Омилени"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Информации за станица"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Вчитани %d станици"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Грешка при репродукција: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Сега свири: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Продолжува: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Откажи ја авторизацијата на Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Исклучи се од Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Поврзи се со Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Авторизацијата на Last.fm е откажана"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Исклучено од Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Поврзување со Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Не можеше да се поврзе со Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Дозволете пристап во вашиот прелистувач…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Авторизацијата на Last.fm истече"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Поврзано со Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Откријте над 30.000 потврдени радио станици од целиот свет"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Означете станици со ѕвезда додека прелистувате за да ги додадете тука"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Пребарувај станици…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Сите јазици"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Филтрирај по јазик"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Сите земји"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Филтрирај по земја"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Нема станици"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Вчитување…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u од %d станици"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станици: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Вчитување станици"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Нема резултати"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ве молиме почекајте…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ниту една станица не одговара на вашето пребарување"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Не можеа да се вчитаат станиците"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL на стримот"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Не свири"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Изберете станица"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Се полни меѓумеморија…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Сега свири"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Паузирано"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Повторно поврзување…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Сега свири"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/mk.po
+++ b/po/mk.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n%10!=1 || n%100==11);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver продолжува да пушта радио по затворањето на прозорецот"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Мени"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Историја на песни"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Продолжи со пуштање во заднина"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "За Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Прелистај"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Омилени"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Информации за станица"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Вчитани %d станици"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Грешка при репродукција: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Сега свири: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Продолжува: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Откажи ја авторизацијата на Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Исклучи се од Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Поврзи се со Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Авторизацијата на Last.fm е откажана"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Исклучено од Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Поврзување со Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Не можеше да се поврзе со Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Дозволете пристап во вашиот прелистувач…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Авторизацијата на Last.fm истече"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Поврзано со Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Откријте над 30.000 потврдени радио станици од целиот свет"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Нема омилени"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Означете станици со ѕвезда додека прелистувате за да ги додадете тука"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Пребарувај станици…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Сите јазици"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Филтрирај по јазик"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Сите земји"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Филтрирај по земја"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Нема станици"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Вчитување…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u од %d станици"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станици: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Вчитување станици"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Нема резултати"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ве молиме почекајте…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ниту една станица не одговара на вашето пребарување"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Не можеа да се вчитаат станиците"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станица"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Земја"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Ознаки"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Веб-страница"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрејт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL на стримот"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Не свири"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Изберете станица"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Се полни меѓумеморија…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Сега свири"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Паузирано"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Повторно поврзување…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Пребарување на YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Пребарувањето не успеа: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Не се пронајдени YouTube резултати"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Сите резултати се недостапни"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Преземање: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Откажано"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Преземањето не успеа: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Зачувано: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Преземи песна"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Откажи преземање"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Сè уште нема песни"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Песните ќе се појават тука додека слушате радио станици"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Штотуку"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "пред %d мин."
 msgstr[1] "пред %d мин."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "пред %d час"
 msgstr[1] "пред %d часа"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ml.po
+++ b/po/ml.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ml\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "വിൻഡോ അടച്ചാലും Receiver റേഡിയോ പ്ലേ ചെയ്യുന്നത് തുടരും"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "മെനു"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "പാട്ടിന്റെ ചരിത്രം"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "പശ്ചാത്തലത്തിൽ പ്ലേ ചെയ്യുന്നത് തുടരുക"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver-നെ കുറിച്ച്"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ബ്രൗസ് ചെയ്യുക"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "പ്രിയങ്കരങ്ങൾ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "സ്റ്റേഷൻ വിവരങ്ങൾ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d സ്റ്റേഷനുകൾ ലോഡുചെയ്തു"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "പിശക്: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "പ്ലേബാക്ക് പിശക്: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "പുനരാരംഭിക്കുന്നു: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm അംഗീകാരം റദ്ദാക്കുക"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-ൽ നിന്ന് വിച്ഛേദിക്കുക"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിക്കുക"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm അംഗീകാരം റദ്ദാക്കി"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-ൽ നിന്ന് വിച്ഛേദിച്ചു"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിക്കുന്നു…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിക്കാൻ കഴിഞ്ഞില്ല"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "നിങ്ങളുടെ ബ്രൗസറിൽ ആക്സസ് നൽകുക…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm അംഗീകാര സമയം കഴിഞ്ഞു"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിച്ചു"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ലോകമെമ്പാടുമുള്ള 30,000-ത്തിലധികം സ്ഥിരീകരിച്ച റേഡിയോ സ്റ്റേഷനുകൾ കണ്ടെത്തുക"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ഇവിടെ ചേർക്കാൻ ബ്രൗസ് ചെയ്യുമ്പോൾ സ്റ്റേഷനുകൾക്ക് നക്ഷത്രം നൽകുക"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "സ്റ്റേഷനുകൾ തിരയുക…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "എല്ലാ ഭാഷകളും"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ഭാഷ അനുസരിച്ച് ഫിൽട്ടർ ചെയ്യുക"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "എല്ലാ രാജ്യങ്ങളും"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "രാജ്യം അനുസരിച്ച് ഫിൽട്ടർ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "സ്റ്റേഷനുകളില്ല"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ലോഡ് ചെയ്യുന്നു…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d സ്റ്റേഷനുകൾ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "സ്റ്റേഷനുകൾ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "സ്റ്റേഷനുകൾ ലോഡ് ചെയ്യുന്നു"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ഫലങ്ങളില്ല"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ദയവായി കാത്തിരിക്കൂ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "നിങ്ങളുടെ തിരയലിന് യാതൊരു സ്റ്റേഷനും പൊരുത്തപ്പെടുന്നില്ല"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "സ്റ്റേഷനുകൾ ലോഡ് ചെയ്യാനായില്ല"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "സ്ട്രീം URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "പ്ലേ ചെയ്യുന്നില്ല"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ഒരു സ്റ്റേഷൻ തിരഞ്ഞെടുക്കുക"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ബഫർ ചെയ്യുന്നു…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "താൽക്കാലികമായി നിർത്തി"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "വീണ്ടും കണക്റ്റ് ചെയ്യുന്നു…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ml.po
+++ b/po/ml.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ml\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "വിൻഡോ അടച്ചാലും Receiver റേഡിയോ പ്ലേ ചെയ്യുന്നത് തുടരും"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "മെനു"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "പാട്ടിന്റെ ചരിത്രം"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "പശ്ചാത്തലത്തിൽ പ്ലേ ചെയ്യുന്നത് തുടരുക"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver-നെ കുറിച്ച്"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ബ്രൗസ് ചെയ്യുക"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "പ്രിയങ്കരങ്ങൾ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "സ്റ്റേഷൻ വിവരങ്ങൾ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d സ്റ്റേഷനുകൾ ലോഡുചെയ്തു"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "പിശക്: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "പ്ലേബാക്ക് പിശക്: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "പുനരാരംഭിക്കുന്നു: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm അംഗീകാരം റദ്ദാക്കുക"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-ൽ നിന്ന് വിച്ഛേദിക്കുക"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിക്കുക"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm അംഗീകാരം റദ്ദാക്കി"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-ൽ നിന്ന് വിച്ഛേദിച്ചു"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിക്കുന്നു…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിക്കാൻ കഴിഞ്ഞില്ല"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "നിങ്ങളുടെ ബ്രൗസറിൽ ആക്സസ് നൽകുക…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm അംഗീകാര സമയം കഴിഞ്ഞു"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-ലേക്ക് ബന്ധിപ്പിച്ചു"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ലോകമെമ്പാടുമുള്ള 30,000-ത്തിലധികം സ്ഥിരീകരിച്ച റേഡിയോ സ്റ്റേഷനുകൾ കണ്ടെത്തുക"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "പ്രിയങ്കരങ്ങൾ ഇല്ല"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ഇവിടെ ചേർക്കാൻ ബ്രൗസ് ചെയ്യുമ്പോൾ സ്റ്റേഷനുകൾക്ക് നക്ഷത്രം നൽകുക"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "സ്റ്റേഷനുകൾ തിരയുക…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "എല്ലാ ഭാഷകളും"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ഭാഷ അനുസരിച്ച് ഫിൽട്ടർ ചെയ്യുക"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "എല്ലാ രാജ്യങ്ങളും"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "രാജ്യം അനുസരിച്ച് ഫിൽട്ടർ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "സ്റ്റേഷനുകളില്ല"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ലോഡ് ചെയ്യുന്നു…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d സ്റ്റേഷനുകൾ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "സ്റ്റേഷനുകൾ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "സ്റ്റേഷനുകൾ ലോഡ് ചെയ്യുന്നു"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ഫലങ്ങളില്ല"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ദയവായി കാത്തിരിക്കൂ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "നിങ്ങളുടെ തിരയലിന് യാതൊരു സ്റ്റേഷനും പൊരുത്തപ്പെടുന്നില്ല"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "സ്റ്റേഷനുകൾ ലോഡ് ചെയ്യാനായില്ല"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "സ്റ്റേഷൻ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "രാജ്യം"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ടാഗുകൾ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "വെബ്‌സൈറ്റ്"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "കോഡെക്"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ബിറ്റ്‌റേറ്റ്"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "സ്ട്രീം URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "പ്ലേ ചെയ്യുന്നില്ല"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ഒരു സ്റ്റേഷൻ തിരഞ്ഞെടുക്കുക"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ബഫർ ചെയ്യുന്നു…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ഇപ്പോൾ പ്ലേ ചെയ്യുന്നു"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "താൽക്കാലികമായി നിർത്തി"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "വീണ്ടും കണക്റ്റ് ചെയ്യുന്നു…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-ൽ തിരയുന്നു…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "തിരയൽ പരാജയപ്പെട്ടു: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ഫലങ്ങളൊന്നും കണ്ടെത്തിയില്ല"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "എല്ലാ ഫലങ്ങളും ലഭ്യമല്ല"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ഡൗൺലോഡ് ചെയ്യുന്നു: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "റദ്ദാക്കി"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ഡൗൺലോഡ് പരാജയപ്പെട്ടു: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "സേവ് ചെയ്തു: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "പാട്ട് ഡൗൺലോഡ് ചെയ്യുക"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ഡൗൺലോഡ് റദ്ദാക്കുക"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ഇതുവരെ പാട്ടുകൾ ഇല്ല"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "റേഡിയോ സ്റ്റേഷനുകൾ കേൾക്കുമ്പോൾ പാട്ടുകൾ ഇവിടെ കാണിക്കും"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ഇപ്പോൾ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d മിനിറ്റ് മുമ്പ്"
 msgstr[1] "%d മിനിറ്റ് മുമ്പ്"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d മണിക്കൂർ മുമ്പ്"
 msgstr[1] "%d മണിക്കൂർ മുമ്പ്"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/mn.po
+++ b/po/mn.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: mn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Цонхыг хаасны дараа ч Receiver радиог тоглуулсаар байна"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Цэс"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Дууны түүх"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Дэвсгэрт тоглуулсаар байх"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver-ийн тухай"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Үзэх"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Дуртай"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Станцын мэдээлэл"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станц ачаалагдлаа"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Алдаа: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Тоглуулах алдаа: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Одоо тоглож байна: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Үргэлжлүүлэх: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm зөвшөөрлийг цуцлах"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-ээс салах"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-д холбогдох"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm зөвшөөрөл цуцлагдлаа"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-ээс салагдлаа"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-д холбогдож байна…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-д холбогдож чадсангүй"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Хөтчөөсөө хандалт олгоно уу…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm зөвшөөрлийн хугацаа дууслаа"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-д холбогдлоо"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Дэлхийн өнцөг булан бүрээс 30,000+ баталгаажсан радио станц олоорой"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Дуртай байхгүй"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Энд нэмэхийн тулд үзэх үедээ станцуудад од тэмдэглэ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Станцуудыг хайх…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Бүх хэл"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Хэлээр шүүх"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Бүх улсууд"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Улсаар шүүх"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Станц байхгүй"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ачааллаж байна…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станц"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцууд: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Станцуудыг ачааллаж байна"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Үр дүн байхгүй"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Түр хүлээнэ үү…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Таны хайлтад тохирох станц олдсонгүй"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Станцуудыг ачаалж чадсангүй"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станц"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Улс"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Шошго"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Вэб сайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битийн хурд"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Урсгалын URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Тоглохгүй байна"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Станц сонгоно уу"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буфердэж байна…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Одоо тоглож байна"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Түр зогссон"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Дахин холбогдож байна…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube дээр хайж байна…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Хайлт амжилтгүй: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube үр дүн олдсонгүй"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Бүх үр дүн боломжгүй"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Татаж байна: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Цуцлагдсан"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Татаж авах амжилтгүй: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Хадгалагдсан: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Дуу татах"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Татаж авахыг цуцлах"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Одоогоор дуу алга"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Радио станц сонсож байхад дуунууд энд харагдана"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Дөнгөж сая"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d мин өмнө"
 msgstr[1] "%d мин өмнө"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d цаг өмнө"
 msgstr[1] "%d цаг өмнө"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/mn.po
+++ b/po/mn.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: mn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Цонхыг хаасны дараа ч Receiver радиог тоглуулсаар байна"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Цэс"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Дууны түүх"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Дэвсгэрт тоглуулсаар байх"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver-ийн тухай"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Үзэх"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Дуртай"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Станцын мэдээлэл"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станц ачаалагдлаа"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Алдаа: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Тоглуулах алдаа: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Одоо тоглож байна: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Үргэлжлүүлэх: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm зөвшөөрлийг цуцлах"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-ээс салах"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-д холбогдох"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm зөвшөөрөл цуцлагдлаа"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-ээс салагдлаа"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-д холбогдож байна…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-д холбогдож чадсангүй"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Хөтчөөсөө хандалт олгоно уу…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm зөвшөөрлийн хугацаа дууслаа"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-д холбогдлоо"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Дэлхийн өнцөг булан бүрээс 30,000+ баталгаажсан радио станц олоорой"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Энд нэмэхийн тулд үзэх үедээ станцуудад од тэмдэглэ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Станцуудыг хайх…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Бүх хэл"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Хэлээр шүүх"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Бүх улсууд"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Улсаар шүүх"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Станц байхгүй"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ачааллаж байна…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станц"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцууд: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Станцуудыг ачааллаж байна"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Үр дүн байхгүй"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Түр хүлээнэ үү…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Таны хайлтад тохирох станц олдсонгүй"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Станцуудыг ачаалж чадсангүй"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Урсгалын URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Тоглохгүй байна"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Станц сонгоно уу"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буфердэж байна…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Одоо тоглож байна"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Түр зогссон"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Дахин холбогдож байна…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Одоо тоглож байна"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/mr.po
+++ b/po/mr.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "विंडो बंद केल्यानंतरही Receiver रेडिओ वाजवत राहते"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "मेनू"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "गाण्याचा इतिहास"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "पार्श्वभूमीत वाजवत राहा"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver बद्दल"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ब्राउझ करा"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "आवडते"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "स्टेशन माहिती"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d स्टेशन लोड झाले"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "त्रुटी: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "प्लेबॅक त्रुटी: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "आत्ता वाजत आहे: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "पुन्हा सुरू होत आहे: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द करा"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm वरून डिस्कनेक्ट करा"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm शी कनेक्ट करा"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द झाले"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm वरून डिस्कनेक्ट झाले"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm शी कनेक्ट होत आहे…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm शी कनेक्ट होऊ शकले नाही"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "तुमच्या ब्राउझरमध्ये प्रवेश द्या…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरणाची वेळ संपली"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm शी कनेक्ट झाले"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "जगभरातील 30,000+ सत्यापित रेडिओ स्टेशन शोधा"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "येथे जोडण्यासाठी ब्राउझ करताना स्टेशन्सना स्टार करा"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "स्टेशन शोधा…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "सर्व भाषा"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "भाषेनुसार फिल्टर करा"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "सर्व देश"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "देशानुसार फिल्टर"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "कोणताही स्टेशन नाही"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "लोड होत आहे…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d स्टेशन"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "स्टेशन: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "स्टेशन लोड होत आहेत"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "कोणताही परिणाम नाही"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "कृपया प्रतीक्षा करा…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "तुमच्या शोधाशी कोणताही स्टेशन जुळत नाही"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "स्टेशन लोड करता आले नाहीत"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "स्ट्रीम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "वाजत नाही"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "एक स्टेशन निवडा"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "बफर होत आहे…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "आत्ता वाजत आहे"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "थांबवले"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "पुन्हा जोडले जात आहे…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "आत्ता वाजत आहे"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/mr.po
+++ b/po/mr.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: mr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "विंडो बंद केल्यानंतरही Receiver रेडिओ वाजवत राहते"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "मेनू"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "गाण्याचा इतिहास"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "पार्श्वभूमीत वाजवत राहा"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver बद्दल"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ब्राउझ करा"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "आवडते"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "स्टेशन माहिती"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d स्टेशन लोड झाले"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "त्रुटी: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "प्लेबॅक त्रुटी: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "आत्ता वाजत आहे: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "पुन्हा सुरू होत आहे: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द करा"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm वरून डिस्कनेक्ट करा"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm शी कनेक्ट करा"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द झाले"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm वरून डिस्कनेक्ट झाले"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm शी कनेक्ट होत आहे…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm शी कनेक्ट होऊ शकले नाही"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "तुमच्या ब्राउझरमध्ये प्रवेश द्या…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरणाची वेळ संपली"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm शी कनेक्ट झाले"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "जगभरातील 30,000+ सत्यापित रेडिओ स्टेशन शोधा"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "आवडते नाही"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "येथे जोडण्यासाठी ब्राउझ करताना स्टेशन्सना स्टार करा"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "स्टेशन शोधा…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "सर्व भाषा"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "भाषेनुसार फिल्टर करा"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "सर्व देश"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "देशानुसार फिल्टर"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "कोणताही स्टेशन नाही"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "लोड होत आहे…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d स्टेशन"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "स्टेशन: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "स्टेशन लोड होत आहेत"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "कोणताही परिणाम नाही"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "कृपया प्रतीक्षा करा…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "तुमच्या शोधाशी कोणताही स्टेशन जुळत नाही"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "स्टेशन लोड करता आले नाहीत"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "स्टेशन"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "देश"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "टॅग्ज"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "कोडेक"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "बिटरेट"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "स्ट्रीम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "वाजत नाही"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "एक स्टेशन निवडा"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "बफर होत आहे…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "आत्ता वाजत आहे"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "थांबवले"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "पुन्हा जोडले जात आहे…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube वर शोधत आहे…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "शोध अयशस्वी: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube परिणाम आढळले नाहीत"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "सर्व परिणाम अनुपलब्ध"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "डाउनलोड होत आहे: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "रद्द केले"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "डाउनलोड अयशस्वी: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "जतन केले: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "गाणे डाउनलोड करा"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "डाउनलोड रद्द करा"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "अजून कोणतीही गाणी नाहीत"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "तुम्ही रेडिओ स्टेशन ऐकत असताना गाणी येथे दिसतील"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "आत्ताच"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d मिनिटांपूर्वी"
 msgstr[1] "%d मिनिटांपूर्वी"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d तासापूर्वी"
 msgstr[1] "%d तासांपूर्वी"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ms.po
+++ b/po/ms.po
@@ -3,311 +3,309 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver terus memainkan radio selepas tetingkap ditutup"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Sejarah Lagu"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Terus mainkan di latar belakang"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Tentang Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Layari"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Kegemaran"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Maklumat stesen"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stesen dimuatkan"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Ralat: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ralat main balik: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sedang dimainkan: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Menyambung semula: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Batalkan kebenaran Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Putuskan sambungan dari Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Sambung ke Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Kebenaran Last.fm dibatalkan"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Terputus dari Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Menyambung ke Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Gagal menyambung ke Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Berikan akses di pelayar anda…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Kebenaran Last.fm telah luput"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Disambungkan ke Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Temui 30,000+ stesen radio yang disahkan dari seluruh dunia"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Tiada kegemaran"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Tandai bintang pada stesen semasa melayari untuk menambahkannya di sini"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cari stesen…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Semua bahasa"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Tapis mengikut bahasa"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Semua negara"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Tapis mengikut negara"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Tiada stesen"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Memuatkan…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u daripada %d stesen"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stesen: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Memuatkan stesen"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Tiada keputusan"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Sila tunggu…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Tiada stesen sepadan dengan carian anda"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Tidak dapat memuatkan stesen"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stesen"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Negara"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tag"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Laman web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Kadar bit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL strim"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Tidak dimainkan"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Pilih stesen"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Menimbal…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Sedang dimainkan"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Dijeda"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Menyambung semula…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Mencari di YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Carian gagal: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Tiada keputusan YouTube ditemui"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Semua keputusan tidak tersedia"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Memuat turun: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Dibatalkan"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Muat turun gagal: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Disimpan: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Muat turun lagu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Batal muat turun"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Tiada Lagu Lagi"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Lagu akan muncul di sini semasa anda mendengar stesen radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Baru sahaja"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min lalu"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d jam lalu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ms.po
+++ b/po/ms.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ms\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver terus memainkan radio selepas tetingkap ditutup"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Sejarah Lagu"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Terus mainkan di latar belakang"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Tentang Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Layari"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Kegemaran"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Maklumat stesen"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stesen dimuatkan"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Ralat: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ralat main balik: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sedang dimainkan: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Menyambung semula: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Batalkan kebenaran Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Putuskan sambungan dari Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Sambung ke Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Kebenaran Last.fm dibatalkan"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Terputus dari Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Menyambung ke Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Gagal menyambung ke Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Berikan akses di pelayar anda…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Kebenaran Last.fm telah luput"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Disambungkan ke Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Temui 30,000+ stesen radio yang disahkan dari seluruh dunia"
 
@@ -114,64 +122,65 @@ msgstr "Tiada kegemaran"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Tandai bintang pada stesen semasa melayari untuk menambahkannya di sini"
+msgstr ""
+"Tandai bintang pada stesen semasa melayari untuk menambahkannya di sini"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cari stesen…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Semua bahasa"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Tapis mengikut bahasa"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Semua negara"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Tapis mengikut negara"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Tiada stesen"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Memuatkan…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u daripada %d stesen"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stesen: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Memuatkan stesen"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Tiada keputusan"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Sila tunggu…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Tiada stesen sepadan dengan carian anda"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Tidak dapat memuatkan stesen"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL strim"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Tidak dimainkan"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Pilih stesen"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Menimbal…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Sedang dimainkan"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Dijeda"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Menyambung semula…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Sedang dimainkan"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/my.po
+++ b/po/my.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ဝင်းဒိုးပိတ်ပြီးနောက်လည်း Receiver က ရေဒီယိုကို ဆက်ဖွင့်ထားသည်"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "မီနူး"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "သီချင်းမှတ်တမ်း"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "နောက်ခံတွင် ဆက်ဖွင့်ပါ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver အကြောင်း"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ရှာဖွေ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "အကြိုက်များ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ဘူတာအချက်အလက်"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ဘူတာ %d ခု ဖွင့်ပြီး"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "အမှား: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ပြန်ဖွင့်ရာ အမှား: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ယခုဖွင့်နေသည်: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ပြန်လည်စတင်: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ခွင့်ပြုချက် ပယ်ဖျက်ရန်"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm မှ ချိတ်ဆက်မှုဖြုတ်ရန်"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm သို့ ချိတ်ဆက်ရန်"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ခွင့်ပြုချက် ပယ်ဖျက်ပြီးပါပြီ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm မှ ချိတ်ဆက်မှု ဖြုတ်ပြီးပါပြီ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm သို့ ချိတ်ဆက်နေသည်…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm သို့ ချိတ်ဆက်၍ မရပါ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "သင့်ဘရောက်ဆာတွင် ခွင့်ပြုပါ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ခွင့်ပြုချက် အချိန်ကုန်ပါပြီ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm သို့ ချိတ်ဆက်ပြီးပါပြီ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ကမ္ဘာအနှံ့ရှိ စစ်ဆေးပြီး ရေဒီယိုအသံလွှင့်ဌာန 30,000+ ကို ရှာဖွေပါ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "အကြိုက်များ မရှိပါ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ဤနေရာတွင် ထည့်ရန် ရှာဖွေနေစဉ် ဘူတာများကို ကြယ်ခြစ်ပါ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ဘူတာများ ရှာဖွေပါ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ဘာသာစကားအားလုံး"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ဘာသာစကားအလိုက် စစ်ထုတ်"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "နိုင်ငံအားလုံး"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "နိုင်ငံအလိုက် စစ်ထုတ်ပါ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ဘူတာမရှိ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ဖွင့်နေသည်…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ဘူတာ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ဘူတာများ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ဘူတာများ ဖွင့်နေသည်"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ရလဒ်မရှိ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ကျေးဇူးပြု၍ စောင့်ပါ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "သင့်ရှာဖွေမှုနှင့် ကိုက်ညီသော ဘူတာမရှိ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ဘူတာများ ဖွင့်၍မရပါ"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ဘူတာ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "နိုင်ငံ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "တဂ်များ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ဝဘ်ဆိုဒ်"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ကုဒ်ဒက်"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ဘစ်နှုန်း"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "စထရိမ် URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ဖွင့်မနေပါ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ဘူတာတစ်ခု ရွေးပါ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ဘာဖာလုပ်နေသည်…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ယခုဖွင့်နေသည်"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ခေတ္တရပ်"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ပြန်ချိတ်ဆက်နေသည်…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube တွင်ရှာဖွေနေသည်…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ရှာဖွေမှုမအောင်မြင်: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ရလဒ်မတွေ့ပါ"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ရလဒ်အားလုံး မရရှိနိုင်"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ဒေါင်းလုပ်နေသည်: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ပယ်ဖျက်ပြီး"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ဒေါင်းလုပ်မအောင်မြင်: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "သိမ်းပြီး: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "သီချင်းဒေါင်းလုပ်"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ဒေါင်းလုပ်ပယ်ဖျက်"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "သီချင်းများ မရှိသေးပါ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ရေဒီယိုအသံလွှင့်ဌာနများကို နားဆင်နေစဉ် သီချင်းများ ဤနေရာတွင် ပေါ်လာပါမည်"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ယခုလေးတင်"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d မိနစ်အကြာ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d နာရီအကြာ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/my.po
+++ b/po/my.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ဝင်းဒိုးပိတ်ပြီးနောက်လည်း Receiver က ရေဒီယိုကို ဆက်ဖွင့်ထားသည်"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "မီနူး"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "သီချင်းမှတ်တမ်း"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "နောက်ခံတွင် ဆက်ဖွင့်ပါ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver အကြောင်း"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ရှာဖွေ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "အကြိုက်များ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ဘူတာအချက်အလက်"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ဘူတာ %d ခု ဖွင့်ပြီး"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "အမှား: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ပြန်ဖွင့်ရာ အမှား: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ယခုဖွင့်နေသည်: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ပြန်လည်စတင်: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ခွင့်ပြုချက် ပယ်ဖျက်ရန်"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm မှ ချိတ်ဆက်မှုဖြုတ်ရန်"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm သို့ ချိတ်ဆက်ရန်"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ခွင့်ပြုချက် ပယ်ဖျက်ပြီးပါပြီ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm မှ ချိတ်ဆက်မှု ဖြုတ်ပြီးပါပြီ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm သို့ ချိတ်ဆက်နေသည်…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm သို့ ချိတ်ဆက်၍ မရပါ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "သင့်ဘရောက်ဆာတွင် ခွင့်ပြုပါ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ခွင့်ပြုချက် အချိန်ကုန်ပါပြီ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm သို့ ချိတ်ဆက်ပြီးပါပြီ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ကမ္ဘာအနှံ့ရှိ စစ်ဆေးပြီး ရေဒီယိုအသံလွှင့်ဌာန 30,000+ ကို ရှာဖွေပါ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ဤနေရာတွင် ထည့်ရန် ရှာဖွေနေစဉ် ဘူတာများကို ကြယ်ခြစ်ပါ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ဘူတာများ ရှာဖွေပါ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ဘာသာစကားအားလုံး"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ဘာသာစကားအလိုက် စစ်ထုတ်"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "နိုင်ငံအားလုံး"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "နိုင်ငံအလိုက် စစ်ထုတ်ပါ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ဘူတာမရှိ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ဖွင့်နေသည်…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ဘူတာ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ဘူတာများ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ဘူတာများ ဖွင့်နေသည်"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ရလဒ်မရှိ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ကျေးဇူးပြု၍ စောင့်ပါ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "သင့်ရှာဖွေမှုနှင့် ကိုက်ညီသော ဘူတာမရှိ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ဘူတာများ ဖွင့်၍မရပါ"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "စထရိမ် URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ဖွင့်မနေပါ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ဘူတာတစ်ခု ရွေးပါ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ဘာဖာလုပ်နေသည်…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ယခုဖွင့်နေသည်"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ခေတ္တရပ်"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ပြန်ချိတ်ဆက်နေသည်…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ယခုဖွင့်နေသည်"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/nb.po
+++ b/po/nb.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver fortsetter å spille radio etter at vinduet er lukket"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meny"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Sanghistorikk"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Fortsett å spille i bakgrunnen"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritter"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stasjonsinformasjon"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasjoner lastet"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Feil: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Avspillingsfeil: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spiller nå: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Gjenopptar: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Avbryt Last.fm-autorisering"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Koble fra Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Koble til Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisering avbrutt"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Koblet fra Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Kobler til Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kunne ikke koble til Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Gi tilgang i nettleseren din…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisering utløpt"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Koblet til Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Oppdag over 30 000 verifiserte radiostasjoner fra hele verden"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Merk stasjoner med stjerne mens du blar for å legge dem til her"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Søk etter stasjoner…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle språk"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrer etter språk"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle land"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrer etter land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ingen stasjoner"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laster…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d stasjoner"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasjoner: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Laster stasjoner"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ingen resultater"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vennligst vent…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ingen stasjoner samsvarer med søket ditt"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kunne ikke laste stasjoner"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Strøm-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Spiller ikke"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Velg en stasjon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufrer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Spiller nå"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Satt på pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Kobler til på nytt…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Spiller nå"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/nb.po
+++ b/po/nb.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: nb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver fortsetter å spille radio etter at vinduet er lukket"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meny"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Sanghistorikk"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Fortsett å spille i bakgrunnen"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritter"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stasjonsinformasjon"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasjoner lastet"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Feil: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Avspillingsfeil: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spiller nå: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Gjenopptar: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Avbryt Last.fm-autorisering"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Koble fra Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Koble til Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisering avbrutt"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Koblet fra Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Kobler til Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kunne ikke koble til Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Gi tilgang i nettleseren din…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisering utløpt"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Koblet til Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Oppdag over 30 000 verifiserte radiostasjoner fra hele verden"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ingen favoritter"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Merk stasjoner med stjerne mens du blar for å legge dem til her"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Søk etter stasjoner…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle språk"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrer etter språk"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle land"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrer etter land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ingen stasjoner"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laster…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d stasjoner"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasjoner: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Laster stasjoner"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ingen resultater"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vennligst vent…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ingen stasjoner samsvarer med søket ditt"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kunne ikke laste stasjoner"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stasjon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Merkelapper"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Nettsted"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bithastighet"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Strøm-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Spiller ikke"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Velg en stasjon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufrer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Spiller nå"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Satt på pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Kobler til på nytt…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Søker på YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Søk mislyktes: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ingen YouTube-resultater funnet"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultater utilgjengelige"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Laster ned: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Avbrutt"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Nedlasting mislyktes: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Lagret: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Last ned sang"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Avbryt nedlasting"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ingen sanger ennå"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Sanger vises her mens du lytter til radiostasjoner"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Akkurat nå"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min siden"
 msgstr[1] "%d min siden"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d time siden"
 msgstr[1] "%d timer siden"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/nds.po
+++ b/po/nds.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: nds\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver speelt Radio wieder, nadem dat Finster tomaakt is"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Leederverlööp"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "In'n Achtergrund wiederspelen"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Över Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Dörkieken"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Leevsten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Senderinfo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d Statschonen laadt"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspeel-Fehler: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Speelt nu: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wiedergaav: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-Genehmigung afbreken"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Vun Last.fm aftrennen"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Mit Last.fm verbinnen"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-Genehmigung afbraken"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Vun Last.fm aftrennt"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Verbinnt mit Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kunn nich mit Last.fm verbinnen"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Geev Togriep in dien Browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-Genehmigung aflopen"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Mit Last.fm verbunnen"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Entdeck mehr as 30.000 prööft Radiosenders ut de ganze Welt"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Keen Leevsten"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Markeer Senders mit en Steern bi't Dörkieken, üm ehr hier totofögen"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Statschonen söken…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "All Spraken"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Na Spraak filtern"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle Länner"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Na Land filtern"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Keen Statschonen"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laadt…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u vun %d Statschonen"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Statschonen: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Statschonen warrt laadt"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Keen Resultaten"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Bitte töven…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Keen Statschonen passt to dien Söök"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kunn Statschonen nich laden"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Sender"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Teken"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Websteed"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Speelt nich"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Wähl en Statschoon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "An't Puffern…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Speelt nu"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Paus"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Verbinnen wedder…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Söken op YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Söök hett nich klappt: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Keen YouTube-Resultaten funnen"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "All Resultaten nich to hebben"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Daaladen: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Afbroken"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Daalladen hett nich klappt: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Speekert: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Leed daaladen"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Daalladen afbreken"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Noch keen Leeder"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Leeder wiest sik hier, wenn du Radiosenders tohöörst"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Jüst nu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "vör %d Min."
 msgstr[1] "vör %d Min."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "vör %d Stünn"
 msgstr[1] "vör %d Stünnen"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/nds.po
+++ b/po/nds.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: nds\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver speelt Radio wieder, nadem dat Finster tomaakt is"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Leederverlööp"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "In'n Achtergrund wiederspelen"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Över Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Dörkieken"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Leevsten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Senderinfo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d Statschonen laadt"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fehler: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspeel-Fehler: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Speelt nu: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wiedergaav: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-Genehmigung afbreken"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Vun Last.fm aftrennen"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Mit Last.fm verbinnen"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-Genehmigung afbraken"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Vun Last.fm aftrennt"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Verbinnt mit Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kunn nich mit Last.fm verbinnen"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Geev Togriep in dien Browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-Genehmigung aflopen"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Mit Last.fm verbunnen"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Entdeck mehr as 30.000 prööft Radiosenders ut de ganze Welt"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Markeer Senders mit en Steern bi't Dörkieken, üm ehr hier totofögen"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Statschonen söken…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "All Spraken"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Na Spraak filtern"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle Länner"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Na Land filtern"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Keen Statschonen"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laadt…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u vun %d Statschonen"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Statschonen: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Statschonen warrt laadt"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Keen Resultaten"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Bitte töven…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Keen Statschonen passt to dien Söök"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kunn Statschonen nich laden"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Speelt nich"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Wähl en Statschoon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "An't Puffern…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Speelt nu"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Paus"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Verbinnen wedder…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Speelt nu"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ne.po
+++ b/po/ne.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "विन्डो बन्द भएपछि पनि Receiver ले रेडियो बजाउन जारी राख्छ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "मेनु"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "गीत इतिहास"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "पृष्ठभूमिमा बजाउन जारी राख्नुहोस्"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver बारेमा"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ब्राउज गर्नुहोस्"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "मनपर्ने"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "स्टेशन जानकारी"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d स्टेशनहरू लोड भए"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "त्रुटि: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "प्लेब्याक त्रुटि: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "अहिले बजिरहेको छ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "पुनः सुरु हुँदैछ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द गर्नुहोस्"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm बाट विच्छेद गर्नुहोस्"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm मा जडान गर्नुहोस्"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द भयो"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm बाट विच्छेद भयो"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm मा जडान गर्दै…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm मा जडान हुन सकेन"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "तपाईंको ब्राउजरमा पहुँच दिनुहोस्…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरण समयसीमा समाप्त"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm मा जडान भयो"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "विश्वभरबाट 30,000+ प्रमाणित रेडियो स्टेशनहरू पत्ता लगाउनुहोस्"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "कुनै मनपर्ने छैन"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "यहाँ थप्न ब्राउज गर्दा स्टेशनहरूमा तारा लगाउनुहोस्"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "स्टेशनहरू खोज्नुहोस्…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "सबै भाषाहरू"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "भाषा अनुसार फिल्टर गर्नुहोस्"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "सबै देशहरू"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "देश अनुसार फिल्टर"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "कुनै स्टेशन छैन"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "लोड हुँदैछ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d स्टेशनहरू"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "स्टेशनहरू: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "स्टेशनहरू लोड हुँदैछ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "कुनै परिणाम छैन"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "कृपया पर्खनुहोस्…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "तपाईंको खोजसँग कुनै स्टेशन मेल खाँदैन"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "स्टेशनहरू लोड गर्न सकिएन"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "स्टेशन"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "देश"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ट्यागहरू"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "वेबसाइट"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "कोडेक"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "बिटरेट"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "स्ट्रिम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "बजिरहेको छैन"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "एउटा स्टेशन छान्नुहोस्"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "बफर हुँदैछ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "अहिले बजिरहेको छ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "रोकिएको"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "पुनः जडान हुँदैछ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube मा खोजिँदैछ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "खोज असफल: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube परिणामहरू फेला परेनन्"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "सबै परिणामहरू उपलब्ध छैनन्"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "डाउनलोड हुँदैछ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "रद्द गरियो"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "डाउनलोड असफल: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "सुरक्षित गरियो: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "गीत डाउनलोड गर्नुहोस्"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "डाउनलोड रद्द गर्नुहोस्"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "अहिलेसम्म कुनै गीत छैन"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "रेडियो स्टेशनहरू सुन्दा गीतहरू यहाँ देखिनेछन्"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "अहिले भर्खरै"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d मिनेट अघि"
 msgstr[1] "%d मिनेट अघि"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d घण्टा अघि"
 msgstr[1] "%d घण्टा अघि"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ne.po
+++ b/po/ne.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ne\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "विन्डो बन्द भएपछि पनि Receiver ले रेडियो बजाउन जारी राख्छ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "मेनु"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "गीत इतिहास"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "पृष्ठभूमिमा बजाउन जारी राख्नुहोस्"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver बारेमा"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ब्राउज गर्नुहोस्"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "मनपर्ने"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "स्टेशन जानकारी"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d स्टेशनहरू लोड भए"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "त्रुटि: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "प्लेब्याक त्रुटि: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "अहिले बजिरहेको छ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "पुनः सुरु हुँदैछ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm प्राधिकरण रद्द गर्नुहोस्"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm बाट विच्छेद गर्नुहोस्"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm मा जडान गर्नुहोस्"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm प्राधिकरण रद्द भयो"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm बाट विच्छेद भयो"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm मा जडान गर्दै…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm मा जडान हुन सकेन"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "तपाईंको ब्राउजरमा पहुँच दिनुहोस्…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm प्राधिकरण समयसीमा समाप्त"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm मा जडान भयो"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "विश्वभरबाट 30,000+ प्रमाणित रेडियो स्टेशनहरू पत्ता लगाउनुहोस्"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "यहाँ थप्न ब्राउज गर्दा स्टेशनहरूमा तारा लगाउनुहोस्"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "स्टेशनहरू खोज्नुहोस्…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "सबै भाषाहरू"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "भाषा अनुसार फिल्टर गर्नुहोस्"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "सबै देशहरू"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "देश अनुसार फिल्टर"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "कुनै स्टेशन छैन"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "लोड हुँदैछ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d स्टेशनहरू"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "स्टेशनहरू: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "स्टेशनहरू लोड हुँदैछ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "कुनै परिणाम छैन"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "कृपया पर्खनुहोस्…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "तपाईंको खोजसँग कुनै स्टेशन मेल खाँदैन"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "स्टेशनहरू लोड गर्न सकिएन"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "स्ट्रिम URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "बजिरहेको छैन"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "एउटा स्टेशन छान्नुहोस्"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "बफर हुँदैछ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "अहिले बजिरहेको छ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "रोकिएको"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "पुनः जडान हुँदैछ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "अहिले बजिरहेको छ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver blijft radio afspelen nadat het venster is gesloten"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Nummersgeschiedenis"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Op de achtergrond blijven afspelen"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Over Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorieten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Zenderinformatie"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d zenders geladen"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspeelfout: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nu aan het spelen: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Hervatten: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-autorisatie annuleren"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Verbinding met Last.fm verbreken"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Verbinden met Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisatie geannuleerd"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Verbinding met Last.fm verbroken"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Verbinden met Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kon geen verbinding maken met Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Geef toegang in uw browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisatie verlopen"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Verbonden met Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Ontdek meer dan 30.000 geverifieerde radiostations uit de hele wereld"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Geen favorieten"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Markeer zenders met een ster tijdens het bladeren om ze hier toe te voegen"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Zenders zoeken…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle talen"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filteren op taal"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle landen"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filteren op land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Geen zenders"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laden…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u van %d zenders"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Zenders: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Zenders laden"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Geen resultaten"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Even geduld…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Geen zenders gevonden voor uw zoekopdracht"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kon zenders niet laden"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Zender"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Labels"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Website"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitsnelheid"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Niet aan het spelen"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selecteer een zender"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufferen…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Nu aan het spelen"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Opnieuw verbinden…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Zoeken op YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Zoeken mislukt: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Geen YouTube-resultaten gevonden"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultaten niet beschikbaar"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Downloaden: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Geannuleerd"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download mislukt: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Opgeslagen: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Nummer downloaden"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Download annuleren"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nog geen nummers"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Nummers verschijnen hier terwijl u naar radiostations luistert"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Zojuist"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min geleden"
 msgstr[1] "%d min geleden"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d uur geleden"
 msgstr[1] "%d uur geleden"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/nl.po
+++ b/po/nl.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver blijft radio afspelen nadat het venster is gesloten"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Nummersgeschiedenis"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Op de achtergrond blijven afspelen"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Over Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Bladeren"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorieten"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Zenderinformatie"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d zenders geladen"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fout: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Afspeelfout: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Nu aan het spelen: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Hervatten: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm-autorisatie annuleren"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Verbinding met Last.fm verbreken"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Verbinden met Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisatie geannuleerd"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Verbinding met Last.fm verbroken"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Verbinden met Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kon geen verbinding maken met Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Geef toegang in uw browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisatie verlopen"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Verbonden met Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Ontdek meer dan 30.000 geverifieerde radiostations uit de hele wereld"
 
@@ -114,64 +122,65 @@ msgstr "Geen favorieten"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Markeer zenders met een ster tijdens het bladeren om ze hier toe te voegen"
+msgstr ""
+"Markeer zenders met een ster tijdens het bladeren om ze hier toe te voegen"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Zenders zoeken…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle talen"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filteren op taal"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle landen"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filteren op land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Geen zenders"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laden…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u van %d zenders"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Zenders: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Zenders laden"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Geen resultaten"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Even geduld…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Geen zenders gevonden voor uw zoekopdracht"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kon zenders niet laden"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "Stream-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Niet aan het spelen"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selecteer een zender"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufferen…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Nu aan het spelen"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Opnieuw verbinden…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Nu aan het spelen"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/nn.po
+++ b/po/nn.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver held fram med å spela radio etter at vindauget er lukka"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meny"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Songhistorikk"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Hald fram med å spela i bakgrunnen"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorittar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stasjonsinformasjon"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasjonar lasta"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Feil: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Avspelingsfeil: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spelar no: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Held fram: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Avbryt Last.fm-autorisering"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Kopla frå Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kopla til Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisering avbroten"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Kopla frå Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Koplar til Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kunne ikkje kopla til Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Gje tilgang i nettlesaren din…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisering tidsavbrot"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Kopla til Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Oppdag over 30 000 verifiserte radiostasjonar frå heile verda"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Merk stasjonar med stjerne mens du blar for å leggje dei til her"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Søk etter stasjonar…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alle språk"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrer etter språk"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alle land"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrer etter land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ingen stasjonar"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Lastar…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d stasjonar"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasjonar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Lastar stasjonar"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ingen resultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ver venleg og vent…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ingen stasjonar samsvarar med søket ditt"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kunne ikkje laste stasjonar"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Straum-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Spelar ikkje"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Vel ein stasjon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Bufrar…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Spelar no"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Sett på pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Koplar til på nytt…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Spelar no"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/nn.po
+++ b/po/nn.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: nn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver held fram med å spela radio etter at vindauget er lukka"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meny"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Songhistorikk"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Hald fram med å spela i bakgrunnen"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Bla gjennom"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorittar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stasjonsinformasjon"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stasjonar lasta"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Feil: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Avspelingsfeil: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spelar no: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Held fram: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Avbryt Last.fm-autorisering"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Kopla frå Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kopla til Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-autorisering avbroten"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Kopla frå Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Koplar til Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kunne ikkje kopla til Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Gje tilgang i nettlesaren din…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-autorisering tidsavbrot"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Kopla til Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Oppdag over 30 000 verifiserte radiostasjonar frå heile verda"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ingen favorittar"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Merk stasjonar med stjerne mens du blar for å leggje dei til her"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Søk etter stasjonar…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alle språk"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrer etter språk"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alle land"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrer etter land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ingen stasjonar"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Lastar…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d stasjonar"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stasjonar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Lastar stasjonar"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ingen resultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ver venleg og vent…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ingen stasjonar samsvarar med søket ditt"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kunne ikkje laste stasjonar"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stasjon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Merkelappar"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Nettstad"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bithastigheit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Straum-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Spelar ikkje"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Vel ein stasjon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Bufrar…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Spelar no"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Sett på pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Koplar til på nytt…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Søkjer på YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Søk mislukkast: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ingen YouTube-resultat funne"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alle resultat utilgjengelege"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Lastar ned: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Avbrote"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Nedlasting mislukkast: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Lagra: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Last ned song"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Avbryt nedlasting"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ingen songar enno"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Songar vert viste her medan du lyttar til radiostasjonar"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Akkurat no"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min sidan"
 msgstr[1] "%d min sidan"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d time sidan"
 msgstr[1] "%d timar sidan"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/nso.po
+++ b/po/nso.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: nso\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver e tšwela pele go bapala radio ka morago ga ge lefasetere le tswaletšwe"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Histori ya dikoša"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Tšwela pele go bapala ka morago"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Ka ga Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Šomiša"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Tše di ratwago"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Tshedimošo ya setšhešene"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Diteišene %d di logilwe"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Phošo: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Phošo ya go bapala: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Bjale e a bapala: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "E a tšwela pele: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Khansela tumelelano ya Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Kgaola go Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kopanya go Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Tumelelano ya Last.fm e khansetšwe"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Go kgaotšwe go Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Go kopanya go Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Go paletšwe go kopanya go Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Fa phihlelelo ka go browser ya gago…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Tumelelano ya Last.fm e fedile"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Go kopantšwe go Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Hwetša ditešene tša radio tše 30,000+ tšeo di netefaditšwego go tšwa "
@@ -119,61 +127,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Swaya dinaledi go ditšhešene ge o šomiša go di oketša mo"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Nyaka diteišene…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Maleme Ka Moka"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Sefa ka leleme"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Dinaga ka moka"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Sefa ka naga"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ga Go Na Diteišene"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "E a logela…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u go tšwa go %d diteišene"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Diteišene: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "E Logela Diteišene"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ga Go Na Dipoelo"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Hle ema…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ga go na diteišene tše swanago le seo o se nyakago"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Ga go kgonege go logela diteišene"
 
@@ -206,25 +214,29 @@ msgid "Stream URL"
 msgstr "URL ya go strima"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ga E Bapale"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Kgetha teišene"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "E a boloka…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Bjale e a bapala"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "E Emisitšwe"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "E a kopanya gape…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Bjale e a bapala"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/nso.po
+++ b/po/nso.po
@@ -3,314 +3,314 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: nso\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver e tšwela pele go bapala radio ka morago ga ge lefasetere le tswaletšwe"
+msgstr ""
+"Receiver e tšwela pele go bapala radio ka morago ga ge lefasetere le "
+"tswaletšwe"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Histori ya dikoša"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Tšwela pele go bapala ka morago"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Ka ga Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Šomiša"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Tše di ratwago"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Tshedimošo ya setšhešene"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Diteišene %d di logilwe"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Phošo: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Phošo ya go bapala: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Bjale e a bapala: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "E a tšwela pele: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Khansela tumelelano ya Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Kgaola go Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kopanya go Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Tumelelano ya Last.fm e khansetšwe"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Go kgaotšwe go Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Go kopanya go Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Go paletšwe go kopanya go Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Fa phihlelelo ka go browser ya gago…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Tumelelano ya Last.fm e fedile"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Go kopantšwe go Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Hwetša ditešene tša radio tše 30,000+ tšeo di netefaditšwego go tšwa "
 "lefaseng ka moka"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ga go na tše di ratwago"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Swaya dinaledi go ditšhešene ge o šomiša go di oketša mo"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Nyaka diteišene…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Maleme Ka Moka"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Sefa ka leleme"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Dinaga ka moka"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Sefa ka naga"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ga Go Na Diteišene"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "E a logela…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u go tšwa go %d diteišene"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Diteišene: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "E Logela Diteišene"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ga Go Na Dipoelo"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Hle ema…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ga go na diteišene tše swanago le seo o se nyakago"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Ga go kgonege go logela diteišene"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Setšhešene"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Naga"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Dithegi"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Wepsaete"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Khouthekhie"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Pisireiti"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ya go strima"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ga E Bapale"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Kgetha teišene"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "E a boloka…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Bjale e a bapala"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "E Emisitšwe"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "E a kopanya gape…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "E nyaka YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Go nyaka go padile: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ga go na dipoelo tša YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Dipoelo ka moka ga di hwetšagale"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "E a tsenya: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "E Khanselitšwe"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Go tsenya go padile: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "E bolokilwe: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Tsenya koša"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Khansela go tsenya"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ga go na dikoša"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Dikoša di tla tšwelela mo ge o theeletša ditešene tša radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Gonabjale"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "metsotso ye %d ye e fetilego"
 msgstr[1] "metsotso ye %d ye e fetilego"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "iri ye %d ye e fetilego"
 msgstr[1] "diiri tše %d tše di fetilego"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/oc.po
+++ b/po/oc.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: oc\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver contunha de difusar la ràdio aprèp la tampadura de la fenèstra"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Istoric de cançons"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Contunhar la lectura en rèireplan"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "A prepaus de Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Percórrer"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorits"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informacions de la estacion"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estacions cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de lectura: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "En lectura: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprèsa: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anullar l'autorizacion de Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Se desconnectar de Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Se connectar a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "L'autorizacion de Last.fm es estada anullada"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectat de Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Connexion a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "S'es pas pogut connectar a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Acordatz l'accès dins vòstre navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "L'autorizacion de Last.fm a expirat"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Connectat a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Descobrissètz mai de 30 000 estacions de ràdio verificadas del mond entièr"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marcatz d'estacions amb una estela en percorrent per las ajustar aicí"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cercar d'estacions…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Totas las lengas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar per lenga"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Totes los païses"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar per país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Cap d'estacion"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Cargament…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Cargament de las estacions"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Cap de resultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Esperatz…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Cap d'estacion correspond pas a vòstra recèrca"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Impossible de cargar las estacions"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL del flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Pas en lectura"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Seleccionatz una estacion"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Mesa en memòria tampon…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "En lectura"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconnexion…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "En lectura"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/oc.po
+++ b/po/oc.po
@@ -3,313 +3,312 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: oc\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver contunha de difusar la ràdio aprèp la tampadura de la fenèstra"
+msgstr ""
+"Receiver contunha de difusar la ràdio aprèp la tampadura de la fenèstra"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menú"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Istoric de cançons"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Contunhar la lectura en rèireplan"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "A prepaus de Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Percórrer"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorits"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informacions de la estacion"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estacions cargadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error de lectura: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "En lectura: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Reprèsa: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anullar l'autorizacion de Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Se desconnectar de Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Se connectar a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "L'autorizacion de Last.fm es estada anullada"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconnectat de Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Connexion a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "S'es pas pogut connectar a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Acordatz l'accès dins vòstre navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "L'autorizacion de Last.fm a expirat"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Connectat a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Descobrissètz mai de 30 000 estacions de ràdio verificadas del mond entièr"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Cap de favorit"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marcatz d'estacions amb una estela en percorrent per las ajustar aicí"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cercar d'estacions…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Totas las lengas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar per lenga"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Totes los païses"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar per país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Cap d'estacion"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Cargament…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estacions"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estacions: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Cargament de las estacions"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Cap de resultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Esperatz…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Cap d'estacion correspond pas a vòstra recèrca"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Impossible de cargar las estacions"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Estacion"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Site web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Còdec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Debfo binòfo"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL del flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Pas en lectura"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Seleccionatz una estacion"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Mesa en memòria tampon…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "En lectura"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconnexion…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Recèrca sus YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "La recèrca a fracassat: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Cap de resultat YouTube trobat"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Totes los resultats indisponibles"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Telecargament: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Anullat"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Lo telecargament a fracassat: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Enregistrat: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Telecargar la cançon"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anullar lo telecargament"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Cap de cançon pel moment"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Las cançons apareisseràn aicí pendent que escotatz estacions de ràdio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ara"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "fa %d min"
 msgstr[1] "fa %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "fa %d ora"
 msgstr[1] "fa %d oras"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/or.po
+++ b/po/or.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: or\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ୱିଣ୍ଡୋ ବନ୍ଦ ହେବା ପରେ ମଧ୍ୟ Receiver ରେଡିଓ ବଜାଇବା ଜାରି ରଖେ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ମେନୁ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ଗୀତ ଇତିହାସ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ପୃଷ୍ଠପଟରେ ବଜାଇବା ଜାରି ରଖନ୍ତୁ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver ବିଷୟରେ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ବ୍ରାଉଜ୍ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ପସନ୍ଦର"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ଷ୍ଟେସନ ତଥ୍ୟ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ଷ୍ଟେସନ ଲୋଡ ହେଲା"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ତ୍ରୁଟି: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ପ୍ଲେବ୍ୟାକ ତ୍ରୁଟି: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ବର୍ତ୍ତମାନ ବାଜୁଛି: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ପୁନଃ ଆରମ୍ଭ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ଅନୁମୋଦନ ବାତିଲ୍ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ସହ ସଂଯୋଗ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ଅନୁମୋଦନ ବାତିଲ୍ ହେଲା"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ ହେଲା"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ସହ ସଂଯୋଗ ହେଉଛି…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ସହ ସଂଯୋଗ ହୋଇପାରିଲା ନାହିଁ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ଆପଣଙ୍କ ବ୍ରାଉଜରରେ ଅନୁମତି ଦିଅନ୍ତୁ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ଅନୁମୋଦନ ସମୟ ଶେଷ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ସହ ସଂଯୁକ୍ତ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ବିଶ୍ୱର ସବୁ ଠାରୁ 30,000+ ଯାଞ୍ଚ ହୋଇଥିବା ରେଡିଓ ଷ୍ଟେସନ ଆବିଷ୍କାର କରନ୍ତୁ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ଏଠାରେ ଯୋଡ଼ିବା ପାଇଁ ବ୍ରାଉଜ୍ କରୁଥିବାବେଳେ ଷ୍ଟେସନଗୁଡ଼ିକୁ ତାରା ଚିହ୍ନ ଦିଅନ୍ତୁ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ଷ୍ଟେସନ ଖୋଜନ୍ତୁ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ସମସ୍ତ ଭାଷା"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ଭାଷା ଅନୁସାରେ ଫିଲ୍ଟର"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ସମସ୍ତ ଦେଶ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ଦେଶ ଅନୁସାରେ ଫିଲ୍ଟର"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "କୌଣସି ଷ୍ଟେସନ ନାହିଁ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ଲୋଡ ହେଉଛି…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ଷ୍ଟେସନ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ଷ୍ଟେସନ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ଷ୍ଟେସନ ଲୋଡ ହେଉଛି"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "କୌଣସି ଫଳାଫଳ ନାହିଁ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ଦୟାକରି ଅପେକ୍ଷା କରନ୍ତୁ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ଆପଣଙ୍କ ଖୋଜ ସହ କୌଣସି ଷ୍ଟେସନ ମେଳ ଖାଉ ନାହିଁ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ଷ୍ଟେସନ ଲୋଡ କରିହେଲା ନାହିଁ"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ଷ୍ଟ୍ରିମ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ବାଜୁ ନାହିଁ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ଗୋଟିଏ ଷ୍ଟେସନ ବାଛନ୍ତୁ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ବଫର ହେଉଛି…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ବର୍ତ୍ତମାନ ବାଜୁଛି"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ବିରତ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ପୁନଃସଂଯୋଗ ହେଉଛି…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ବର୍ତ୍ତମାନ ବାଜୁଛି"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/or.po
+++ b/po/or.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: or\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ୱିଣ୍ଡୋ ବନ୍ଦ ହେବା ପରେ ମଧ୍ୟ Receiver ରେଡିଓ ବଜାଇବା ଜାରି ରଖେ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ମେନୁ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ଗୀତ ଇତିହାସ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ପୃଷ୍ଠପଟରେ ବଜାଇବା ଜାରି ରଖନ୍ତୁ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver ବିଷୟରେ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ବ୍ରାଉଜ୍ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ପସନ୍ଦର"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ଷ୍ଟେସନ ତଥ୍ୟ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ଷ୍ଟେସନ ଲୋଡ ହେଲା"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ତ୍ରୁଟି: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ପ୍ଲେବ୍ୟାକ ତ୍ରୁଟି: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ବର୍ତ୍ତମାନ ବାଜୁଛି: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ପୁନଃ ଆରମ୍ଭ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ଅନୁମୋଦନ ବାତିଲ୍ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ସହ ସଂଯୋଗ କରନ୍ତୁ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ଅନୁମୋଦନ ବାତିଲ୍ ହେଲା"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ରୁ ସଂଯୋଗ ବିଚ୍ଛିନ୍ନ ହେଲା"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ସହ ସଂଯୋଗ ହେଉଛି…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ସହ ସଂଯୋଗ ହୋଇପାରିଲା ନାହିଁ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ଆପଣଙ୍କ ବ୍ରାଉଜରରେ ଅନୁମତି ଦିଅନ୍ତୁ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ଅନୁମୋଦନ ସମୟ ଶେଷ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ସହ ସଂଯୁକ୍ତ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ବିଶ୍ୱର ସବୁ ଠାରୁ 30,000+ ଯାଞ୍ଚ ହୋଇଥିବା ରେଡିଓ ଷ୍ଟେସନ ଆବିଷ୍କାର କରନ୍ତୁ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "କୌଣସି ପସନ୍ଦର ନାହିଁ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ଏଠାରେ ଯୋଡ଼ିବା ପାଇଁ ବ୍ରାଉଜ୍ କରୁଥିବାବେଳେ ଷ୍ଟେସନଗୁଡ଼ିକୁ ତାରା ଚିହ୍ନ ଦିଅନ୍ତୁ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ଷ୍ଟେସନ ଖୋଜନ୍ତୁ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ସମସ୍ତ ଭାଷା"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ଭାଷା ଅନୁସାରେ ଫିଲ୍ଟର"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ସମସ୍ତ ଦେଶ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ଦେଶ ଅନୁସାରେ ଫିଲ୍ଟର"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "କୌଣସି ଷ୍ଟେସନ ନାହିଁ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ଲୋଡ ହେଉଛି…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ଷ୍ଟେସନ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ଷ୍ଟେସନ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ଷ୍ଟେସନ ଲୋଡ ହେଉଛି"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "କୌଣସି ଫଳାଫଳ ନାହିଁ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ଦୟାକରି ଅପେକ୍ଷା କରନ୍ତୁ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ଆପଣଙ୍କ ଖୋଜ ସହ କୌଣସି ଷ୍ଟେସନ ମେଳ ଖାଉ ନାହିଁ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ଷ୍ଟେସନ ଲୋଡ କରିହେଲା ନାହିଁ"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ଷ୍ଟେସନ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ଦେଶ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ଟ୍ୟାଗ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ୱେବସାଇଟ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "କୋଡେକ"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ବିଟରେଟ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ଷ୍ଟ୍ରିମ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ବାଜୁ ନାହିଁ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ଗୋଟିଏ ଷ୍ଟେସନ ବାଛନ୍ତୁ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ବଫର ହେଉଛି…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ବର୍ତ୍ତମାନ ବାଜୁଛି"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ବିରତ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ପୁନଃସଂଯୋଗ ହେଉଛି…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube ରେ ଖୋଜା ଯାଉଛି…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ଖୋଜ ବିଫଳ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ଫଳାଫଳ ମିଳିଲା ନାହିଁ"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ସମସ୍ତ ଫଳାଫଳ ଉପಲବ୍ଧ ନୁହେଁ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ଡାଉନଲୋଡ ହେଉଛି: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ବାତିଲ ହେଲା"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ଡାଉନଲୋଡ ବିଫଳ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ସଞ୍ଚିତ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ଗୀତ ଡାଉନଲୋଡ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ଡାଉନଲୋଡ ବାତିଲ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ଏପର୍ଯ୍ୟନ୍ତ କୌଣସି ଗୀତ ନାହିଁ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ଆପଣ ରେଡିଓ ଷ୍ଟେସନ ଶୁଣୁଥିବାବେଳେ ଗୀତ ଏଠାରେ ଦେଖାଯିବ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ଏବେ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d ମିନିଟ୍ ପୂର୍ବେ"
 msgstr[1] "%d ମିନିଟ୍ ପୂର୍ବେ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ଘଣ୍ଟା ପୂର୍ବେ"
 msgstr[1] "%d ଘଣ୍ଟା ପୂର୍ବେ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/pa.po
+++ b/po/pa.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: pa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ਵਿੰਡੋ ਬੰਦ ਹੋਣ ਤੋਂ ਬਾਅਦ ਵੀ Receiver ਰੇਡੀਓ ਚਲਾਉਂਦਾ ਰਹਿੰਦਾ ਹੈ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ਮੀਨੂ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ਗੀਤ ਇਤਿਹਾਸ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ਬੈਕਗ੍ਰਾਊਂਡ ਵਿੱਚ ਚਲਾਉਂਦੇ ਰਹੋ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver ਬਾਰੇ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ਬ੍ਰਾਊਜ਼ ਕਰੋ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ਮਨਪਸੰਦ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ਸਟੇਸ਼ਨ ਜਾਣਕਾਰੀ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ਸਟੇਸ਼ਨ ਲੋਡ ਹੋਏ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ਗਲਤੀ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ਪਲੇਬੈਕ ਗਲਤੀ: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ਮੁੜ ਸ਼ੁਰੂ ਹੋ ਰਿਹਾ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ਅਧਿਕਾਰ ਰੱਦ ਕਰੋ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ਤੋਂ ਡਿਸਕਨੈਕਟ ਕਰੋ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਕਰੋ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ਅਧਿਕਾਰ ਰੱਦ ਹੋਇਆ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ਤੋਂ ਡਿਸਕਨੈਕਟ ਹੋਇਆ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਹੋ ਸਕਿਆ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ਆਪਣੇ ਬ੍ਰਾਊਜ਼ਰ ਵਿੱਚ ਪਹੁੰਚ ਦਿਓ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ਅਧਿਕਾਰ ਦਾ ਸਮਾਂ ਖਤਮ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਹੋਇਆ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ਦੁਨੀਆ ਭਰ ਤੋਂ 30,000+ ਪ੍ਰਮਾਣਿਤ ਰੇਡੀਓ ਸਟੇਸ਼ਨ ਖੋਜੋ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ਇੱਥੇ ਜੋੜਨ ਲਈ ਬ੍ਰਾਊਜ਼ ਕਰਦੇ ਸਮੇਂ ਸਟੇਸ਼ਨਾਂ ਨੂੰ ਸਟਾਰ ਕਰੋ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ਸਟੇਸ਼ਨ ਖੋਜੋ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ਸਾਰੀਆਂ ਭਾਸ਼ਾਵਾਂ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ਭਾਸ਼ਾ ਅਨੁਸਾਰ ਫਿਲਟਰ ਕਰੋ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ਸਾਰੇ ਦੇਸ਼"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ਦੇਸ਼ ਅਨੁਸਾਰ ਫ਼ਿਲਟਰ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ਕੋਈ ਸਟੇਸ਼ਨ ਨਹੀਂ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ਸਟੇਸ਼ਨ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ਸਟੇਸ਼ਨ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ਸਟੇਸ਼ਨ ਲੋਡ ਹੋ ਰਹੇ ਹਨ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ਕੋਈ ਨਤੀਜੇ ਨਹੀਂ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਉਡੀਕ ਕਰੋ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ਤੁਹਾਡੀ ਖੋਜ ਨਾਲ ਕੋਈ ਸਟੇਸ਼ਨ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ਸਟੇਸ਼ਨ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕੇ"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ਸਟ੍ਰੀਮ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ਨਹੀਂ ਚੱਲ ਰਿਹਾ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ਇੱਕ ਸਟੇਸ਼ਨ ਚੁਣੋ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ਬਫ਼ਰ ਹੋ ਰਿਹਾ ਹੈ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ਰੁਕਿਆ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ਮੁੜ ਜੁੜ ਰਿਹਾ ਹੈ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/pa.po
+++ b/po/pa.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: pa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ਵਿੰਡੋ ਬੰਦ ਹੋਣ ਤੋਂ ਬਾਅਦ ਵੀ Receiver ਰੇਡੀਓ ਚਲਾਉਂਦਾ ਰਹਿੰਦਾ ਹੈ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ਮੀਨੂ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ਗੀਤ ਇਤਿਹਾਸ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ਬੈਕਗ੍ਰਾਊਂਡ ਵਿੱਚ ਚਲਾਉਂਦੇ ਰਹੋ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver ਬਾਰੇ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ਬ੍ਰਾਊਜ਼ ਕਰੋ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ਮਨਪਸੰਦ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ਸਟੇਸ਼ਨ ਜਾਣਕਾਰੀ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ਸਟੇਸ਼ਨ ਲੋਡ ਹੋਏ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ਗਲਤੀ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ਪਲੇਬੈਕ ਗਲਤੀ: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ਮੁੜ ਸ਼ੁਰੂ ਹੋ ਰਿਹਾ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ਅਧਿਕਾਰ ਰੱਦ ਕਰੋ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ਤੋਂ ਡਿਸਕਨੈਕਟ ਕਰੋ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਕਰੋ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ਅਧਿਕਾਰ ਰੱਦ ਹੋਇਆ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ਤੋਂ ਡਿਸਕਨੈਕਟ ਹੋਇਆ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਹੋ ਰਿਹਾ ਹੈ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਨਹੀਂ ਹੋ ਸਕਿਆ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ਆਪਣੇ ਬ੍ਰਾਊਜ਼ਰ ਵਿੱਚ ਪਹੁੰਚ ਦਿਓ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ਅਧਿਕਾਰ ਦਾ ਸਮਾਂ ਖਤਮ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ਨਾਲ ਕਨੈਕਟ ਹੋਇਆ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ਦੁਨੀਆ ਭਰ ਤੋਂ 30,000+ ਪ੍ਰਮਾਣਿਤ ਰੇਡੀਓ ਸਟੇਸ਼ਨ ਖੋਜੋ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ਕੋਈ ਮਨਪਸੰਦ ਨਹੀਂ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ਇੱਥੇ ਜੋੜਨ ਲਈ ਬ੍ਰਾਊਜ਼ ਕਰਦੇ ਸਮੇਂ ਸਟੇਸ਼ਨਾਂ ਨੂੰ ਸਟਾਰ ਕਰੋ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ਸਟੇਸ਼ਨ ਖੋਜੋ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ਸਾਰੀਆਂ ਭਾਸ਼ਾਵਾਂ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ਭਾਸ਼ਾ ਅਨੁਸਾਰ ਫਿਲਟਰ ਕਰੋ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ਸਾਰੇ ਦੇਸ਼"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ਦੇਸ਼ ਅਨੁਸਾਰ ਫ਼ਿਲਟਰ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ਕੋਈ ਸਟੇਸ਼ਨ ਨਹੀਂ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ਲੋਡ ਹੋ ਰਿਹਾ ਹੈ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ਸਟੇਸ਼ਨ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ਸਟੇਸ਼ਨ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ਸਟੇਸ਼ਨ ਲੋਡ ਹੋ ਰਹੇ ਹਨ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ਕੋਈ ਨਤੀਜੇ ਨਹੀਂ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ਕਿਰਪਾ ਕਰਕੇ ਉਡੀਕ ਕਰੋ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ਤੁਹਾਡੀ ਖੋਜ ਨਾਲ ਕੋਈ ਸਟੇਸ਼ਨ ਮੇਲ ਨਹੀਂ ਖਾਂਦਾ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ਸਟੇਸ਼ਨ ਲੋਡ ਨਹੀਂ ਹੋ ਸਕੇ"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ਸਟੇਸ਼ਨ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ਦੇਸ਼"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ਟੈਗ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ਵੈੱਬਸਾਈਟ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ਕੋਡੈਕ"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ਬਿੱਟਰੇਟ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ਸਟ੍ਰੀਮ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ਨਹੀਂ ਚੱਲ ਰਿਹਾ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ਇੱਕ ਸਟੇਸ਼ਨ ਚੁਣੋ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ਬਫ਼ਰ ਹੋ ਰਿਹਾ ਹੈ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ਹੁਣ ਚੱਲ ਰਿਹਾ ਹੈ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ਰੁਕਿਆ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ਮੁੜ ਜੁੜ ਰਿਹਾ ਹੈ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube ਤੇ ਖੋਜ ਰਿਹਾ ਹੈ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ਖੋਜ ਅਸਫ਼ਲ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "ਕੋਈ YouTube ਨਤੀਜੇ ਨਹੀਂ ਮਿਲੇ"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ਸਾਰੇ ਨਤੀਜੇ ਉਪਲਬਧ ਨਹੀਂ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ਡਾਊਨਲੋਡ ਹੋ ਰਿਹਾ ਹੈ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ਰੱਦ ਕੀਤਾ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ਡਾਊਨਲੋਡ ਅਸਫ਼ਲ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ਸੁਰੱਖਿਅਤ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ਗਾਣਾ ਡਾਊਨਲੋਡ ਕਰੋ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ਡਾਊਨਲੋਡ ਰੱਦ ਕਰੋ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ਅਜੇ ਕੋਈ ਗੀਤ ਨਹੀਂ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ਰੇਡੀਓ ਸਟੇਸ਼ਨ ਸੁਣਦੇ ਸਮੇਂ ਗੀਤ ਇੱਥੇ ਦਿਖਾਈ ਦੇਣਗੇ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ਹੁਣੇ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d ਮਿੰਟ ਪਹਿਲਾਂ"
 msgstr[1] "%d ਮਿੰਟ ਪਹਿਲਾਂ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ਘੰਟਾ ਪਹਿਲਾਂ"
 msgstr[1] "%d ਘੰਟੇ ਪਹਿਲਾਂ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "PO-Revision-Date: 2026-02-06 22:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: Polish\n"
@@ -17,101 +17,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver dalej odtwarza radio po zamknięciu okna"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historia utworów"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Odtwarzaj dalej w tle"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O programie Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Ulubione"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informacje o stacji"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Załadowano %d stacji"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Błąd: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Błąd odtwarzania: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Teraz gra: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wznawiam: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anuluj autoryzację Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Rozłącz z Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Połącz z Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autoryzacja Last.fm anulowana"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Rozłączono z Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Łączenie z Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nie udało się połączyć z Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Udziel dostępu w przeglądarce…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autoryzacja Last.fm wygasła"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Połączono z Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Odkryj ponad 30 000 zweryfikowanych stacji radiowych z całego świata"
 
@@ -124,61 +132,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Oznacz stacje gwiazdką podczas przeglądania, aby dodać je tutaj"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Szukaj stacji…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Wszystkie języki"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtruj według języka"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Wszystkie kraje"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtruj według kraju"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Brak stacji"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ładowanie…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d stacji"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacji: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ładowanie stacji"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Brak wyników"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Proszę czekać…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Brak stacji pasujących do wyszukiwania"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nie można załadować stacji"
 
@@ -211,25 +219,29 @@ msgid "Stream URL"
 msgstr "URL strumienia"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nie odtwarza"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Wybierz stację"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buforowanie…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Teraz gra"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Wstrzymano"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ponowne łączenie…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Teraz gra"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/pl.po
+++ b/po/pl.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "PO-Revision-Date: 2026-02-06 22:14+0100\n"
 "Last-Translator: \n"
 "Language-Team: Polish\n"
@@ -17,291 +17,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver dalej odtwarza radio po zamknięciu okna"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historia utworów"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Odtwarzaj dalej w tle"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O programie Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Przeglądaj"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Ulubione"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informacje o stacji"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Załadowano %d stacji"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Błąd: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Błąd odtwarzania: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Teraz gra: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wznawiam: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anuluj autoryzację Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Rozłącz z Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Połącz z Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autoryzacja Last.fm anulowana"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Rozłączono z Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Łączenie z Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nie udało się połączyć z Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Udziel dostępu w przeglądarce…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autoryzacja Last.fm wygasła"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Połączono z Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Odkryj ponad 30 000 zweryfikowanych stacji radiowych z całego świata"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Brak ulubionych"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Oznacz stacje gwiazdką podczas przeglądania, aby dodać je tutaj"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Szukaj stacji…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Wszystkie języki"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtruj według języka"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Wszystkie kraje"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtruj według kraju"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Brak stacji"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ładowanie…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d stacji"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacji: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ładowanie stacji"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Brak wyników"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Proszę czekać…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Brak stacji pasujących do wyszukiwania"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nie można załadować stacji"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stacja"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Kraj"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tagi"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Strona internetowa"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Przepływność"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL strumienia"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nie odtwarza"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Wybierz stację"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buforowanie…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Teraz gra"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Wstrzymano"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ponowne łączenie…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Wyszukiwanie w YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Wyszukiwanie nie powiodło się: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nie znaleziono wyników w YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Wszystkie wyniki niedostępne"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Pobieranie: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Anulowano"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Pobieranie nie powiodło się: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Zapisano: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Pobierz utwór"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anuluj pobieranie"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Brak utworów"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Utwory pojawią się tutaj podczas słuchania stacji radiowych"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Właśnie teraz"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -309,7 +307,7 @@ msgstr[0] "%d min temu"
 msgstr[1] "%d min temu"
 msgstr[2] "%d min temu"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -317,7 +315,7 @@ msgstr[0] "%d godzinę temu"
 msgstr[1] "%d godziny temu"
 msgstr[2] "%d godzin temu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ps.po
+++ b/po/ps.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ps\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "د کړکۍ تړل کېدو وروسته هم Receiver راډیو غږولو ته دوام ورکوي"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "مینو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "د سندرو تاریخ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "په شالید کې غږولو ته دوام ورکړئ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "د Receiver په اړه"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "لټون"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "خوښې"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "د سټیشن معلومات"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d سټېشنونه پورته شول"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "تېروتنه: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "د غږولو تېروتنه: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "اوس غږیږي: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "بیا پیلوي: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "د Last.fm واک لغوه کړئ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "له Last.fm څخه جلا شئ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm سره وصل شئ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "د Last.fm واک لغوه شو"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "له Last.fm څخه جلا شو"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm سره وصل کیږي…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm سره نشو وصل کیدی"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "په خپل براوزر کې لاسرسی ورکړئ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "د Last.fm واک وخت پوره شو"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm سره وصل شو"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "د نړۍ له هر ګوټ څخه 30,000+ تایید شوي راډیو سټیشنونه ومومئ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "دلته د اضافه کولو لپاره د لټون پر مهال سټیشنونه ستوري کړئ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "د سټېشنونو لټون…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ټولې ژبې"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "د ژبې په اساس فلټر"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ټول هېوادونه"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "د هېواد له مخې فلټر"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "سټېشنونه نشته"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "پورته کیږي…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u له %d سټېشنونو"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "سټېشنونه: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "سټېشنونه پورته کیږي"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "پایلې نشته"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "مهرباني وکړئ صبر وکړئ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ستاسو لټون سره هیڅ سټېشن سمون نه خوري"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "سټېشنونه پورته نشول"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "سټریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "نه غږیږي"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "یو سټېشن وټاکئ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "بفرول کیږي…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "اوس غږیږي"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ودرول شوی"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "بیا نښلول…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "اوس غږیږي"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ps.po
+++ b/po/ps.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ps\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "د کړکۍ تړل کېدو وروسته هم Receiver راډیو غږولو ته دوام ورکوي"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "مینو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "د سندرو تاریخ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "په شالید کې غږولو ته دوام ورکړئ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "د Receiver په اړه"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "لټون"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "خوښې"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "د سټیشن معلومات"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d سټېشنونه پورته شول"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "تېروتنه: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "د غږولو تېروتنه: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "اوس غږیږي: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "بیا پیلوي: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "د Last.fm واک لغوه کړئ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "له Last.fm څخه جلا شئ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm سره وصل شئ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "د Last.fm واک لغوه شو"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "له Last.fm څخه جلا شو"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm سره وصل کیږي…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm سره نشو وصل کیدی"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "په خپل براوزر کې لاسرسی ورکړئ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "د Last.fm واک وخت پوره شو"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm سره وصل شو"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "د نړۍ له هر ګوټ څخه 30,000+ تایید شوي راډیو سټیشنونه ومومئ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "خوښې نشته"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "دلته د اضافه کولو لپاره د لټون پر مهال سټیشنونه ستوري کړئ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "د سټېشنونو لټون…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ټولې ژبې"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "د ژبې په اساس فلټر"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ټول هېوادونه"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "د هېواد له مخې فلټر"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "سټېشنونه نشته"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "پورته کیږي…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u له %d سټېشنونو"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "سټېشنونه: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "سټېشنونه پورته کیږي"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "پایلې نشته"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "مهرباني وکړئ صبر وکړئ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ستاسو لټون سره هیڅ سټېشن سمون نه خوري"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "سټېشنونه پورته نشول"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "سټیشن"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "هېواد"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ټګونه"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ویبپاڼه"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کوډیک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "بټ ریټ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "سټریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "نه غږیږي"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "یو سټېشن وټاکئ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "بفرول کیږي…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "اوس غږیږي"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ودرول شوی"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "بیا نښلول…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "په YouTube کې لټون…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "لټون ناکامه شوه: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "د YouTube پایلې ونه موندل شوې"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ټولې پایلې شتون نلري"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ښکته کیږي: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "لغوه شوه"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ښکته کول ناکامه شوه: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "خوندي شوه: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "سندره ښکته کړئ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ښکته کول لغوه کړئ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "تر اوسه سندرې نشته"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "کله چې تاسو راډیو سټیشنونه اورئ سندرې به دلته ښکاره شي"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "همدا اوس"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d دقیقې مخکې"
 msgstr[1] "%d دقیقې مخکې"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ساعت مخکې"
 msgstr[1] "%d ساعتونه مخکې"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/pt.po
+++ b/po/pt.po
@@ -3,312 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "O Receiver continua a reproduzir a rádio depois de a janela ser fechada"
+msgstr ""
+"O Receiver continua a reproduzir a rádio depois de a janela ser fechada"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Histórico de músicas"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continuar a reproduzir em segundo plano"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Sobre o Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informação da estação"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estações carregadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erro de reprodução: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproduzindo: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Retomando: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorização do Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar do Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conectar ao Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorização do Last.fm cancelada"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado do Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "A conectar ao Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Falha ao conectar ao Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Conceda acesso no seu navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorização do Last.fm expirou"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conectado ao Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubra mais de 30.000 estações de rádio verificadas de todo o mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sem favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Marque estações com estrela enquanto explora para as adicionar aqui"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Pesquisar estações…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Todos os idiomas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar por idioma"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Todos os países"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Sem estações"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Carregando…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estações"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estações: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Carregando estações"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sem resultados"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Por favor, aguarde…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nenhuma estação corresponde à sua pesquisa"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Não foi possível carregar as estações"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Estação"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Sítio web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL da transmissão"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Sem reprodução"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selecione uma estação"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "A armazenar em buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Reproduzindo"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconectando…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Pesquisando no YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Falha na pesquisa: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nenhum resultado do YouTube encontrado"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Todos os resultados indisponíveis"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Baixando: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Falha no download: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvo: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Baixar música"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancelar download"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ainda sem músicas"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "As músicas aparecerão aqui enquanto ouve estações de rádio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Agora mesmo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "há %d min"
 msgstr[1] "há %d min"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "há %d hora"
 msgstr[1] "há %d horas"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/pt.po
+++ b/po/pt.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "O Receiver continua a reproduzir a rádio depois de a janela ser fechada"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Histórico de músicas"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continuar a reproduzir em segundo plano"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Sobre o Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informação da estação"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estações carregadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erro de reprodução: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Reproduzindo: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Retomando: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorização do Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar do Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conectar ao Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorização do Last.fm cancelada"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado do Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "A conectar ao Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Falha ao conectar ao Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Conceda acesso no seu navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorização do Last.fm expirou"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conectado ao Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubra mais de 30.000 estações de rádio verificadas de todo o mundo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Marque estações com estrela enquanto explora para as adicionar aqui"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Pesquisar estações…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Todos os idiomas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar por idioma"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Todos os países"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Sem estações"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Carregando…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estações"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estações: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Carregando estações"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sem resultados"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Por favor, aguarde…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nenhuma estação corresponde à sua pesquisa"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Não foi possível carregar as estações"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL da transmissão"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Sem reprodução"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selecione uma estação"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "A armazenar em buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Reproduzindo"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconectando…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Reproduzindo"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "O Receiver continua reproduzindo o rádio após o fechamento da janela"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Histórico de músicas"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continuar reproduzindo em segundo plano"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Sobre o Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informações da estação"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estações carregadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erro de reprodução: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Tocando agora: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Retomando: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorização do Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar do Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conectar ao Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorização do Last.fm cancelada"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado do Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Conectando ao Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Falha ao conectar ao Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Conceda acesso no seu navegador…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorização do Last.fm expirou"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conectado ao Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubra mais de 30.000 estações de rádio verificadas de todo o mundo"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Favorite estações enquanto navega para adicioná-las aqui"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Pesquisar estações…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Todos os idiomas"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrar por idioma"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Todos os países"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nenhuma estação"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Carregando…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estações"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Estações: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Carregando estações"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nenhum resultado"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Por favor, aguarde…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nenhuma estação corresponde à sua pesquisa"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Não foi possível carregar as estações"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL do fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Não está tocando"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selecione uma estação"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Armazenando em buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Tocando agora"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Reconectando…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Tocando agora"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "O Receiver continua reproduzindo o rádio após o fechamento da janela"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Histórico de músicas"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continuar reproduzindo em segundo plano"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Sobre o Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Explorar"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoritos"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informações da estação"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d estações carregadas"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Erro: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Erro de reprodução: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Tocando agora: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Retomando: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Cancelar autorização do Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Desconectar do Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conectar ao Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorização do Last.fm cancelada"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Desconectado do Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Conectando ao Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Falha ao conectar ao Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Conceda acesso no seu navegador…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorização do Last.fm expirou"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conectado ao Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Descubra mais de 30.000 estações de rádio verificadas de todo o mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sem favoritos"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Favorite estações enquanto navega para adicioná-las aqui"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Pesquisar estações…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Todos os idiomas"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrar por idioma"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Todos os países"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrar por país"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nenhuma estação"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Carregando…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u de %d estações"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Estações: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Carregando estações"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nenhum resultado"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Por favor, aguarde…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nenhuma estação corresponde à sua pesquisa"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Não foi possível carregar as estações"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Estação"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "País"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Site"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL do fluxo"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Não está tocando"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selecione uma estação"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Armazenando em buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Tocando agora"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Reconectando…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Pesquisando no YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Pesquisa falhou: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nenhum resultado do YouTube encontrado"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Todos os resultados indisponíveis"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Baixando: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Cancelado"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Download falhou: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvo: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Baixar música"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Cancelar download"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nenhuma música ainda"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "As músicas aparecerão aqui enquanto você ouve estações de rádio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Agora mesmo"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min atrás"
 msgstr[1] "%d min atrás"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d hora atrás"
 msgstr[1] "%d horas atrás"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/receiver.pot
+++ b/po/receiver.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,305 +18,303 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr ""
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr ""
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr ""
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr ""
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr ""
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr ""
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr ""
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr ""
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr ""
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr ""
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr ""
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr ""
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr ""
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr ""
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr ""
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr ""
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr ""
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr ""
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr ""
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr ""
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr ""
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr ""
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr ""
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr ""
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr ""
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr ""
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr ""
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr ""
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr ""
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr ""
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr ""
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr ""
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr ""
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr ""
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr ""
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr ""
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr ""
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr ""
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr ""
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr ""
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr ""
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr ""
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr ""
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr ""
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr ""
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr ""
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr ""
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr ""
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr ""
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr ""
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr ""
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr ""
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/receiver.pot
+++ b/po/receiver.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,101 +18,109 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr ""
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr ""
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr ""
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr ""
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr ""
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr ""
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr ""
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr ""
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr ""
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr ""
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr ""
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr ""
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr ""
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr ""
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr ""
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr ""
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr ""
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr ""
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr ""
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 
@@ -125,61 +133,61 @@ msgid "Star stations while browsing to add them here"
 msgstr ""
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr ""
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr ""
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr ""
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr ""
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr ""
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr ""
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr ""
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr ""
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr ""
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr ""
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr ""
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr ""
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr ""
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr ""
 
@@ -212,24 +220,28 @@ msgid "Stream URL"
 msgstr ""
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr ""
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr ""
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr ""
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr ""
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr ""
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
-msgstr ""
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
 msgstr ""
 
 #. indeterminate while searching

--- a/po/ro.po
+++ b/po/ro.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100>0 && "
 "n%100<20)) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continuă să redea radioul după închiderea ferestrei"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meniu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Istoricul melodiilor"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continuă redarea în fundal"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Despre Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Răsfoiește"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favorite"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informații post"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d posturi încărcate"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Eroare: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Eroare de redare: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Se redă acum: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Se reia: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anulați autorizarea Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Deconectați de la Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Conectați la Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizarea Last.fm a fost anulată"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Deconectat de la Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Se conectează la Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nu s-a putut conecta la Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Acordați acces în browserul dvs.…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizarea Last.fm a expirat"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Conectat la Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Descoperă peste 30.000 de posturi de radio verificate din întreaga lume"
@@ -116,64 +124,65 @@ msgstr "Fără favorite"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Marchează posturi cu stea în timp ce răsfoiești pentru a le adăuga aici"
+msgstr ""
+"Marchează posturi cu stea în timp ce răsfoiești pentru a le adăuga aici"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Caută posturi…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Toate limbile"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrează după limbă"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Toate țările"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrează după țară"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Niciun post"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Se încarcă…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u din %d posturi"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Posturi: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Se încarcă posturile"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Niciun rezultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vă rugăm așteptați…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Niciun post nu corespunde căutării"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nu s-au putut încărca posturile"
 
@@ -206,25 +215,29 @@ msgid "Stream URL"
 msgstr "URL flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nu se redă"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Selectați un post"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Se memorează în buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Se redă acum"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "În pauză"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Se reconectează…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Se redă acum"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ro.po
+++ b/po/ro.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,293 +11,291 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100>0 && "
 "n%100<20)) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver continuă să redea radioul după închiderea ferestrei"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meniu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Istoricul melodiilor"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continuă redarea în fundal"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Despre Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Răsfoiește"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favorite"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informații post"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d posturi încărcate"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Eroare: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Eroare de redare: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Se redă acum: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Se reia: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anulați autorizarea Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Deconectați de la Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Conectați la Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizarea Last.fm a fost anulată"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Deconectat de la Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Se conectează la Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nu s-a putut conecta la Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Acordați acces în browserul dvs.…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizarea Last.fm a expirat"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Conectat la Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Descoperă peste 30.000 de posturi de radio verificate din întreaga lume"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Fără favorite"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Marchează posturi cu stea în timp ce răsfoiești pentru a le adăuga aici"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Caută posturi…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Toate limbile"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrează după limbă"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Toate țările"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrează după țară"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Niciun post"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Se încarcă…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u din %d posturi"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Posturi: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Se încarcă posturile"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Niciun rezultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vă rugăm așteptați…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Niciun post nu corespunde căutării"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nu s-au putut încărca posturile"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Post"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Țară"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etichete"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Site web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Rată de biți"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nu se redă"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Selectați un post"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Se memorează în buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Se redă acum"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "În pauză"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Se reconectează…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Se caută pe YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Căutarea a eșuat: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nu s-au găsit rezultate YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Toate rezultatele sunt indisponibile"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Se descarcă: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Anulat"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Descărcarea a eșuat: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Salvat: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Descarcă melodia"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anulează descărcarea"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nicio melodie încă"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Melodiile vor apărea aici în timp ce ascultați posturi de radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Chiar acum"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -305,7 +303,7 @@ msgstr[0] "acum %d minut"
 msgstr[1] "acum %d minute"
 msgstr[2] "acum %d de minute"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -313,7 +311,7 @@ msgstr[0] "acum %d oră"
 msgstr[1] "acum %d ore"
 msgstr[2] "acum %d de ore"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sat.po
+++ b/po/sat.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sat\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ᱣᱤᱱᱰᱳ ᱵᱚᱸᱫ ᱦᱩᱭ ᱛᱟᱭᱚᱢ ᱦᱚᱸ Receiver ᱨᱮᱰᱤᱭᱳ ᱵᱟᱡᱟᱣ ᱞᱟᱦᱟᱭ ᱠᱟᱱᱟ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "ᱢᱮᱱᱩ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ᱥᱮᱨᱮᱧ ᱤᱛᱤᱦᱟᱥ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ᱛᱟᱭᱚᱢ ᱛᱮ ᱵᱟᱡᱟᱣ ᱞᱟᱦᱟᱭ ᱢᱮ"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver ᱵᱟᱵᱚᱛ"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "ᱵᱽᱨᱟᱣᱡᱽ"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ᱢᱚᱱᱮ ᱢᱚᱱᱮ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱠᱷᱚᱵᱚᱨ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ᱥᱴᱮᱥᱚᱱ ᱞᱚᱰ ᱦᱩᱭᱮᱱᱟ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ᱵᱷᱩᱞ: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ᱯᱞᱮᱵᱮᱠ ᱵᱷᱩᱞ: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ᱱᱤᱛᱚᱜ ᱢᱤᱫ ᱡᱷᱟᱹᱞᱟᱜ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "ᱟᱨᱩ ᱡᱷᱟᱹᱞᱟᱜ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ᱟᱡᱚᱨ ᱵᱟᱹᱲᱟ"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ᱠᱷᱚᱱ ᱡᱩᱲᱟᱹᱣ ᱛᱟᱹᱲ"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ᱟᱡᱚᱨ ᱵᱟᱹᱲᱟᱹ ᱦᱩᱭᱮᱱᱟ"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ᱠᱷᱚᱱ ᱡᱩᱲᱟᱹᱣ ᱛᱟᱹᱲᱮᱱᱟ"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ ᱦᱩᱭ ᱠᱟᱱᱟ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ ᱵᱟᱝ ᱦᱩᱭ ᱠᱟᱱᱟ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ᱟᱢᱟᱜ ᱵᱽᱨᱟᱣᱡᱚᱨ ᱨᱮ ᱥᱮᱸᱫᱽᱨᱟ ᱮᱢ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ᱟᱡᱚᱨ ᱚᱠᱛᱚ ᱥᱤᱧᱚᱛᱮᱱᱟ"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ ᱦᱩᱭᱮᱱᱟ"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ᱫᱩᱱᱤᱭᱟᱹ ᱥᱟᱨᱟ ᱠᱷᱚᱱ 30,000+ ᱛᱟᱹᱥᱫᱤᱭᱟᱜ ᱨᱮᱰᱤᱭᱳ ᱥᱴᱮᱥᱚᱱ ᱠᱚ ᱠᱷᱚᱡ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ᱡᱟᱦᱟᱸ ᱢᱚᱱᱮ ᱢᱚᱱᱮ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ᱱᱚᱶᱟ ᱨᱮ ᱥᱮᱞᱮᱫ ᱞᱟᱹᱜᱤᱫ ᱵᱽᱨᱟᱣᱡᱽ ᱥᱚᱢᱚᱭ ᱨᱮ ᱥᱴᱮᱥᱚᱱ ᱠᱚᱨᱮ ᱤᱯᱤᱞ ᱮᱢ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱯᱟᱱᱛᱮ…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ᱡᱷᱚᱛᱚ ᱯᱟᱹᱨᱥᱤ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "ᱯᱟᱹᱨᱥᱤ ᱛᱮ ᱪᱷᱟᱹᱱᱤ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ᱡᱷᱚᱛᱚ ᱫᱤᱥᱚᱢ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ᱫᱤᱥᱚᱢ ᱛᱮ ᱯᱷᱤᱞᱴᱚᱨ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ᱞᱚᱰ ᱦᱚᱪᱚᱜ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%d ᱨᱮᱱ %u ᱥᱴᱮᱥᱚᱱ"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ᱥᱴᱮᱥᱚᱱ: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱞᱚᱰ ᱦᱚᱪᱚᱜ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ᱱᱟᱛᱤᱡᱟ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱛᱟᱞᱟ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ᱟᱢᱟᱜ ᱯᱟᱱᱛᱮ ᱞᱮᱠᱟ ᱥᱴᱮᱥᱚᱱ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱞᱚᱰ ᱠᱟ ᱫᱟᱹᱲᱤᱭᱟᱹ"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ᱥᱴᱮᱥᱚᱱ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ᱫᱤᱥᱚᱢ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ᱴᱮᱜ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ᱣᱮᱵᱥᱟᱭᱴ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ᱠᱳᱰᱮᱠ"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ᱵᱤᱴᱨᱮᱴ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ᱥᱴᱨᱤᱢ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ᱵᱟᱹᱱᱩᱜ ᱡᱷᱟᱹᱞ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ᱢᱤᱫ ᱥᱴᱮᱥᱚᱱ ᱵᱟᱪᱷᱟᱣ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ᱵᱟᱯᱷᱟᱨ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ᱱᱤᱛᱚᱜ ᱡᱷᱟᱹᱞᱟᱜ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "ᱛᱟᱦᱮᱸᱱ ᱟᱠᱟᱱᱟ"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "ᱟᱨᱩ ᱡᱩᱲᱟᱜ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube ᱨᱮ ᱯᱟᱱᱛᱮᱜ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ᱯᱟᱱᱛᱮ ᱵᱤᱯᱷᱚᱞ: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ᱱᱟᱛᱤᱡᱟ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ᱡᱷᱚᱛᱚ ᱱᱟᱛᱤᱡᱟ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ᱰᱟᱣᱱᱞᱚᱰ ᱦᱚᱪᱚᱜ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ᱵᱚᱸᱫ ᱟᱠᱟᱱᱟ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ᱰᱟᱣᱱᱞᱚᱰ ᱵᱤᱯᱷᱚᱞ: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ᱥᱮᱵ ᱟᱠᱟᱱᱟ: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ᱥᱮᱨᱮᱧ ᱰᱟᱣᱱᱞᱚᱰ"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ᱰᱟᱣᱱᱞᱚᱰ ᱵᱚᱸᱫ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ᱱᱤᱛ ᱦᱚᱸ ᱡᱟᱦᱟᱸ ᱥᱮᱨᱮᱧ ᱵᱟᱝᱟ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ᱨᱮᱰᱤᱭᱳ ᱥᱴᱮᱥᱚᱱ ᱟᱧᱡᱩᱢ ᱛᱟᱭᱚᱢ ᱥᱮᱨᱮᱧ ᱠᱚ ᱱᱚᱶᱟ ᱨᱮ ᱧᱮᱞ ᱦᱩᱭᱩᱜ ᱠᱟᱱᱟ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ᱱᱤᱛ ᱠᱷᱚᱱ"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d ᱢᱤᱱᱤᱴ ᱢᱟᱲᱟᱝ"
 msgstr[1] "%d ᱢᱤᱱᱤᱴ ᱢᱟᱲᱟᱝ"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ᱜᱷᱚᱱᱴᱟ ᱢᱟᱲᱟᱝ"
 msgstr[1] "%d ᱜᱷᱚᱱᱴᱟ ᱢᱟᱲᱟᱝ"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sat.po
+++ b/po/sat.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sat\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ᱣᱤᱱᱰᱳ ᱵᱚᱸᱫ ᱦᱩᱭ ᱛᱟᱭᱚᱢ ᱦᱚᱸ Receiver ᱨᱮᱰᱤᱭᱳ ᱵᱟᱡᱟᱣ ᱞᱟᱦᱟᱭ ᱠᱟᱱᱟ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "ᱢᱮᱱᱩ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ᱥᱮᱨᱮᱧ ᱤᱛᱤᱦᱟᱥ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ᱛᱟᱭᱚᱢ ᱛᱮ ᱵᱟᱡᱟᱣ ᱞᱟᱦᱟᱭ ᱢᱮ"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver ᱵᱟᱵᱚᱛ"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "ᱵᱽᱨᱟᱣᱡᱽ"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ᱢᱚᱱᱮ ᱢᱚᱱᱮ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱠᱷᱚᱵᱚᱨ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ᱥᱴᱮᱥᱚᱱ ᱞᱚᱰ ᱦᱩᱭᱮᱱᱟ"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ᱵᱷᱩᱞ: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ᱯᱞᱮᱵᱮᱠ ᱵᱷᱩᱞ: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ᱱᱤᱛᱚᱜ ᱢᱤᱫ ᱡᱷᱟᱹᱞᱟᱜ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "ᱟᱨᱩ ᱡᱷᱟᱹᱞᱟᱜ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ᱟᱡᱚᱨ ᱵᱟᱹᱲᱟ"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm ᱠᱷᱚᱱ ᱡᱩᱲᱟᱹᱣ ᱛᱟᱹᱲ"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ᱟᱡᱚᱨ ᱵᱟᱹᱲᱟᱹ ᱦᱩᱭᱮᱱᱟ"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm ᱠᱷᱚᱱ ᱡᱩᱲᱟᱹᱣ ᱛᱟᱹᱲᱮᱱᱟ"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ ᱦᱩᱭ ᱠᱟᱱᱟ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ ᱵᱟᱝ ᱦᱩᱭ ᱠᱟᱱᱟ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ᱟᱢᱟᱜ ᱵᱽᱨᱟᱣᱡᱚᱨ ᱨᱮ ᱥᱮᱸᱫᱽᱨᱟ ᱮᱢ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ᱟᱡᱚᱨ ᱚᱠᱛᱚ ᱥᱤᱧᱚᱛᱮᱱᱟ"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ᱥᱟᱶᱛᱮ ᱡᱩᱲᱟᱹᱣ ᱦᱩᱭᱮᱱᱟ"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ᱫᱩᱱᱤᱭᱟᱹ ᱥᱟᱨᱟ ᱠᱷᱚᱱ 30,000+ ᱛᱟᱹᱥᱫᱤᱭᱟᱜ ᱨᱮᱰᱤᱭᱳ ᱥᱴᱮᱥᱚᱱ ᱠᱚ ᱠᱷᱚᱡ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ᱱᱚᱶᱟ ᱨᱮ ᱥᱮᱞᱮᱫ ᱞᱟᱹᱜᱤᱫ ᱵᱽᱨᱟᱣᱡᱽ ᱥᱚᱢᱚᱭ ᱨᱮ ᱥᱴᱮᱥᱚᱱ ᱠᱚᱨᱮ ᱤᱯᱤᱞ ᱮᱢ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱯᱟᱱᱛᱮ…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ᱡᱷᱚᱛᱚ ᱯᱟᱹᱨᱥᱤ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "ᱯᱟᱹᱨᱥᱤ ᱛᱮ ᱪᱷᱟᱹᱱᱤ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ᱡᱷᱚᱛᱚ ᱫᱤᱥᱚᱢ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ᱫᱤᱥᱚᱢ ᱛᱮ ᱯᱷᱤᱞᱴᱚᱨ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ᱞᱚᱰ ᱦᱚᱪᱚᱜ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%d ᱨᱮᱱ %u ᱥᱴᱮᱥᱚᱱ"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ᱥᱴᱮᱥᱚᱱ: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱞᱚᱰ ᱦᱚᱪᱚᱜ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ᱱᱟᱛᱤᱡᱟ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ᱫᱟᱭᱟ ᱠᱟᱛᱮ ᱛᱟᱞᱟ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ᱟᱢᱟᱜ ᱯᱟᱱᱛᱮ ᱞᱮᱠᱟ ᱥᱴᱮᱥᱚᱱ ᱵᱟᱹᱱᱩᱜ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ᱥᱴᱮᱥᱚᱱ ᱞᱚᱰ ᱠᱟ ᱫᱟᱹᱲᱤᱭᱟᱹ"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ᱥᱴᱨᱤᱢ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ᱵᱟᱹᱱᱩᱜ ᱡᱷᱟᱹᱞ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ᱢᱤᱫ ᱥᱴᱮᱥᱚᱱ ᱵᱟᱪᱷᱟᱣ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ᱵᱟᱯᱷᱟᱨ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ᱱᱤᱛᱚᱜ ᱡᱷᱟᱹᱞᱟᱜ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "ᱛᱟᱦᱮᱸᱱ ᱟᱠᱟᱱᱟ"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "ᱟᱨᱩ ᱡᱩᱲᱟᱜ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ᱱᱤᱛᱚᱜ ᱡᱷᱟᱹᱞᱟᱜ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/si.po
+++ b/po/si.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: si\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "කවුළුව වසා දැමීමෙන් පසුවද Receiver ගුවන් විදුලිය වාදනය කරගෙන යයි"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "මෙනුව"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ගීත ඉතිහාසය"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "පසුබිමින් වාදනය කරගෙන යන්න"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver පිළිබඳව"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "පිරික්සන්න"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ප්‍රියතමයන්"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "මධ්‍යස්ථාන තොරතුරු"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ස්ථාන %d ක් පූරණය විය"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "දෝෂය: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ප්ලේබැක් දෝෂය: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "දැන් වාදනය වෙයි: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "නැවත ආරම්භ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm අනුමැතිය අවලංගු කරන්න"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm වෙතින් විසන්ධි කරන්න"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm වෙත සම්බන්ධ වන්න"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm අනුමැතිය අවලංගු කරන ලදි"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm වෙතින් විසන්ධි විය"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm වෙත සම්බන්ධ වෙමින්…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm වෙත සම්බන්ධ වීමට අපොහොසත් විය"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ඔබේ බ්‍රවුසරයේ ප්‍රවේශය ලබා දෙන්න…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm අනුමැතිය කල් ඉකුත් විය"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm වෙත සම්බන්ධ විය"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ලොව පුරා 30,000+ සත්‍යාපිත ගුවන් විදුලි මධ්‍යස්ථාන සොයා ගන්න"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ප්‍රියතමයන් නැත"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "මෙහි එක් කිරීමට පිරික්සන විට මධ්‍යස්ථානවලට තරු ලකුණු කරන්න"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ස්ථාන සොයන්න…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "සියලු භාෂා"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "භාෂාව අනුව පෙරන්න"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "සියලුම රටවල්"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "රට අනුව පෙරන්න"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ස්ථාන නැත"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "පූරණය වෙමින්…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ස්ථාන"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ස්ථාන: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ස්ථාන පූරණය වෙමින්"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ප්‍රතිඵල නැත"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "කරුණාකර රැඳී සිටින්න…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ඔබේ සෙවීමට ගැළපෙන ස්ථාන නැත"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ස්ථාන පූරණය කළ නොහැක"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "මධ්‍යස්ථානය"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "රට"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ටැග"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "වෙබ් අඩවිය"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "කොඩෙක්"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "බිට්රේට්"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ප්‍රවාහ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "වාදනය නොවේ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ස්ථානයක් තෝරන්න"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "බෆර් වෙමින්…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "දැන් වාදනය වෙයි"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "විරාමය"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "නැවත සම්බන්ධ වෙමින්…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube හි සොයමින්…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "සෙවීම අසාර්ථකයි: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ප්‍රතිඵල හමු නොවීය"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "සියලු ප්‍රතිඵල ලබාගත නොහැක"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "බාගත කරමින්: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "අවලංගු කරන ලදී"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "බාගත කිරීම අසාර්ථකයි: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "සුරකින ලදී: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ගීතය බාගත කරන්න"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "බාගත කිරීම අවලංගු කරන්න"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "තවම ගීත නැත"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ඔබ ගුවන් විදුලි මධ්‍යස්ථාන වලට ඇහුම්කන් දෙන විට ගීත මෙහි දිස් වේ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "දැන්ම"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "මිනිත්තු %dකට පෙර"
 msgstr[1] "මිනිත්තු %dකට පෙර"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "පැය %dකට පෙර"
 msgstr[1] "පැය %dකට පෙර"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/si.po
+++ b/po/si.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: si\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "කවුළුව වසා දැමීමෙන් පසුවද Receiver ගුවන් විදුලිය වාදනය කරගෙන යයි"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "මෙනුව"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ගීත ඉතිහාසය"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "පසුබිමින් වාදනය කරගෙන යන්න"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver පිළිබඳව"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "පිරික්සන්න"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ප්‍රියතමයන්"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "මධ්‍යස්ථාන තොරතුරු"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "ස්ථාන %d ක් පූරණය විය"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "දෝෂය: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ප්ලේබැක් දෝෂය: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "දැන් වාදනය වෙයි: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "නැවත ආරම්භ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm අනුමැතිය අවලංගු කරන්න"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm වෙතින් විසන්ධි කරන්න"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm වෙත සම්බන්ධ වන්න"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm අනුමැතිය අවලංගු කරන ලදි"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm වෙතින් විසන්ධි විය"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm වෙත සම්බන්ධ වෙමින්…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm වෙත සම්බන්ධ වීමට අපොහොසත් විය"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ඔබේ බ්‍රවුසරයේ ප්‍රවේශය ලබා දෙන්න…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm අනුමැතිය කල් ඉකුත් විය"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm වෙත සම්බන්ධ විය"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ලොව පුරා 30,000+ සත්‍යාපිත ගුවන් විදුලි මධ්‍යස්ථාන සොයා ගන්න"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "මෙහි එක් කිරීමට පිරික්සන විට මධ්‍යස්ථානවලට තරු ලකුණු කරන්න"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ස්ථාන සොයන්න…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "සියලු භාෂා"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "භාෂාව අනුව පෙරන්න"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "සියලුම රටවල්"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "රට අනුව පෙරන්න"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ස්ථාන නැත"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "පූරණය වෙමින්…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ස්ථාන"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ස්ථාන: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ස්ථාන පූරණය වෙමින්"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ප්‍රතිඵල නැත"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "කරුණාකර රැඳී සිටින්න…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ඔබේ සෙවීමට ගැළපෙන ස්ථාන නැත"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ස්ථාන පූරණය කළ නොහැක"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ප්‍රවාහ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "වාදනය නොවේ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ස්ථානයක් තෝරන්න"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "බෆර් වෙමින්…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "දැන් වාදනය වෙයි"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "විරාමය"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "නැවත සම්බන්ධ වෙමින්…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "දැන් වාදනය වෙයි"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sk.po
+++ b/po/sk.po
@@ -3,298 +3,296 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver po zatvorení okna pokračuje v prehrávaní rádia"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Ponuka"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "História skladieb"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Pokračovať v prehrávaní na pozadí"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O aplikácii Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Prehľadávať"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Obľúbené"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informácie o stanici"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Načítaných %d staníc"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Chyba prehrávania: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Práve hrá: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Obnovenie: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Zrušiť autorizáciu Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Odpojiť od Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Pripojiť k Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizácia Last.fm zrušená"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Odpojené od Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Pripájanie k Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nepodarilo sa pripojiť k Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Udeľte prístup vo svojom prehliadači…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizácia Last.fm vypršala"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Pripojené k Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Objavte viac ako 30 000 overených rozhlasových staníc z celého sveta"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Žiadne obľúbené"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Pri prehľadávaní označte stanice hviezdičkou a pridajte ich sem"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Hľadať stanice…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Všetky jazyky"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrovať podľa jazyka"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Všetky krajiny"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrovať podľa krajiny"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Žiadne stanice"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Načítavanie…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d staníc"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanice: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Načítavanie staníc"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Žiadne výsledky"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Prosím, čakajte…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Žiadne stanice nezodpovedajú vášmu hľadaniu"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nepodarilo sa načítať stanice"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stanica"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Krajina"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Štítky"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webová stránka"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Dátový tok"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL streamu"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nehrá"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Vyberte stanicu"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ukladá sa do vyrovnávacej pamäte…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Práve hrá"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pozastavené"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Opätovné pripojenie…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Hľadanie na YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Hľadanie zlyhalo: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nenašli sa žiadne výsledky na YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Všetky výsledky sú nedostupné"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Sťahovanie: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Zrušené"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Sťahovanie zlyhalo: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Uložené: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Stiahnuť skladbu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Zrušiť sťahovanie"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Zatiaľ žiadne skladby"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Skladby sa tu zobrazia pri počúvaní rozhlasových staníc"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Práve teraz"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -302,7 +300,7 @@ msgstr[0] "pred %d minútou"
 msgstr[1] "pred %d minútami"
 msgstr[2] "pred %d minútami"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -310,7 +308,7 @@ msgstr[0] "pred %d hodinou"
 msgstr[1] "pred %d hodinami"
 msgstr[2] "pred %d hodinami"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sk.po
+++ b/po/sk.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver po zatvorení okna pokračuje v prehrávaní rádia"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Ponuka"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "História skladieb"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Pokračovať v prehrávaní na pozadí"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O aplikácii Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Prehľadávať"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Obľúbené"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informácie o stanici"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Načítaných %d staníc"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Chyba: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Chyba prehrávania: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Práve hrá: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Obnovenie: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Zrušiť autorizáciu Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Odpojiť od Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Pripojiť k Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizácia Last.fm zrušená"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Odpojené od Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Pripájanie k Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nepodarilo sa pripojiť k Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Udeľte prístup vo svojom prehliadači…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizácia Last.fm vypršala"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Pripojené k Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Objavte viac ako 30 000 overených rozhlasových staníc z celého sveta"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Pri prehľadávaní označte stanice hviezdičkou a pridajte ich sem"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Hľadať stanice…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Všetky jazyky"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrovať podľa jazyka"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Všetky krajiny"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrovať podľa krajiny"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Žiadne stanice"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Načítavanie…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u z %d staníc"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanice: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Načítavanie staníc"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Žiadne výsledky"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Prosím, čakajte…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Žiadne stanice nezodpovedajú vášmu hľadaniu"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nepodarilo sa načítať stanice"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL streamu"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nehrá"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Vyberte stanicu"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ukladá sa do vyrovnávacej pamäte…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Práve hrá"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pozastavené"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Opätovné pripojenie…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Práve hrá"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sl.po
+++ b/po/sl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100>=3 && "
 "n%100<=4 ? 2 : 3);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver po zaprtju okna nadaljuje s predvajanjem radia"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Zgodovina pesmi"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Nadaljuj predvajanje v ozadju"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Brskaj"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Priljubljeni"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Podatki o postaji"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Naloženih %d postaj"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Napaka: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Napaka predvajanja: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Zdaj predvaja: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nadaljevanje: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Prekliči pooblastilo Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Prekini povezavo z Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Poveži se z Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Pooblastilo Last.fm preklicano"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Povezava z Last.fm prekinjena"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Povezovanje z Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Povezava z Last.fm ni uspela"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dovolite dostop v brskalniku…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Pooblastilo Last.fm je poteklo"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Povezan z Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Odkrijte več kot 30.000 preverjenih radijskih postaj z vsega sveta"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Med brskanjem označite postaje z zvezdico, da jih dodate sem"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Iskanje postaj…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Vsi jeziki"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Vse države"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtriraj po državi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ni postaj"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Nalaganje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d postaj"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Postaje: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Nalaganje postaj"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ni rezultatov"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Prosimo, počakajte…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nobena postaja ne ustreza vašemu iskanju"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Postaj ni bilo mogoče naložiti"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL pretoka"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne predvaja"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Izberite postajo"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Predpomnjenje…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Zdaj predvaja"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Začasno ustavljeno"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ponovna povezava…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Zdaj predvaja"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sl.po
+++ b/po/sl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100>=3 && "
 "n%100<=4 ? 2 : 3);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver po zaprtju okna nadaljuje s predvajanjem radia"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Zgodovina pesmi"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Nadaljuj predvajanje v ozadju"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Brskaj"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Priljubljeni"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Podatki o postaji"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Naloženih %d postaj"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Napaka: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Napaka predvajanja: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Zdaj predvaja: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nadaljevanje: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Prekliči pooblastilo Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Prekini povezavo z Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Poveži se z Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Pooblastilo Last.fm preklicano"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Povezava z Last.fm prekinjena"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Povezovanje z Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Povezava z Last.fm ni uspela"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dovolite dostop v brskalniku…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Pooblastilo Last.fm je poteklo"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Povezan z Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Odkrijte več kot 30.000 preverjenih radijskih postaj z vsega sveta"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Ni priljubljenih"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Med brskanjem označite postaje z zvezdico, da jih dodate sem"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Iskanje postaj…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Vsi jeziki"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Vse države"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtriraj po državi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ni postaj"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Nalaganje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d postaj"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Postaje: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Nalaganje postaj"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ni rezultatov"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Prosimo, počakajte…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nobena postaja ne ustreza vašemu iskanju"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Postaj ni bilo mogoče naložiti"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Postaja"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Država"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Spletna stran"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitna hitrost"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL pretoka"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne predvaja"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Izberite postajo"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Predpomnjenje…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Zdaj predvaja"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Začasno ustavljeno"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ponovna povezava…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Iskanje na YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Iskanje ni uspelo: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ni najdenih rezultatov YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Vsi rezultati so nedosegljivi"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Prenašanje: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Preklicano"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Prenos ni uspel: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Shranjeno: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Prenesi pesem"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Prekliči prenos"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Še ni pesmi"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Pesmi se bodo pojavile tukaj, ko poslušate radijske postaje"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ravnokar"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -304,7 +302,7 @@ msgstr[1] "pred %d minutama"
 msgstr[2] "pred %d minutami"
 msgstr[3] "pred %d minutami"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -313,7 +311,7 @@ msgstr[1] "pred %d urama"
 msgstr[2] "pred %d urami"
 msgstr[3] "pred %d urami"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sq.po
+++ b/po/sq.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver vazhdon ta luajë radion pasi dritarja është mbyllur"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyja"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historiku i këngëve"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Vazhdo luajtjen në sfond"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Rreth Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Të preferuarat"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informacione mbi stacionin"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stacione të ngarkuara"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Gabim: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Gabim luajtjeje: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Duke luajtur tani: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Duke rifilluar: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anulo autorizimin e Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Shkëputu nga Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Lidhu me Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizimi i Last.fm u anulua"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "U shkëput nga Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Po lidhet me Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Lidhja me Last.fm dështoi"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Jepni akses te shfletuesi juaj…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizimi i Last.fm ka skaduar"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Lidhur me Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Zbuloni mbi 30.000 stacione radio të verifikuara nga mbarë bota"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nuk ka të preferuara"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Vendosni yll stacioneve gjatë shfletimit për t'i shtuar këtu"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Kërko stacione…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Të gjitha gjuhët"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtro sipas gjuhës"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Të gjitha vendet"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtro sipas vendit"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Asnjë stacion"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Duke ngarkuar…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u nga %d stacione"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacione: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Duke ngarkuar stacionet"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Asnjë rezultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ju lutem prisni…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Asnjë stacion nuk përputhet me kërkimin tuaj"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nuk mundën të ngarkoheshin stacionet"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stacioni"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Vendi"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiketat"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Faqja e internetit"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeku"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Shpejtësia e biteve"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL e transmetimit"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Nuk po luhet"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Zgjidhni një stacion"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Po mbushet buffer-i…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Duke luajtur tani"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Në pauzë"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Duke u rilidhur…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Duke kërkuar në YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Kërkimi dështoi: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nuk u gjetën rezultate YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Të gjitha rezultatet janë të padisponueshme"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Duke shkarkuar: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "U anulua"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Shkarkimi dështoi: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "U ruajt: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Shkarko kërgën"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Anulo shkarkimin"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ende asnjë këngë"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Këngët do të shfaqen këtu ndërsa dëgjoni stacione radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Pikërisht tani"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min më parë"
 msgstr[1] "%d min më parë"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d orë më parë"
 msgstr[1] "%d orë më parë"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sq.po
+++ b/po/sq.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sq\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver vazhdon ta luajë radion pasi dritarja është mbyllur"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyja"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historiku i këngëve"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Vazhdo luajtjen në sfond"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Rreth Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Shfleto"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Të preferuarat"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informacione mbi stacionin"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stacione të ngarkuara"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Gabim: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Gabim luajtjeje: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Duke luajtur tani: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Duke rifilluar: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anulo autorizimin e Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Shkëputu nga Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Lidhu me Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizimi i Last.fm u anulua"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "U shkëput nga Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Po lidhet me Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Lidhja me Last.fm dështoi"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Jepni akses te shfletuesi juaj…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizimi i Last.fm ka skaduar"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Lidhur me Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Zbuloni mbi 30.000 stacione radio të verifikuara nga mbarë bota"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Vendosni yll stacioneve gjatë shfletimit për t'i shtuar këtu"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Kërko stacione…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Të gjitha gjuhët"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtro sipas gjuhës"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Të gjitha vendet"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtro sipas vendit"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Asnjë stacion"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Duke ngarkuar…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u nga %d stacione"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacione: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Duke ngarkuar stacionet"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Asnjë rezultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ju lutem prisni…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Asnjë stacion nuk përputhet me kërkimin tuaj"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nuk mundën të ngarkoheshin stacionet"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL e transmetimit"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Nuk po luhet"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Zgjidhni një stacion"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Po mbushet buffer-i…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Duke luajtur tani"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Në pauzë"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Duke u rilidhur…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Duke luajtur tani"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sr.po
+++ b/po/sr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver наставља да репродукује радио након затварања прозора"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Мени"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Историја песама"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Настави репродукцију у позадини"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "О програму Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Прегледај"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Омиљени"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Подаци о станици"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Учитано %d станица"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Грешка при репродукцији: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Сада свира: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Наставља се: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Откажи ауторизацију за Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Прекини везу са Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Повежи се са Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Ауторизација за Last.fm је отказана"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Веза са Last.fm прекинута"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Повезивање са Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Повезивање са Last.fm није успело"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Дозволите приступ у прегледачу…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Ауторизација за Last.fm је истекла"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Повезан са Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Откријте 30.000+ проверених радио станица из целог света"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Нема омиљених"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Означите станице звездицом током прегледања да бисте их додали овде"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Претражи станице…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Сви језици"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Филтрирај по језику"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Све земље"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Филтрирај по земљи"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Нема станица"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Учитавање…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u од %d станица"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станице: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Учитавање станица"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Нема резултата"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Молимо сачекајте…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ниједна станица не одговара вашој претрази"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Није могуће учитати станице"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станица"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Земља"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Ознаке"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Веб-сајт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрејт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL стрима"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Не свира"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Изаберите станицу"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Пуњење бафера…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Сада свира"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Паузирано"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Поновно повезивање…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Претраживање YouTubea…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Претрага неуспешна: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Нису пронађени YouTube резултати"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Сви резултати недоступни"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Преузимање: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Отказано"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Преузимање неуспешно: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Сачувано: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Преузми песму"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Откажи преузимање"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Још нема песама"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Песме ће се појавити овде док слушате радио станице"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Управо сада"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "пре %d минут"
 msgstr[1] "пре %d минута"
 msgstr[2] "пре %d минута"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "пре %d сат"
 msgstr[1] "пре %d сата"
 msgstr[2] "пре %d сати"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sr.po
+++ b/po/sr.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver наставља да репродукује радио након затварања прозора"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Мени"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Историја песама"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Настави репродукцију у позадини"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "О програму Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Прегледај"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Омиљени"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Подаци о станици"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Учитано %d станица"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Грешка: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Грешка при репродукцији: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Сада свира: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Наставља се: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Откажи ауторизацију за Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Прекини везу са Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Повежи се са Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Ауторизација за Last.fm је отказана"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Веза са Last.fm прекинута"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Повезивање са Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Повезивање са Last.fm није успело"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Дозволите приступ у прегледачу…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Ауторизација за Last.fm је истекла"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Повезан са Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Откријте 30.000+ проверених радио станица из целог света"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Означите станице звездицом током прегледања да бисте их додали овде"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Претражи станице…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Сви језици"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Филтрирај по језику"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Све земље"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Филтрирај по земљи"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Нема станица"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Учитавање…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u од %d станица"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станице: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Учитавање станица"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Нема резултата"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Молимо сачекајте…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ниједна станица не одговара вашој претрази"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Није могуће учитати станице"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL стрима"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Не свира"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Изаберите станицу"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Пуњење бафера…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Сада свира"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Паузирано"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Поновно повезивање…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Сада свира"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver nastavlja da reprodukuje radio nakon zatvaranja prozora"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Istorija pesama"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Nastavi reprodukciju u pozadini"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Omiljeni"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Podaci o stanici"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Učitano %d stanica"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Greška: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Greška pri reprodukciji: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sada svira: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nastavlja se: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Otkaži autorizaciju za Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Prekini vezu sa Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Poveži se sa Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizacija za Last.fm je otkazana"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Veza sa Last.fm prekinuta"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Povezivanje sa Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Povezivanje sa Last.fm nije uspelo"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dozvolite pristup u pregledaču…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizacija za Last.fm je istekla"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Povezan sa Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Otkrijte 30.000+ proverenih radio stanica iz celog sveta"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nema omiljenih"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Označite stanice zvezdicom tokom pregledanja da biste ih dodali ovde"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Pretraži stanice…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Svi jezici"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Sve zemlje"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtriraj po zemlji"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nema stanica"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Učitavanje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d stanica"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanice: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Učitavanje stanica"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nema rezultata"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Molimo sačekajte…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nijedna stanica ne odgovara vašoj pretrazi"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Nije moguće učitati stanice"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stanica"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Zemlja"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Veb-sajt"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrejt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL strima"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne svira"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Izaberite stanicu"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Punjenje bafera…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Sada svira"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ponovno povezivanje…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Pretraživanje YouTubea…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Pretraga neuspešna: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nisu pronađeni YouTube rezultati"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Svi rezultati nedostupni"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Preuzimanje: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Otkazano"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Preuzimanje neuspešno: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Sačuvano: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Preuzmi pesmu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Otkaži preuzimanje"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Još nema pesama"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Pesme će se pojaviti ovde dok slušate radio stanice"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Upravo sada"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "pre %d minut"
 msgstr[1] "pre %d minuta"
 msgstr[2] "pre %d minuta"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "pre %d sat"
 msgstr[1] "pre %d sata"
 msgstr[2] "pre %d sati"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sr@latin\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver nastavlja da reprodukuje radio nakon zatvaranja prozora"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meni"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Istorija pesama"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Nastavi reprodukciju u pozadini"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "O programu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Pregledaj"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Omiljeni"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Podaci o stanici"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Učitano %d stanica"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Greška: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Greška pri reprodukciji: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sada svira: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Nastavlja se: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Otkaži autorizaciju za Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Prekini vezu sa Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Poveži se sa Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizacija za Last.fm je otkazana"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Veza sa Last.fm prekinuta"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Povezivanje sa Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Povezivanje sa Last.fm nije uspelo"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dozvolite pristup u pregledaču…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizacija za Last.fm je istekla"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Povezan sa Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Otkrijte 30.000+ proverenih radio stanica iz celog sveta"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Označite stanice zvezdicom tokom pregledanja da biste ih dodali ovde"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Pretraži stanice…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Svi jezici"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtriraj po jeziku"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Sve zemlje"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtriraj po zemlji"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nema stanica"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Učitavanje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u od %d stanica"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stanice: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Učitavanje stanica"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nema rezultata"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Molimo sačekajte…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nijedna stanica ne odgovara vašoj pretrazi"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Nije moguće učitati stanice"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL strima"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne svira"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Izaberite stanicu"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Punjenje bafera…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Sada svira"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ponovno povezivanje…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Sada svira"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sv.po
+++ b/po/sv.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver fortsätter att spela radio efter att fönstret stängts"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Meny"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Låthistorik"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Fortsätt spela i bakgrunden"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriter"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stationsinformation"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationer laddade"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Fel: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Uppspelningsfel: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spelar nu: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Återupptar: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Avbryt Last.fm-auktorisering"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Koppla från Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Anslut till Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-auktorisering avbruten"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Frånkopplad från Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Ansluter till Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Kunde inte ansluta till Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Ge åtkomst i din webbläsare…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-auktorisering löpte ut"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ansluten till Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Upptäck över 30 000 verifierade radiostationer från hela världen"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Stjärnmarkera stationer medan du bläddrar för att lägga till dem här"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Sök stationer…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Alla språk"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrera efter språk"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Alla länder"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrera efter land"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Inga stationer"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Laddar…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d stationer"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationer: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Laddar stationer"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Inga resultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vänta…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Inga stationer matchar din sökning"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Kunde inte ladda stationer"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Ström-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Spelar inte"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Välj en station"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buffrar…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Spelar nu"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Pausad"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Återansluter…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Spelar nu"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sv.po
+++ b/po/sv.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver fortsätter att spela radio efter att fönstret stängts"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Meny"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Låthistorik"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Fortsätt spela i bakgrunden"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Om Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Bläddra"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriter"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stationsinformation"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stationer laddade"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Fel: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Uppspelningsfel: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Spelar nu: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Återupptar: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Avbryt Last.fm-auktorisering"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Koppla från Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Anslut till Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm-auktorisering avbruten"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Frånkopplad från Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Ansluter till Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Kunde inte ansluta till Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Ge åtkomst i din webbläsare…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm-auktorisering löpte ut"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ansluten till Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Upptäck över 30 000 verifierade radiostationer från hela världen"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Inga favoriter"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Stjärnmarkera stationer medan du bläddrar för att lägga till dem här"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Sök stationer…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Alla språk"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrera efter språk"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Alla länder"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrera efter land"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Inga stationer"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Laddar…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u av %d stationer"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stationer: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Laddar stationer"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Inga resultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vänta…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Inga stationer matchar din sökning"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Kunde inte ladda stationer"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Station"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Land"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Taggar"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webbplats"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bithastighet"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Ström-URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Spelar inte"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Välj en station"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buffrar…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Spelar nu"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Pausad"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Återansluter…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Söker på YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Sökning misslyckades: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Inga YouTube-resultat hittades"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Alla resultat otillgängliga"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Laddar ner: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Avbruten"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Nedladdning misslyckades: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Sparad: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Ladda ner låt"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Avbryt nedladdning"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Inga låtar ännu"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Låtar visas här medan du lyssnar på radiostationer"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Just nu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min sedan"
 msgstr[1] "%d min sedan"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d timme sedan"
 msgstr[1] "%d timmar sedan"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/sw.po
+++ b/po/sw.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: sw\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver inaendelea kucheza redio baada ya dirisha kufungwa"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historia ya Nyimbo"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Endelea kucheza chinichini"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Kuhusu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Vinjari"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Vipendwa"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Maelezo ya kituo"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Vituo %d vimepakiwa"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Hitilafu: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Hitilafu ya uchezaji: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Inacheza sasa: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Inaendelea: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Ghairi uidhinishaji wa Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Tenganisha kutoka Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Unganisha na Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Uidhinishaji wa Last.fm umeghairiwa"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Umetenganishwa kutoka Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Inaunganisha na Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Imeshindwa kuunganisha na Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Toa ufikiaji katika kivinjari chako…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Muda wa uidhinishaji wa Last.fm umekwisha"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Umeunganishwa na Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Gundua vituo vya redio 30,000+ vilivyothibitishwa kutoka ulimwenguni kote"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Weka nyota kwenye vituo unapovinjari ili kuviongeza hapa"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Tafuta vituo…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Lugha zote"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Chuja kwa lugha"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Nchi zote"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Chuja kwa nchi"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Hakuna vituo"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Inapakia…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u kati ya %d vituo"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Vituo: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Vituo vinapakiwa"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Hakuna matokeo"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Tafadhali subiri…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Hakuna kituo kinacholingana na utafutaji wako"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Haikuweza kupakia vituo"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL ya utiririshaji"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Haichezi"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Chagua kituo"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Inahifadhi kwa muda…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Inacheza sasa"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Imesimamishwa"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Inaunganisha tena…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Inacheza sasa"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/sw.po
+++ b/po/sw.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: sw\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver inaendelea kucheza redio baada ya dirisha kufungwa"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historia ya Nyimbo"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Endelea kucheza chinichini"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Kuhusu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Vinjari"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Vipendwa"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Maelezo ya kituo"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Vituo %d vimepakiwa"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Hitilafu: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Hitilafu ya uchezaji: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Inacheza sasa: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Inaendelea: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Ghairi uidhinishaji wa Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Tenganisha kutoka Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Unganisha na Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Uidhinishaji wa Last.fm umeghairiwa"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Umetenganishwa kutoka Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Inaunganisha na Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Imeshindwa kuunganisha na Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Toa ufikiaji katika kivinjari chako…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Muda wa uidhinishaji wa Last.fm umekwisha"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Umeunganishwa na Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Gundua vituo vya redio 30,000+ vilivyothibitishwa kutoka ulimwenguni kote"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Hakuna vipendwa"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Weka nyota kwenye vituo unapovinjari ili kuviongeza hapa"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Tafuta vituo…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Lugha zote"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Chuja kwa lugha"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Nchi zote"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Chuja kwa nchi"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Hakuna vituo"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Inapakia…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u kati ya %d vituo"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Vituo: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Vituo vinapakiwa"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Hakuna matokeo"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Tafadhali subiri…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Hakuna kituo kinacholingana na utafutaji wako"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Haikuweza kupakia vituo"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Kituo"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Nchi"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Lebo"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Tovuti"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodeki"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Kiwango cha biti"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ya utiririshaji"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Haichezi"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Chagua kituo"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Inahifadhi kwa muda…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Inacheza sasa"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Imesimamishwa"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Inaunganisha tena…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Inatafuta kwenye YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Utafutaji umeshindwa: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Hakuna matokeo ya YouTube yaliyopatikana"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Matokeo yote hayapatikani"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Inapakua: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Imeghairiwa"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Upakuaji umeshindwa: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Imehifadhiwa: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Pakua wimbo"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Ghairi upakuaji"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Hakuna Nyimbo Bado"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Nyimbo zitaonekana hapa unaposikiliza vituo vya redio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Sasa hivi"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "dakika %d zilizopita"
 msgstr[1] "dakika %d zilizopita"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "saa %d iliyopita"
 msgstr[1] "masaa %d yaliyopita"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/szl.po
+++ b/po/szl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: szl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver dalij gro radyjo po zawarciu ôkna"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Historyjo piosenek"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Grej dalij w tle"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Ło programie Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Przeglōndej"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Oblubōne"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informacyjo ô stacyji"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Naczytano %d stacyji"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Feler: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Feler ôdtworzanio: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Teroz gro: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wznowiyniu: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Anuluj autorizacyjo Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Rozłōncz z Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Połōncz z Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizacyjo Last.fm anulowano"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Rozłōnczono z Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Łōnczenie z Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Niy szło sie połōnczyć z Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dej dostymp we przeglōndarce…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Autorizacyjo Last.fm wygasła"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Połōnczono z Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Odkryj wiyncyj jak 30 000 zweryfikowanych stacyj radiowych ze cołkigo świata"
@@ -119,61 +127,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Ôznacz stacyje gwiozdkōm przi przeglōndaniu, coby je sam dodać"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Szukej stacyje…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Wszyskie godki"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtruj podug godki"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Wszyskie kraje"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtruj podug kraju"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Niy ma stacyji"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ladowanie…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ze %d stacyji"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacyje: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ladowanie stacyji"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Niy ma wynikōw"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Proszã czekać…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Żodne stacyje niy pasujōm do twojigo szukanio"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Niy szło naczytać stacyji"
 
@@ -206,25 +214,29 @@ msgid "Stream URL"
 msgstr "URL strumiynia"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Niy gro"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Ôbier stacyjõ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buforowanie…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Teroz gro"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Wstrzimano"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Łōnczyniu…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Teroz gro"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/szl.po
+++ b/po/szl.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: szl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,292 +11,290 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
 "|| n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver dalij gro radyjo po zawarciu ôkna"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Historyjo piosenek"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Grej dalij w tle"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Ło programie Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Przeglōndej"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Oblubōne"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informacyjo ô stacyji"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Naczytano %d stacyji"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Feler: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Feler ôdtworzanio: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Teroz gro: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Wznowiyniu: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Anuluj autorizacyjo Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Rozłōncz z Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Połōncz z Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Autorizacyjo Last.fm anulowano"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Rozłōnczono z Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Łōnczenie z Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Niy szło sie połōnczyć z Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dej dostymp we przeglōndarce…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Autorizacyjo Last.fm wygasła"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Połōnczono z Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Odkryj wiyncyj jak 30 000 zweryfikowanych stacyj radiowych ze cołkigo świata"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Żodne oblubōne"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Ôznacz stacyje gwiozdkōm przi przeglōndaniu, coby je sam dodać"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Szukej stacyje…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Wszyskie godki"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtruj podug godki"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Wszyskie kraje"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtruj podug kraju"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Niy ma stacyji"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ladowanie…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ze %d stacyji"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stacyje: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ladowanie stacyji"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Niy ma wynikōw"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Proszã czekać…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Żodne stacyje niy pasujōm do twojigo szukanio"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Niy szło naczytać stacyji"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stacyjo"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Kraj"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tagi"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Strōna internetowo"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Przepływność"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL strumiynia"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Niy gro"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Ôbier stacyjõ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buforowanie…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Teroz gro"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Wstrzimano"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Łōnczyniu…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Szukaniy na YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Szukaniy niy udało sie: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Niy znŏdniyto wynikōw na YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Wszyskie wyniki sōm niydostympne"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Pobieranie: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Ôdciepniynte"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Pobieranie niy udało sie: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Spamiyntano: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Pobier pieśń"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Ôdciep pobieranie"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Żŏdne piosenki"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Piosenki pokożōm sie tukej jak bydyiesz słuchać stacyj radiowych"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Prawie teroz"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -304,7 +302,7 @@ msgstr[0] "%d min tymu"
 msgstr[1] "%d min tymu"
 msgstr[2] "%d min tymu"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -312,7 +310,7 @@ msgstr[0] "%d godzina tymu"
 msgstr[1] "%d godziny tymu"
 msgstr[2] "%d godzin tymu"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ta.po
+++ b/po/ta.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ta\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "சாளரம் மூடப்பட்ட பிறகும் Receiver வானொலியை இயக்கிக்கொண்டே இருக்கும்"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "பட்டி"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "பாடல் வரலாறு"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "பின்னணியில் இயக்கிக்கொண்டே இரு"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver பற்றி"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "உலாவு"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "பிடித்தவை"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "நிலைய தகவல்"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d நிலையங்கள் ஏற்றப்பட்டன"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "பிழை: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "இயக்கப் பிழை: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "இப்போது இயங்குகிறது: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "தொடர்கிறது: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm அங்கீகாரத்தை ரத்து செய்"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm இலிருந்து துண்டி"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm உடன் இணை"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm அங்கீகாரம் ரத்து செய்யப்பட்டது"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm இலிருந்து துண்டிக்கப்பட்டது"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm உடன் இணைக்கிறது…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm உடன் இணைக்க இயலவில்லை"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "உங்கள் உலாவியில் அணுகலை வழங்குங்கள்…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm அங்கீகார நேரம் முடிந்தது"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm உடன் இணைக்கப்பட்டது"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "உலகம் முழுவதிலிருந்து 30,000+ சரிபார்க்கப்பட்ட வானொலி நிலையங்களைக் கண்டறியுங்கள்"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "இங்கே சேர்க்க உலாவும்போது நிலையங்களை நட்சத்திரமிடுங்கள்"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "நிலையங்களைத் தேடுங்கள்…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "அனைத்து மொழிகள்"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "மொழி வாரியாக வடிகட்டு"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "அனைத்து நாடுகளும்"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "நாடு வாரியாக வடிகட்டு"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "நிலையங்கள் இல்லை"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "ஏற்றுகிறது…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d நிலையங்கள்"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "நிலையங்கள்: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "நிலையங்கள் ஏற்றப்படுகின்றன"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "முடிவுகள் இல்லை"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "தயவுசெய்து காத்திருங்கள்…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "உங்கள் தேடலுக்கு பொருத்தமான நிலையம் இல்லை"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "நிலையங்களை ஏற்ற இயலவில்லை"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ஸ்ட்ரீம் URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "இயங்கவில்லை"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ஒரு நிலையத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "இடையகப்படுத்துகிறது…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "இப்போது இயங்குகிறது"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "இடைநிறுத்தம்"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "மீண்டும் இணைகிறது…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "இப்போது இயங்குகிறது"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ta.po
+++ b/po/ta.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ta\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "சாளரம் மூடப்பட்ட பிறகும் Receiver வானொலியை இயக்கிக்கொண்டே இருக்கும்"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "பட்டி"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "பாடல் வரலாறு"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "பின்னணியில் இயக்கிக்கொண்டே இரு"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver பற்றி"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "உலாவு"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "பிடித்தவை"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "நிலைய தகவல்"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d நிலையங்கள் ஏற்றப்பட்டன"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "பிழை: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "இயக்கப் பிழை: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "இப்போது இயங்குகிறது: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "தொடர்கிறது: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm அங்கீகாரத்தை ரத்து செய்"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm இலிருந்து துண்டி"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm உடன் இணை"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm அங்கீகாரம் ரத்து செய்யப்பட்டது"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm இலிருந்து துண்டிக்கப்பட்டது"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm உடன் இணைக்கிறது…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm உடன் இணைக்க இயலவில்லை"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "உங்கள் உலாவியில் அணுகலை வழங்குங்கள்…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm அங்கீகார நேரம் முடிந்தது"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm உடன் இணைக்கப்பட்டது"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "உலகம் முழுவதிலிருந்து 30,000+ சரிபார்க்கப்பட்ட வானொலி நிலையங்களைக் கண்டறியுங்கள்"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "பிடித்தவை இல்லை"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "இங்கே சேர்க்க உலாவும்போது நிலையங்களை நட்சத்திரமிடுங்கள்"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "நிலையங்களைத் தேடுங்கள்…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "அனைத்து மொழிகள்"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "மொழி வாரியாக வடிகட்டு"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "அனைத்து நாடுகளும்"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "நாடு வாரியாக வடிகட்டு"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "நிலையங்கள் இல்லை"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "ஏற்றுகிறது…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d நிலையங்கள்"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "நிலையங்கள்: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "நிலையங்கள் ஏற்றப்படுகின்றன"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "முடிவுகள் இல்லை"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "தயவுசெய்து காத்திருங்கள்…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "உங்கள் தேடலுக்கு பொருத்தமான நிலையம் இல்லை"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "நிலையங்களை ஏற்ற இயலவில்லை"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "நிலையம்"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "நாடு"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "குறிச்சொற்கள்"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "இணையதளம்"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "கோடக்"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "பிட்ரேட்"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ஸ்ட்ரீம் URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "இயங்கவில்லை"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ஒரு நிலையத்தைத் தேர்ந்தெடுக்கவும்"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "இடையகப்படுத்துகிறது…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "இப்போது இயங்குகிறது"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "இடைநிறுத்தம்"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "மீண்டும் இணைகிறது…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube இல் தேடுகிறது…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "தேடல் தோல்வி: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube முடிவுகள் கிடைக்கவில்லை"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "அனைத்து முடிவுகளும் கிடைக்கவில்லை"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "பதிவிறக்குகிறது: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ரத்து செய்யப்பட்டது"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "பதிவிறக்கம் தோல்வி: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "சேமிக்கப்பட்டது: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "பாடலைப் பதிவிறக்கு"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "பதிவிறக்கத்தை ரத்து செய்"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "இதுவரை பாடல்கள் இல்லை"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "வானொலி நிலையங்களைக் கேட்கும்போது பாடல்கள் இங்கே தோன்றும்"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "இப்போது"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d நிமிடம் முன்"
 msgstr[1] "%d நிமிடங்கள் முன்"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d மணி நேரம் முன்"
 msgstr[1] "%d மணி நேரங்கள் முன்"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/te.po
+++ b/po/te.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: te\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "విండో మూసివేసిన తర్వాత కూడా Receiver రేడియోను ప్లే చేస్తూనే ఉంటుంది"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "మెనూ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "పాట చరిత్ర"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "నేపథ్యంలో ప్లే చేస్తూ ఉండండి"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver గురించి"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "బ్రౌజ్ చేయండి"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ఇష్టమైనవి"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "స్టేషన్ సమాచారం"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d స్టేషన్లు లోడ్ అయ్యాయి"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "లోపం: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ప్లేబ్యాక్ లోపం: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ఇప్పుడు ప్లే అవుతోంది: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "తిరిగి ప్రారంభం: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ఆథరైజేషన్ రద్దు చేయండి"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm నుండి డిస్‌కనెక్ట్ చేయండి"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm కు కనెక్ట్ చేయండి"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ఆథరైజేషన్ రద్దయింది"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm నుండి డిస్‌కనెక్ట్ అయింది"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm కు కనెక్ట్ అవుతోంది…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm కు కనెక్ట్ కాలేకపోయింది"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "మీ బ్రౌజర్‌లో యాక్సెస్ ఇవ్వండి…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ఆథరైజేషన్ సమయం ముగిసింది"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm కు కనెక్ట్ అయింది"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ప్రపంచవ్యాప్తంగా 30,000+ ధృవీకరించిన రేడియో స్టేషన్‌లను కనుగొనండి"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ఇక్కడ జోడించడానికి బ్రౌజ్ చేస్తున్నప్పుడు స్టేషన్‌లకు స్టార్ చేయండి"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "స్టేషన్లు వెతకండి…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "అన్ని భాషలు"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "భాష ద్వారా ఫిల్టర్ చేయండి"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "అన్ని దేశాలు"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "దేశం ప్రకారం ఫిల్టర్"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "స్టేషన్లు లేవు"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "లోడ్ అవుతోంది…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d స్టేషన్లు"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "స్టేషన్లు: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "స్టేషన్లు లోడ్ అవుతున్నాయి"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ఫలితాలు లేవు"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "దయచేసి వేచి ఉండండి…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "మీ శోధనకు ఏ స్టేషన్ సరిపోలడం లేదు"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "స్టేషన్లు లోడ్ చేయలేకపోయాము"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "స్ట్రీమ్ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ప్లే అవడం లేదు"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ఒక స్టేషన్ ఎంచుకోండి"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "బఫర్ అవుతోంది…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ఇప్పుడు ప్లే అవుతోంది"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "విరామం"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "మళ్ళీ కనెక్ట్ అవుతోంది…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ఇప్పుడు ప్లే అవుతోంది"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/te.po
+++ b/po/te.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: te\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "విండో మూసివేసిన తర్వాత కూడా Receiver రేడియోను ప్లే చేస్తూనే ఉంటుంది"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "మెనూ"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "పాట చరిత్ర"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "నేపథ్యంలో ప్లే చేస్తూ ఉండండి"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver గురించి"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "బ్రౌజ్ చేయండి"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ఇష్టమైనవి"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "స్టేషన్ సమాచారం"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d స్టేషన్లు లోడ్ అయ్యాయి"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "లోపం: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ప్లేబ్యాక్ లోపం: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ఇప్పుడు ప్లే అవుతోంది: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "తిరిగి ప్రారంభం: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ఆథరైజేషన్ రద్దు చేయండి"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm నుండి డిస్‌కనెక్ట్ చేయండి"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm కు కనెక్ట్ చేయండి"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ఆథరైజేషన్ రద్దయింది"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm నుండి డిస్‌కనెక్ట్ అయింది"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm కు కనెక్ట్ అవుతోంది…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm కు కనెక్ట్ కాలేకపోయింది"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "మీ బ్రౌజర్‌లో యాక్సెస్ ఇవ్వండి…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ఆథరైజేషన్ సమయం ముగిసింది"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm కు కనెక్ట్ అయింది"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ప్రపంచవ్యాప్తంగా 30,000+ ధృవీకరించిన రేడియో స్టేషన్‌లను కనుగొనండి"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ఇష్టమైనవి లేవు"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ఇక్కడ జోడించడానికి బ్రౌజ్ చేస్తున్నప్పుడు స్టేషన్‌లకు స్టార్ చేయండి"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "స్టేషన్లు వెతకండి…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "అన్ని భాషలు"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "భాష ద్వారా ఫిల్టర్ చేయండి"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "అన్ని దేశాలు"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "దేశం ప్రకారం ఫిల్టర్"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "స్టేషన్లు లేవు"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "లోడ్ అవుతోంది…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d స్టేషన్లు"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "స్టేషన్లు: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "స్టేషన్లు లోడ్ అవుతున్నాయి"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ఫలితాలు లేవు"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "దయచేసి వేచి ఉండండి…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "మీ శోధనకు ఏ స్టేషన్ సరిపోలడం లేదు"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "స్టేషన్లు లోడ్ చేయలేకపోయాము"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "స్టేషన్"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "దేశం"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ట్యాగ్‌లు"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "వెబ్‌సైట్"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "కోడెక్"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "బిట్‌రేట్"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "స్ట్రీమ్ URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ప్లే అవడం లేదు"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ఒక స్టేషన్ ఎంచుకోండి"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "బఫర్ అవుతోంది…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ఇప్పుడు ప్లే అవుతోంది"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "విరామం"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "మళ్ళీ కనెక్ట్ అవుతోంది…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube లో వెతుకుతోంది…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "శోధన విఫలం: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube ఫలితాలు కనుగొనబడలేదు"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "అన్ని ఫలితాలు అందుబాటులో లేవు"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "డౌన్‌లోడ్ అవుతోంది: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "రద్దు చేయబడింది"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "డౌన్‌లోడ్ విఫలం: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "సేవ్ చేయబడింది: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "పాట డౌన్‌లోడ్ చేయండి"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "డౌన్‌లోడ్ రద్దు చేయండి"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ఇంకా పాటలు లేవు"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "రేడియో స్టేషన్‌లు వింటున్నప్పుడు పాటలు ఇక్కడ కనిపిస్తాయి"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ఇప్పుడే"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d నిమిషం క్రితం"
 msgstr[1] "%d నిమిషాల క్రితం"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d గంట క్రితం"
 msgstr[1] "%d గంటల క్రితం"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/tg.po
+++ b/po/tg.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: tg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver пас аз пӯшидани тиреза навохтани радиоро идома медиҳад"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Таърихи сурудҳо"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Дар замина навохтанро идома диҳед"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Дар бораи Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Дидан"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Дӯстдоштаҳо"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Маълумоти истгоҳ"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d стансия бор карда шуд"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Хато: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Хатои пахш: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ҳоло пахш мешавад: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Идома додан: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Лағви иҷозати Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Ҷудо шудан аз Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Пайваст шудан ба Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Иҷозати Last.fm лағв шуд"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Аз Last.fm ҷудо шуд"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Ба Last.fm пайваст мешавад…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Ба Last.fm пайваст шудан нашуд"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Дар браузери худ дастрасӣ диҳед…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Вақти иҷозати Last.fm гузашт"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Ба Last.fm пайваст шуд"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Аз саросари ҷаҳон зиёда аз 30,000 радиоистгоҳи тасдиқшударо кашф кунед"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Дӯстдоштаҳо нест"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Барои илова кардан дар ин ҷо ҳангоми дидан ба истгоҳҳо ситора гузоред"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Ҷустуҷӯи стансияҳо…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Ҳамаи забонҳо"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Филтр аз рӯи забон"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Ҳамаи кишварҳо"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Филтр аз рӯи кишвар"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Стансия нест"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Бор шудан…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u аз %d стансия"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Стансияҳо: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Стансияҳо бор мешаванд"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Натиҷа нест"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Лутфан интизор шавед…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ягон стансия ба ҷустуҷӯи шумо мувофиқ нест"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Стансияҳоро бор кардан имконнопазир нест"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Истгоҳ"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Кишвар"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Тегҳо"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Вебсайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Суръати бит"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL-и ҷараён"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Пахш намешавад"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Стансияро интихоб кунед"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферкунӣ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Ҳоло пахш мешавад"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Таваққуф"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Аз нав пайвастшавӣ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ҷустуҷӯ дар YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Ҷустуҷӯ ноком шуд: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Натиҷаи YouTube ёфт нашуд"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Ҳамаи натиҷаҳо дастнорас нестанд"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Боргирӣ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Бекор карда шуд"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Боргирӣ ноком шуд: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Захира шуд: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Боргирии суруд"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Бекор кардани боргирӣ"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ҳанӯз сурудҳо нест"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Ҳангоми гӯш кардани радиоистгоҳҳо суруд дар ин ҷо пайдо мешаванд"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ҳамин алон"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d дақиқа пеш"
 msgstr[1] "%d дақиқа пеш"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d соат пеш"
 msgstr[1] "%d соат пеш"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/tg.po
+++ b/po/tg.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: tg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver пас аз пӯшидани тиреза навохтани радиоро идома медиҳад"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Таърихи сурудҳо"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Дар замина навохтанро идома диҳед"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Дар бораи Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Дидан"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Дӯстдоштаҳо"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Маълумоти истгоҳ"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d стансия бор карда шуд"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Хато: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Хатои пахш: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ҳоло пахш мешавад: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Идома додан: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Лағви иҷозати Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Ҷудо шудан аз Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Пайваст шудан ба Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Иҷозати Last.fm лағв шуд"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Аз Last.fm ҷудо шуд"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Ба Last.fm пайваст мешавад…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Ба Last.fm пайваст шудан нашуд"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Дар браузери худ дастрасӣ диҳед…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Вақти иҷозати Last.fm гузашт"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Ба Last.fm пайваст шуд"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Аз саросари ҷаҳон зиёда аз 30,000 радиоистгоҳи тасдиқшударо кашф кунед"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Барои илова кардан дар ин ҷо ҳангоми дидан ба истгоҳҳо ситора гузоред"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Ҷустуҷӯи стансияҳо…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Ҳамаи забонҳо"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Филтр аз рӯи забон"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Ҳамаи кишварҳо"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Филтр аз рӯи кишвар"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Стансия нест"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Бор шудан…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u аз %d стансия"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Стансияҳо: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Стансияҳо бор мешаванд"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Натиҷа нест"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Лутфан интизор шавед…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ягон стансия ба ҷустуҷӯи шумо мувофиқ нест"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Стансияҳоро бор кардан имконнопазир нест"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL-и ҷараён"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Пахш намешавад"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Стансияро интихоб кунед"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферкунӣ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Ҳоло пахш мешавад"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Таваққуф"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Аз нав пайвастшавӣ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Ҳоло пахш мешавад"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/th.po
+++ b/po/th.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver เล่นวิทยุต่อไปหลังจากปิดหน้าต่างแล้ว"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "เมนู"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ประวัติเพลง"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "เล่นต่อในเบื้องหลัง"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "เกี่ยวกับ Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "เรียกดู"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "รายการโปรด"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ข้อมูลสถานี"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "โหลด %d สถานีแล้ว"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "ข้อผิดพลาด: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "ข้อผิดพลาดในการเล่น: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "กำลังเล่น: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "กำลังเล่นต่อ: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "ยกเลิกการอนุญาต Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "ตัดการเชื่อมต่อจาก Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "เชื่อมต่อกับ Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "ยกเลิกการอนุญาต Last.fm แล้ว"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "ตัดการเชื่อมต่อจาก Last.fm แล้ว"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "กำลังเชื่อมต่อกับ Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "เชื่อมต่อกับ Last.fm ไม่สำเร็จ"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "ให้สิทธิ์เข้าถึงในเบราว์เซอร์ของคุณ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "การอนุญาต Last.fm หมดเวลา"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "เชื่อมต่อกับ Last.fm แล้ว"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ค้นพบสถานีวิทยุที่ยืนยันแล้วกว่า 30,000 สถานีจากทั่วโลก"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ไม่มีรายการโปรด"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "ติดดาวสถานีขณะเรียกดูเพื่อเพิ่มที่นี่"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ค้นหาสถานี…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "ทุกภาษา"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "กรองตามภาษา"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "ทุกประเทศ"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "กรองตามประเทศ"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ไม่มีสถานี"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "กำลังโหลด…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u จาก %d สถานี"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "สถานี: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "กำลังโหลดสถานี"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "ไม่มีผลลัพธ์"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "กรุณารอสักครู่…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ไม่มีสถานีตรงกับการค้นหาของคุณ"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ไม่สามารถโหลดสถานีได้"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "สถานี"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ประเทศ"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "แท็ก"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "เว็บไซต์"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "ตัวแปลงสัญญาณ"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "บิตเรต"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL สตรีม"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "ไม่ได้เล่น"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "เลือกสถานี"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "กำลังบัฟเฟอร์…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "กำลังเล่น"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "หยุดชั่วคราว"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "กำลังเชื่อมต่อใหม่…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "กำลังค้นหาใน YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "การค้นหาล้มเหลว: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "ไม่พบผลลัพธ์ YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "ผลลัพธ์ทั้งหมดไม่พร้อมใช้งาน"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "กำลังดาวน์โหลด: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "ยกเลิกแล้ว"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "การดาวน์โหลดล้มเหลว: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "บันทึกแล้ว: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ดาวน์โหลดเพลง"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ยกเลิกการดาวน์โหลด"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ยังไม่มีเพลง"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "เพลงจะปรากฏที่นี่เมื่อคุณฟังสถานีวิทยุ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "เมื่อสักครู่"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d นาทีที่แล้ว"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d ชั่วโมงที่แล้ว"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/th.po
+++ b/po/th.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver เล่นวิทยุต่อไปหลังจากปิดหน้าต่างแล้ว"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "เมนู"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ประวัติเพลง"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "เล่นต่อในเบื้องหลัง"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "เกี่ยวกับ Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "เรียกดู"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "รายการโปรด"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ข้อมูลสถานี"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "โหลด %d สถานีแล้ว"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "ข้อผิดพลาด: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "ข้อผิดพลาดในการเล่น: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "กำลังเล่น: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "กำลังเล่นต่อ: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "ยกเลิกการอนุญาต Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "ตัดการเชื่อมต่อจาก Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "เชื่อมต่อกับ Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "ยกเลิกการอนุญาต Last.fm แล้ว"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "ตัดการเชื่อมต่อจาก Last.fm แล้ว"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "กำลังเชื่อมต่อกับ Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "เชื่อมต่อกับ Last.fm ไม่สำเร็จ"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "ให้สิทธิ์เข้าถึงในเบราว์เซอร์ของคุณ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "การอนุญาต Last.fm หมดเวลา"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "เชื่อมต่อกับ Last.fm แล้ว"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "ค้นพบสถานีวิทยุที่ยืนยันแล้วกว่า 30,000 สถานีจากทั่วโลก"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "ติดดาวสถานีขณะเรียกดูเพื่อเพิ่มที่นี่"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ค้นหาสถานี…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "ทุกภาษา"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "กรองตามภาษา"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "ทุกประเทศ"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "กรองตามประเทศ"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ไม่มีสถานี"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "กำลังโหลด…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u จาก %d สถานี"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "สถานี: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "กำลังโหลดสถานี"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "ไม่มีผลลัพธ์"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "กรุณารอสักครู่…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ไม่มีสถานีตรงกับการค้นหาของคุณ"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ไม่สามารถโหลดสถานีได้"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL สตรีม"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "ไม่ได้เล่น"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "เลือกสถานี"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "กำลังบัฟเฟอร์…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "กำลังเล่น"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "หยุดชั่วคราว"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "กำลังเชื่อมต่อใหม่…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "กำลังเล่น"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/tk.po
+++ b/po/tk.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: tk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Penjire ýapylandan soň Receiver radio çalmagy dowam etdirýär"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menýu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Aýdym taryhy"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Arka fonda çalmagy dowam et"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver hakynda"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Göz aýla"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Halanlarym"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stansiýa barada maglumat"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiýa ýüklendi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Ýalňyşlyk: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oýnatma ýalňyşlygy: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Häzir oýnaýar: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Dowam edýär: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ygtyýarnamasyny ýatyr"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-den aýyr"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm-e birikdir"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ygtyýarnamasy ýatyryldy"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-den aýrylan"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-e birikdirilýär…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-e birikdirmek başartmady"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Brauzer arkaly ygtyýar beriň…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ygtyýarnamasynyň wagty geçdi"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm-e birikdirildi"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dünýäniň çar künjünden 30 000+ tassyklanan radio stansiýany tapyň"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Bu ýere goşmak üçin göz aýlanyňyzda stansiýalary ýyldyz bilen belläň"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stansiýalary gözle…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Ähli diller"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Dil boýunça süz"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Ähli ýurtlar"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Ýurt boýunça süzmek"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stansiýa ýok"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ýüklenýär…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiýa"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiýalar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stansiýalar ýüklenýär"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Netije ýok"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Haýyş, garaşyň…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Gözlegiňize gabat gelýän stansiýa tapylmady"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stansiýalary ýükläp bolmady"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Akym URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Oýnamaýar"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stansiýa saýlaň"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buferlenýär…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Häzir oýnaýar"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Durzuldy"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Täzeden birikýär…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Häzir oýnaýar"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/tk.po
+++ b/po/tk.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: tk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Penjire ýapylandan soň Receiver radio çalmagy dowam etdirýär"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menýu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Aýdym taryhy"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Arka fonda çalmagy dowam et"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver hakynda"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Göz aýla"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Halanlarym"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stansiýa barada maglumat"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiýa ýüklendi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Ýalňyşlyk: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oýnatma ýalňyşlygy: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Häzir oýnaýar: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Dowam edýär: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ygtyýarnamasyny ýatyr"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm-den aýyr"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm-e birikdir"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ygtyýarnamasy ýatyryldy"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm-den aýrylan"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm-e birikdirilýär…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm-e birikdirmek başartmady"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Brauzer arkaly ygtyýar beriň…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ygtyýarnamasynyň wagty geçdi"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm-e birikdirildi"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dünýäniň çar künjünden 30 000+ tassyklanan radio stansiýany tapyň"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Halanlar ýok"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Bu ýere goşmak üçin göz aýlanyňyzda stansiýalary ýyldyz bilen belläň"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stansiýalary gözle…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Ähli diller"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Dil boýunça süz"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Ähli ýurtlar"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Ýurt boýunça süzmek"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stansiýa ýok"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ýüklenýär…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiýa"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiýalar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stansiýalar ýüklenýär"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Netije ýok"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Haýyş, garaşyň…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Gözlegiňize gabat gelýän stansiýa tapylmady"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stansiýalary ýükläp bolmady"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stansiýa"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ýurt"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Bellikler"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Web sahypa"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitreýt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Akym URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Oýnamaýar"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stansiýa saýlaň"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buferlenýär…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Häzir oýnaýar"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Durzuldy"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Täzeden birikýär…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-da gözlenýär…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Gözleg şowsuz: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube netijesi tapylmady"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Ähli netijeler elýeterli däl"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ýüklenýär: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Ýatyryldy"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Ýükleme şowsuz: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saklanan: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Aýdymy ýükle"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Ýüklemäni ýatyr"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Heniz aýdym ýok"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Radio stansiýalaryny diňleýände aýdymlar bu ýerde görkeziler"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Şu wagt"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d minut öň"
 msgstr[1] "%d minut öň"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d sagat öň"
 msgstr[1] "%d sagat öň"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/tl.po
+++ b/po/tl.po
@@ -3,315 +3,314 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: tl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Patuloy na nagpe-play ng radyo ang Receiver pagkatapos isara ang bintana"
+msgstr ""
+"Patuloy na nagpe-play ng radyo ang Receiver pagkatapos isara ang bintana"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Kasaysayan ng Kanta"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Magpatuloy sa pag-play sa background"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Tungkol sa Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Mag-browse"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Mga Paborito"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Impormasyon ng Istasyon"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Na-load ang %d na istasyon"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error sa pag-play: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Pinapatugtog ngayon: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ipinagpapatuloy: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Kanselahin ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Idiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kumonekta sa Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Nakansela ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Nadiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Kumokonekta sa Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Hindi nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Magbigay ng access sa iyong browser…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Nag-expire ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Tumuklas ng 30,000+ na na-verify na istasyon ng radyo mula sa buong mundo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Walang paborito"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Lagyan ng bituin ang mga istasyon habang nagba-browse para idagdag dito"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Maghanap ng mga istasyon…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Lahat ng wika"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "I-filter ayon sa wika"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Lahat ng bansa"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "I-filter ayon sa bansa"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Walang istasyon"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Naglo-load…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u sa %d na istasyon"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Mga istasyon: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Naglo-load ng mga istasyon"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Walang resulta"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Maghintay po…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Walang istasyong tumutugma sa iyong hinanap"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Hindi ma-load ang mga istasyon"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Istasyon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Bansa"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Mga tag"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Website"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Stream URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Hindi pinapatugtog"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Pumili ng istasyon"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Nagba-buffer…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Pinapatugtog ngayon"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Naka-pause"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Muling kumokonekta…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Naghahanap sa YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Nabigo ang paghahanap: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Walang nahanap na resulta sa YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Lahat ng resulta ay hindi available"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Dina-download: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Nakansela"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Nabigo ang download: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Na-save: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "I-download ang kanta"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Kanselahin ang download"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Wala Pang Mga Kanta"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Lalabas dito ang mga kanta habang nakikinig ka ng mga istasyon ng radyo"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ngayon lang"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min ang nakalipas"
 msgstr[1] "%d min ang nakalipas"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d oras ang nakalipas"
 msgstr[1] "%d oras ang nakalipas"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/tl.po
+++ b/po/tl.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: tl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Patuloy na nagpe-play ng radyo ang Receiver pagkatapos isara ang bintana"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Kasaysayan ng Kanta"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Magpatuloy sa pag-play sa background"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Tungkol sa Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Mag-browse"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Mga Paborito"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Impormasyon ng Istasyon"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Na-load ang %d na istasyon"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Error: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Error sa pag-play: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Pinapatugtog ngayon: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ipinagpapatuloy: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Kanselahin ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Idiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kumonekta sa Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Nakansela ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Nadiskonekta sa Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Kumokonekta sa Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Hindi nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Magbigay ng access sa iyong browser…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Nag-expire ang pahintulot sa Last.fm"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Nakakonekta sa Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Tumuklas ng 30,000+ na na-verify na istasyon ng radyo mula sa buong mundo"
@@ -115,64 +123,65 @@ msgstr "Walang paborito"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Lagyan ng bituin ang mga istasyon habang nagba-browse para idagdag dito"
+msgstr ""
+"Lagyan ng bituin ang mga istasyon habang nagba-browse para idagdag dito"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Maghanap ng mga istasyon…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Lahat ng wika"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "I-filter ayon sa wika"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Lahat ng bansa"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "I-filter ayon sa bansa"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Walang istasyon"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Naglo-load…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u sa %d na istasyon"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Mga istasyon: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Naglo-load ng mga istasyon"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Walang resulta"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Maghintay po…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Walang istasyong tumutugma sa iyong hinanap"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Hindi ma-load ang mga istasyon"
 
@@ -205,25 +214,29 @@ msgid "Stream URL"
 msgstr "Stream URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Hindi pinapatugtog"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Pumili ng istasyon"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Nagba-buffer…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Pinapatugtog ngayon"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Naka-pause"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Muling kumokonekta…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Pinapatugtog ngayon"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/tr.po
+++ b/po/tr.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Pencere kapatıldıktan sonra Receiver radyoyu çalmaya devam eder"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Şarkı Geçmişi"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Arka planda çalmaya devam et"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver Hakkında"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Favoriler"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "İstasyon bilgisi"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d istasyon yüklendi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Hata: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oynatma hatası: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Şimdi çalıyor: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Devam ediliyor: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm yetkilendirmesini iptal et"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm bağlantısını kes"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm'e bağlan"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm yetkilendirmesi iptal edildi"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm bağlantısı kesildi"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm'e bağlanıyor…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm'e bağlanılamadı"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Tarayıcınızda erişim izni verin…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm yetkilendirmesi zaman aşımına uğradı"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm'e bağlandı"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Dünya genelinden 30.000'den fazla doğrulanmış radyo istasyonunu keşfedin"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Buraya eklemek için göz atarken istasyonları yıldızlayın"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "İstasyon ara…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Tüm diller"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Dile göre filtrele"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tüm ülkeler"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Ülkeye göre filtrele"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "İstasyon yok"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Yükleniyor…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%d istasyondan %u"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "İstasyon: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "İstasyonlar yükleniyor"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Sonuç yok"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Lütfen bekleyin…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Aramanızla eşleşen istasyon yok"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "İstasyonlar yüklenemedi"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "Yayın URL'si"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Çalmıyor"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Bir istasyon seçin"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Arabelleğe alınıyor…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Şimdi çalıyor"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Duraklatıldı"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Yeniden bağlanılıyor…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Şimdi çalıyor"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/tr.po
+++ b/po/tr.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Pencere kapatıldıktan sonra Receiver radyoyu çalmaya devam eder"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menü"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Şarkı Geçmişi"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Arka planda çalmaya devam et"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver Hakkında"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Göz at"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Favoriler"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "İstasyon bilgisi"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d istasyon yüklendi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Hata: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Oynatma hatası: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Şimdi çalıyor: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Devam ediliyor: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm yetkilendirmesini iptal et"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm bağlantısını kes"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm'e bağlan"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm yetkilendirmesi iptal edildi"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm bağlantısı kesildi"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm'e bağlanıyor…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm'e bağlanılamadı"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Tarayıcınızda erişim izni verin…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm yetkilendirmesi zaman aşımına uğradı"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm'e bağlandı"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Dünya genelinden 30.000'den fazla doğrulanmış radyo istasyonunu keşfedin"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Favori yok"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Buraya eklemek için göz atarken istasyonları yıldızlayın"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "İstasyon ara…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Tüm diller"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Dile göre filtrele"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tüm ülkeler"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Ülkeye göre filtrele"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "İstasyon yok"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Yükleniyor…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%d istasyondan %u"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "İstasyon: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "İstasyonlar yükleniyor"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Sonuç yok"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Lütfen bekleyin…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Aramanızla eşleşen istasyon yok"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "İstasyonlar yüklenemedi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "İstasyon"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ülke"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiketler"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Web sitesi"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bit hızı"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Yayın URL'si"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Çalmıyor"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Bir istasyon seçin"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Arabelleğe alınıyor…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Şimdi çalıyor"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Duraklatıldı"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Yeniden bağlanılıyor…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube'da aranıyor…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Arama başarısız: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube sonucu bulunamadı"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tüm sonuçlar kullanılamıyor"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "İndiriliyor: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "İptal edildi"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "İndirme başarısız: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Kaydedildi: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Şarkıyı indir"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "İndirmeyi iptal et"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Henüz şarkı yok"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Radyo istasyonlarını dinlerken şarkılar burada görünecek"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Az önce"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d dk önce"
 msgstr[1] "%d dk önce"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d saat önce"
 msgstr[1] "%d saat önce"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ts.po
+++ b/po/ts.po
@@ -3,313 +3,313 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ts\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
-msgstr "Receiver yi ya emahlweni yi tlanga radio endzhaku ka loko fasitere ri pfariwile"
+msgstr ""
+"Receiver yi ya emahlweni yi tlanga radio endzhaku ka loko fasitere ri "
+"pfariwile"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Matimu ya tinsimu"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Ya emahlweni u tlanga endzhaku"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Hi mayelana na Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Languta"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Swa u swi rhandzaka"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Vuxokoxoko bya xitichi"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Switichi %d swi layichiwe"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Xihoxo: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Xihoxo xa ku tlanga: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sweswi ya tlanga: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ya ya emahlweni: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Pfumala mpfumelelo wa Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Tshika ku Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Hlanganisa na Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Mpfumelelo wa Last.fm wu pfumalariwile"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "U tshikiwile eka Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Ku hlanganisa na Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "A swi kotekanga ku hlanganisa na Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Nyika mfikelelo eka browser ya wena…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Nkarhi wa mpfumelelo wa Last.fm wu hundzile"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "U hlanganiswile na Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Kuma switexini swa radio 30,000+ leswi tiyisekisiweke kusuka misava hinkwayo"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "A ku na swa u swi rhandzaka"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Veka tinyeleti eka switichi loko u languta ku engetela laha"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Lava switichi…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Tindzimi Hinkwato"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Hlela hi ririmi"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Matiko hinkwawo"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Hlela hi tiko"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Ku Hava Switichi"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Ya layicha…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ka %d switichi"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Switichi: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Ya Layicha Switichi"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Ku Hava Mbuyelo"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ndzi kombela u yima…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Ku hava switichi leswi faneleke ku lava ka wena"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "A swi koteki ku layicha switichi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Xitichi"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Tiko"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Tithekhwe"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Webusayiti"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Khodekhi"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Mpimo wa biti"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL ya ku strima"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "A Yi Tlangi"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Hlawula xitichi"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Ya hlayisa…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Sweswi ya tlanga"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Yi Yimisiwe"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Ya tlhela yi hlanganisa…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Ya lava YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Ku lava ku tsandzekile: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Ku hava mbuyelo wa YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Mbuyelo hinkwawo a wu kumeki"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Ya dawuniloda: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Yi Herisiwe"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Ku dawuniloda ku tsandzekile: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Yi hlayisiwe: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Dawuniloda risimu"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Herisa ku dawuniloda"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "A ku na tinsimu"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Tinsimu ti ta vonaka laha loko u yingisela switexini swa radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Sweswi"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d min. loko ku hundzile"
 msgstr[1] "%d min. loko ku hundzile"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d awara loko ku hundzile"
 msgstr[1] "%d tiawara loko ku hundzile"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ts.po
+++ b/po/ts.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ts\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver yi ya emahlweni yi tlanga radio endzhaku ka loko fasitere ri pfariwile"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Matimu ya tinsimu"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Ya emahlweni u tlanga endzhaku"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Hi mayelana na Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Languta"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Swa u swi rhandzaka"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Vuxokoxoko bya xitichi"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Switichi %d swi layichiwe"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Xihoxo: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Xihoxo xa ku tlanga: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Sweswi ya tlanga: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ya ya emahlweni: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Pfumala mpfumelelo wa Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Tshika ku Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Hlanganisa na Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Mpfumelelo wa Last.fm wu pfumalariwile"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "U tshikiwile eka Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Ku hlanganisa na Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "A swi kotekanga ku hlanganisa na Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Nyika mfikelelo eka browser ya wena…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Nkarhi wa mpfumelelo wa Last.fm wu hundzile"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "U hlanganiswile na Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Kuma switexini swa radio 30,000+ leswi tiyisekisiweke kusuka misava hinkwayo"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Veka tinyeleti eka switichi loko u languta ku engetela laha"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Lava switichi…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Tindzimi Hinkwato"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Hlela hi ririmi"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Matiko hinkwawo"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Hlela hi tiko"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Ku Hava Switichi"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Ya layicha…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u ka %d switichi"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Switichi: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Ya Layicha Switichi"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Ku Hava Mbuyelo"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ndzi kombela u yima…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Ku hava switichi leswi faneleke ku lava ka wena"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "A swi koteki ku layicha switichi"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL ya ku strima"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "A Yi Tlangi"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Hlawula xitichi"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Ya hlayisa…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Sweswi ya tlanga"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Yi Yimisiwe"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Ya tlhela yi hlanganisa…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Sweswi ya tlanga"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/tt.po
+++ b/po/tt.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: tt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Тәрәзә ябылгач та Receiver радионы уйнатуны дәвам итә"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Җыр тарихы"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Фонда уйнатуны дәвам итү"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver турында"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Карау"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Сайланмалар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Станция турында"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция йөкләнде"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Хата: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Уйнату хатасы: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Хәзер уйный: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Дәвам итү: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm рөхсәтен юкка чыгару"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm белән аерылу"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm белән тоташу"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm рөхсәте юкка чыгарылды"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm белән аерылды"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm белән тоташа…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm белән тоташа алмады"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Браузерыгызда рөхсәт бирегез…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm рөхсәтенең вакыты чыкты"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm белән тоташты"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Бөтен дөньядан 30 000+ тикшерелгән радио станцияне табыгыз"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Монда өстәү өчен карау вакытында станцияларны йолдыз белән билгеләгез"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Станцияләрне эзләү…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Барлык телләр"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Тел буенча фильтрлау"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Барлык илләр"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Ил буенча сөзү"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Станцияләр юк"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Йөкләнә…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцияләр: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Станцияләр йөкләнә"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Нәтиҗәләр юк"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Зинһар көтегез…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Эзләүегезгә туры килгән станция табылмады"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Станцияләрне йөкләп булмады"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "Агым URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Уйнамый"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Станция сайлагыз"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферлау…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Хәзер уйный"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Тукталды"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Яңадан тоташу…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Хәзер уйный"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/tt.po
+++ b/po/tt.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: tt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Тәрәзә ябылгач та Receiver радионы уйнатуны дәвам итә"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Җыр тарихы"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Фонда уйнатуны дәвам итү"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver турында"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Карау"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Сайланмалар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Станция турында"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция йөкләнде"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Хата: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Уйнату хатасы: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Хәзер уйный: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Дәвам итү: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm рөхсәтен юкка чыгару"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm белән аерылу"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm белән тоташу"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm рөхсәте юкка чыгарылды"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm белән аерылды"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm белән тоташа…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm белән тоташа алмады"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Браузерыгызда рөхсәт бирегез…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm рөхсәтенең вакыты чыкты"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm белән тоташты"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Бөтен дөньядан 30 000+ тикшерелгән радио станцияне табыгыз"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Сайланмалар юк"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Монда өстәү өчен карау вакытында станцияларны йолдыз белән билгеләгез"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Станцияләрне эзләү…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Барлык телләр"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Тел буенча фильтрлау"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Барлык илләр"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Ил буенча сөзү"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Станцияләр юк"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Йөкләнә…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцияләр: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Станцияләр йөкләнә"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Нәтиҗәләр юк"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Зинһар көтегез…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Эзләүегезгә туры килгән станция табылмады"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Станцияләрне йөкләп булмады"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станция"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Ил"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Тегләр"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрейт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Агым URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Уйнамый"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Станция сайлагыз"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферлау…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Хәзер уйный"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Тукталды"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Яңадан тоташу…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube-та эзләү…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Эзләү уңышсыз: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube нәтиҗәләре табылмады"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Барлык нәтиҗәләр мөмкин түгел"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Йөкләнә: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Кире кагылды"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Йөкләү уңышсыз: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Сакланды: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Җырны йөкләү"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Йөкләүне кире кагу"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Әлегә җырлар юк"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Радио станцияларны тыңлаганда җырлар монда күренәчәк"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Хәзер генә"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d мин элек"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d сәг элек"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/ug.po
+++ b/po/ug.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ug\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "كۆزنەك يېپىلغاندىن كېيىنمۇ Receiver رادىئونى قويۇشنى داۋاملاشتۇرىدۇ"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "تىزىملىك"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ناخشا تارىخى"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "ئارقا سۇپىدا قويۇشنى داۋاملاشتۇر"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver ھەققىدە"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "كۆرۈش"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "ياقتۇرغانلار"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "ستانسىيە ئۇچۇرلىرى"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ئىستانسىيە يۈكلەندى"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "خاتالىق: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "قويۇش خاتالىقى: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ھازىر قويۇلىۋاتىدۇ: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "داۋاملاشتۇرۇش: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ھوقۇقىنى بىكار قىل"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm دىن ئۈز"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm غا ئۇلا"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ھوقۇقى بىكار قىلىندى"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm دىن ئۈزۈلدى"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm غا ئۇلىنىۋاتىدۇ…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm غا ئۇلىنالمىدى"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "توركۆرگۈچىڭىزدە ئىجازەت بېرىڭ…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ھوقۇقىنىڭ ۋاقتى ئۆتتى"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm غا ئۇلاندى"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "پۈتكۈل دۇنيادىن 30,000+ دىن ئارتۇق دەلىللەنگەن رادىئو ئىستانسا بايقاڭ"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "بۇ يەرگە قوشۇش ئۈچۈن كۆرۈش جەريانىدا ستانسىيەلەرنى يۇلتۇزلاڭ"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "ئىستانسىيە ئىزدەش…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "بارلىق تىللار"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "تىل بويىچە سۈزۈش"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "بارلىق دۆلەتلەر"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "دۆلەت بويىچە سۈزۈش"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "ئىستانسىيە يوق"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "يۈكلىنىۋاتىدۇ…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ئىستانسىيە"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "ئىستانسىيەلەر: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "ئىستانسىيەلەر يۈكلىنىۋاتىدۇ"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "نەتىجە يوق"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ساقلاپ تۇرۇڭ…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "ئىزدەشىڭىزگە ماس كېلىدىغان ئىستانسىيە تېپىلمىدى"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "ئىستانسىيەلەرنى يۈكلىيەلمىدى"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "ئېقىم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "قويۇلمىۋاتىدۇ"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ئىستانسىيە تاللاڭ"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "ۋاقىتلىق ساقلاۋاتىدۇ…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ھازىر قويۇلىۋاتىدۇ"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "توختىتىلدى"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "قايتا ئۇلىنىۋاتىدۇ…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ھازىر قويۇلىۋاتىدۇ"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ug.po
+++ b/po/ug.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ug\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "كۆزنەك يېپىلغاندىن كېيىنمۇ Receiver رادىئونى قويۇشنى داۋاملاشتۇرىدۇ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "تىزىملىك"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ناخشا تارىخى"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "ئارقا سۇپىدا قويۇشنى داۋاملاشتۇر"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver ھەققىدە"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "كۆرۈش"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "ياقتۇرغانلار"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "ستانسىيە ئۇچۇرلىرى"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ئىستانسىيە يۈكلەندى"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "خاتالىق: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "قويۇش خاتالىقى: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ھازىر قويۇلىۋاتىدۇ: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "داۋاملاشتۇرۇش: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ھوقۇقىنى بىكار قىل"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm دىن ئۈز"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm غا ئۇلا"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ھوقۇقى بىكار قىلىندى"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm دىن ئۈزۈلدى"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm غا ئۇلىنىۋاتىدۇ…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm غا ئۇلىنالمىدى"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "توركۆرگۈچىڭىزدە ئىجازەت بېرىڭ…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ھوقۇقىنىڭ ۋاقتى ئۆتتى"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm غا ئۇلاندى"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "پۈتكۈل دۇنيادىن 30,000+ دىن ئارتۇق دەلىللەنگەن رادىئو ئىستانسا بايقاڭ"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "ياقتۇرغان يوق"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "بۇ يەرگە قوشۇش ئۈچۈن كۆرۈش جەريانىدا ستانسىيەلەرنى يۇلتۇزلاڭ"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "ئىستانسىيە ئىزدەش…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "بارلىق تىللار"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "تىل بويىچە سۈزۈش"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "بارلىق دۆلەتلەر"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "دۆلەت بويىچە سۈزۈش"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "ئىستانسىيە يوق"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "يۈكلىنىۋاتىدۇ…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d ئىستانسىيە"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "ئىستانسىيەلەر: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "ئىستانسىيەلەر يۈكلىنىۋاتىدۇ"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "نەتىجە يوق"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ساقلاپ تۇرۇڭ…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "ئىزدەشىڭىزگە ماس كېلىدىغان ئىستانسىيە تېپىلمىدى"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "ئىستانسىيەلەرنى يۈكلىيەلمىدى"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "ستانسىيە"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "دۆلەت"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "بەلگىلەر"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "توربېكەت"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "كودېك"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "بىت سۈرئىتى"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "ئېقىم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "قويۇلمىۋاتىدۇ"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ئىستانسىيە تاللاڭ"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "ۋاقىتلىق ساقلاۋاتىدۇ…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ھازىر قويۇلىۋاتىدۇ"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "توختىتىلدى"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "قايتا ئۇلىنىۋاتىدۇ…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube دا ئىزدەۋاتىدۇ…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "ئىزدەش مەغلۇب بولدى: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube نەتىجىسى تېپىلمىدى"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "بارلىق نەتىجىلەر ئىشلەتكىلى بولمايدۇ"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "چۈشۈرۈۋاتىدۇ: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "بىكار قىلىندى"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "چۈشۈرۈش مەغلۇب بولدى: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "ساقلاندى: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "ناخشا چۈشۈرۈش"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "چۈشۈرۈشنى بىكار قىلىش"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "تېخى ناخشا يوق"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "رادىئو ئىستانسالارنى ئاڭلىغاندا ناخشىلار بۇ يەردە كۆرۈنىدۇ"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ھازىر"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d مىنۇت ئىلگىرى"
 msgstr[1] "%d مىنۇت ئىلگىرى"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d سائەت ئىلگىرى"
 msgstr[1] "%d سائەت ئىلگىرى"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/uk.po
+++ b/po/uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,291 +11,289 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver продовжує відтворювати радіо після закриття вікна"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Історія пісень"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Продовжувати відтворення у фоні"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Про Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Огляд"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Улюблені"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Відомості про станцію"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Завантажено %d станцій"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Помилка: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Помилка відтворення: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Зараз грає: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Відновлення: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Скасувати авторизацію Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Від'єднатися від Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Під'єднатися до Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Авторизацію Last.fm скасовано"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Від'єднано від Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Під'єднання до Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Не вдалося під'єднатися до Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Надайте доступ у вашому браузері…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Час авторизації Last.fm вийшов"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Під'єднано до Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Відкрийте понад 30 000 перевірених радіостанцій з усього світу"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Немає улюблених"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Позначте станції зіркою під час перегляду, щоб додати їх сюди"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Пошук станцій…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Усі мови"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Фільтрувати за мовою"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Усі країни"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Фільтрувати за країною"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Станцій немає"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Завантаження…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u з %d станцій"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцій: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Завантаження станцій"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Немає результатів"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Зачекайте…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Жодна станція не відповідає вашому пошуку"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Не вдалося завантажити станції"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станція"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Країна"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Теги"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Вебсайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Бітрейт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL потоку"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Не відтворюється"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Оберіть станцію"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферизація…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Зараз грає"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Призупинено"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Повторне підключення…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Пошук на YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Пошук не вдався: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Результатів YouTube не знайдено"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Всі результати недоступні"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Завантаження: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Скасовано"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Помилка завантаження: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Збережено: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Завантажити пісню"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Скасувати завантаження"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ще немає пісень"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Пісні з'являтимуться тут, коли ви слухатимете радіостанції"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Щойно"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
@@ -303,7 +301,7 @@ msgstr[0] "%d хвилину тому"
 msgstr[1] "%d хвилини тому"
 msgstr[2] "%d хвилин тому"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
@@ -311,7 +309,7 @@ msgstr[0] "%d годину тому"
 msgstr[1] "%d години тому"
 msgstr[2] "%d годин тому"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/uk.po
+++ b/po/uk.po
@@ -3,7 +3,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -11,101 +11,109 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver продовжує відтворювати радіо після закриття вікна"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Історія пісень"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Продовжувати відтворення у фоні"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Про Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Огляд"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Улюблені"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Відомості про станцію"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Завантажено %d станцій"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Помилка: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Помилка відтворення: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Зараз грає: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Відновлення: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Скасувати авторизацію Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Від'єднатися від Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Під'єднатися до Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Авторизацію Last.fm скасовано"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Від'єднано від Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Під'єднання до Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Не вдалося під'єднатися до Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Надайте доступ у вашому браузері…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Час авторизації Last.fm вийшов"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Під'єднано до Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Відкрийте понад 30 000 перевірених радіостанцій з усього світу"
 
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Позначте станції зіркою під час перегляду, щоб додати їх сюди"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Пошук станцій…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Усі мови"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Фільтрувати за мовою"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Усі країни"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Фільтрувати за країною"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Станцій немає"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Завантаження…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u з %d станцій"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станцій: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Завантаження станцій"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Немає результатів"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Зачекайте…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Жодна станція не відповідає вашому пошуку"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Не вдалося завантажити станції"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL потоку"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Не відтворюється"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Оберіть станцію"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферизація…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Зараз грає"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Призупинено"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Повторне підключення…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Зараз грає"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ur.po
+++ b/po/ur.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: ur\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "ونڈو بند ہونے کے بعد بھی Receiver ریڈیو چلاتا رہتا ہے"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "مینو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "گانوں کی تاریخ"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "پس منظر میں چلاتے رہیں"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver کے بارے میں"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "براؤز کریں"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "پسندیدہ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "اسٹیشن کی معلومات"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d اسٹیشن لوڈ ہوئے"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "خرابی: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک کی خرابی: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "ابھی چل رہا ہے: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "دوبارہ شروع ہو رہا ہے: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm اجازت منسوخ کریں"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm سے منقطع کریں"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm سے جڑیں"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm اجازت منسوخ ہو گئی"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm سے منقطع ہو گیا"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm سے جوڑ رہا ہے…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm سے جڑنے میں ناکام"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "اپنے براؤزر میں رسائی دیں…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm اجازت کا وقت ختم ہو گیا"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm سے جڑ گیا"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "پوری دنیا سے 30,000+ تصدیق شدہ ریڈیو اسٹیشن دریافت کریں"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "یہاں شامل کرنے کے لیے براؤز کرتے وقت اسٹیشنوں کو ستارہ لگائیں"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "اسٹیشن تلاش کریں…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "تمام زبانیں"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "زبان کے لحاظ سے فلٹر کریں"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "تمام ممالک"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "ملک کے مطابق فلٹر"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "کوئی اسٹیشن نہیں"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "لوڈ ہو رہا ہے…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u از %d اسٹیشن"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "اسٹیشن: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "اسٹیشن لوڈ ہو رہے ہیں"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "کوئی نتیجہ نہیں"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "براہ کرم انتظار کریں…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "آپ کی تلاش سے کوئی اسٹیشن نہیں ملتا"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "اسٹیشن لوڈ نہیں ہو سکے"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "سٹریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "نہیں چل رہا"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "ایک اسٹیشن منتخب کریں"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "بفر ہو رہا ہے…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "ابھی چل رہا ہے"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "روکا ہوا"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "دوبارہ جڑ رہا ہے…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "ابھی چل رہا ہے"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/ur.po
+++ b/po/ur.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: ur\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "ونڈو بند ہونے کے بعد بھی Receiver ریڈیو چلاتا رہتا ہے"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "مینو"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "گانوں کی تاریخ"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "پس منظر میں چلاتے رہیں"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver کے بارے میں"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "براؤز کریں"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "پسندیدہ"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "اسٹیشن کی معلومات"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d اسٹیشن لوڈ ہوئے"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "خرابی: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "پلے بیک کی خرابی: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "ابھی چل رہا ہے: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "دوبارہ شروع ہو رہا ہے: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm اجازت منسوخ کریں"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm سے منقطع کریں"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm سے جڑیں"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm اجازت منسوخ ہو گئی"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm سے منقطع ہو گیا"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm سے جوڑ رہا ہے…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm سے جڑنے میں ناکام"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "اپنے براؤزر میں رسائی دیں…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm اجازت کا وقت ختم ہو گیا"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm سے جڑ گیا"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "پوری دنیا سے 30,000+ تصدیق شدہ ریڈیو اسٹیشن دریافت کریں"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "کوئی پسندیدہ نہیں"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "یہاں شامل کرنے کے لیے براؤز کرتے وقت اسٹیشنوں کو ستارہ لگائیں"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "اسٹیشن تلاش کریں…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "تمام زبانیں"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "زبان کے لحاظ سے فلٹر کریں"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "تمام ممالک"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "ملک کے مطابق فلٹر"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "کوئی اسٹیشن نہیں"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "لوڈ ہو رہا ہے…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u از %d اسٹیشن"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "اسٹیشن: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "اسٹیشن لوڈ ہو رہے ہیں"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "کوئی نتیجہ نہیں"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "براہ کرم انتظار کریں…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "آپ کی تلاش سے کوئی اسٹیشن نہیں ملتا"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "اسٹیشن لوڈ نہیں ہو سکے"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "اسٹیشن"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "ملک"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "ٹیگز"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "ویب سائٹ"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "کوڈیک"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "بٹ ریٹ"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "سٹریم URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "نہیں چل رہا"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "ایک اسٹیشن منتخب کریں"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "بفر ہو رہا ہے…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "ابھی چل رہا ہے"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "روکا ہوا"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "دوبارہ جڑ رہا ہے…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube پر تلاش ہو رہی ہے…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "تلاش ناکام ہوئی: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube کے نتائج نہیں ملے"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "تمام نتائج دستیاب نہیں"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "ڈاؤن لوڈ ہو رہا ہے: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "منسوخ"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "ڈاؤن لوڈ ناکام ہوا: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "محفوظ ہو گیا: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "گانا ڈاؤن لوڈ کریں"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "ڈاؤن لوڈ منسوخ کریں"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "ابھی تک کوئی گانے نہیں"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "ریڈیو اسٹیشن سنتے وقت گانے یہاں ظاہر ہوں گے"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "ابھی"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d منٹ پہلے"
 msgstr[1] "%d منٹ پہلے"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d گھنٹہ پہلے"
 msgstr[1] "%d گھنٹے پہلے"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/uz.po
+++ b/po/uz.po
@@ -3,314 +3,312 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: uz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Oyna yopilgandan keyin ham Receiver radioni ijro etishda davom etadi"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Qo'shiq tarixi"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Orqa fonda ijro etishni davom ettirish"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver haqida"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Ko'rish"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Sevimlilar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Stansiya haqida"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yuklandi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Xato: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ijro xatosi: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Hozir ijro etilmoqda: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Davom etish: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ruxsatini bekor qilish"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm dan uzish"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm ga ulanish"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ruxsati bekor qilindi"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm dan uzildi"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ga ulanmoqda…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ga ulanib bo'lmadi"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Brauzeringizda ruxsat bering…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ruxsati muddati tugadi"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm ga ulandi"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dunyo bo'ylab 30 000+ tasdiqlangan radio stansiyalarini kashf eting"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Sevimlilar yo'q"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Bu yerga qo'shish uchun ko'rayotganingizda stansiyalarni yulduzcha bilan "
 "belgilang"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Stansiyalarni qidirish…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Barcha tillar"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Til boʻyicha saralash"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Barcha davlatlar"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Davlat bo'yicha saralash"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Stansiyalar yoʻq"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Yuklanmoqda…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Stansiyalar yuklanmoqda"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Natijalar yoʻq"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Iltimos, kuting…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Qidiruvingizga mos stansiya topilmadi"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Stansiyalarni yuklab boʻlmadi"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Stansiya"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Davlat"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Teglar"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Veb-sayt"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Kodek"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitreyt"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Oqim URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ijro etilmayapti"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Stansiya tanlang"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Buferlanmoqda…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Hozir ijro etilmoqda"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Toʻxtatildi"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Qayta ulanmoqda…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube dan qidirish…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Qidiruv muvaffaqiyatsiz: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube natijalari topilmadi"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Barcha natijalar mavjud emas"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Yuklanmoqda: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Bekor qilindi"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Yuklash muvaffaqiyatsiz: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Saqlandi: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Qoʻshiqni yuklab olish"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Yuklashni bekor qilish"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Hali qo'shiqlar yo'q"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Radio stansiyalarni tinglaganingizda qo'shiqlar bu yerda ko'rinadi"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Hozirgina"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d daqiqa oldin"
 msgstr[1] "%d daqiqa oldin"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d soat oldin"
 msgstr[1] "%d soat oldin"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/uz.po
+++ b/po/uz.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: uz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Oyna yopilgandan keyin ham Receiver radioni ijro etishda davom etadi"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menyu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Qo'shiq tarixi"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Orqa fonda ijro etishni davom ettirish"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver haqida"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Ko'rish"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Sevimlilar"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Stansiya haqida"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d stansiya yuklandi"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Xato: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ijro xatosi: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Hozir ijro etilmoqda: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Davom etish: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm ruxsatini bekor qilish"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm dan uzish"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm ga ulanish"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm ruxsati bekor qilindi"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm dan uzildi"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm ga ulanmoqda…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm ga ulanib bo'lmadi"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Brauzeringizda ruxsat bering…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm ruxsati muddati tugadi"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm ga ulandi"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Dunyo bo'ylab 30 000+ tasdiqlangan radio stansiyalarini kashf eting"
 
@@ -114,64 +122,66 @@ msgstr "Sevimlilar yo'q"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Bu yerga qo'shish uchun ko'rayotganingizda stansiyalarni yulduzcha bilan belgilang"
+msgstr ""
+"Bu yerga qo'shish uchun ko'rayotganingizda stansiyalarni yulduzcha bilan "
+"belgilang"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Stansiyalarni qidirish…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Barcha tillar"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Til boʻyicha saralash"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Barcha davlatlar"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Davlat bo'yicha saralash"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Stansiyalar yoʻq"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Yuklanmoqda…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d stansiya"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Stansiyalar: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Stansiyalar yuklanmoqda"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Natijalar yoʻq"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Iltimos, kuting…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Qidiruvingizga mos stansiya topilmadi"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Stansiyalarni yuklab boʻlmadi"
 
@@ -204,25 +214,29 @@ msgid "Stream URL"
 msgstr "Oqim URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ijro etilmayapti"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Stansiya tanlang"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Buferlanmoqda…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Hozir ijro etilmoqda"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Toʻxtatildi"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Qayta ulanmoqda…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Hozir ijro etilmoqda"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/uz@cyrillic.po
+++ b/po/uz@cyrillic.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: uz@cyrillic\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Дераза ёпилгандан кейин ҳам Receiver радиони ижро этишда давом этади"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Қўшиқ тарихи"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Орқа фонда ижрони давом эттириш"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Receiver ҳақида"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Кўриш"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Севимлилар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Станция ҳақида"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция юкланди"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Хато: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ижро хатоси: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ҳозир ижро этилмоқда: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Давом этиш: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm рухсатини бекор қилиш"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm дан узиш"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Last.fm га уланиш"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm рухсати бекор қилинди"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm дан узилди"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm га уланмоқда…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm га уланиб бўлмади"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Браузерингизда рухсат беринг…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm рухсати муддати тугади"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Last.fm га уланди"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Дунё бўйлаб 30 000+ тасдиқланган радио станцияларини кашф этинг"
 
@@ -114,64 +122,65 @@ msgstr "Севимлилар йўқ"
 
 #: src/widgets/favourites_page.vala:26
 msgid "Star stations while browsing to add them here"
-msgstr "Бу ерга қўшиш учун кўраётганингизда станцияларни юлдузча билан белгиланг"
+msgstr ""
+"Бу ерга қўшиш учун кўраётганингизда станцияларни юлдузча билан белгиланг"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Станцияларни қидириш…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Барча тиллар"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Тил бўйича саралаш"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Барча давлатлар"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Давлат бўйича саралаш"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Станциялар йўқ"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Юкланмоқда…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Станциялар: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Станциялар юкланмоқда"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Натижалар йўқ"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Илтимос, кутинг…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Қидирувингизга мос станция топилмади"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Станцияларни юклаб бўлмади"
 
@@ -204,25 +213,29 @@ msgid "Stream URL"
 msgstr "Оқим URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ижро этилмаяпти"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Станция танланг"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Буферланмоқда…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Ҳозир ижро этилмоқда"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Тўхтатилди"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Қайта уланмоқда…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Ҳозир ижро этилмоқда"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/uz@cyrillic.po
+++ b/po/uz@cyrillic.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: uz@cyrillic\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Дераза ёпилгандан кейин ҳам Receiver радиони ижро этишда давом этади"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Меню"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Қўшиқ тарихи"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Орқа фонда ижрони давом эттириш"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Receiver ҳақида"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Кўриш"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Севимлилар"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Станция ҳақида"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d станция юкланди"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Хато: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Ижро хатоси: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Ҳозир ижро этилмоқда: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Давом этиш: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Last.fm рухсатини бекор қилиш"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Last.fm дан узиш"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Last.fm га уланиш"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm рухсати бекор қилинди"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Last.fm дан узилди"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Last.fm га уланмоқда…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Last.fm га уланиб бўлмади"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Браузерингизда рухсат беринг…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm рухсати муддати тугади"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Last.fm га уланди"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Дунё бўйлаб 30 000+ тасдиқланган радио станцияларини кашф этинг"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Севимлилар йўқ"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr ""
 "Бу ерга қўшиш учун кўраётганингизда станцияларни юлдузча билан белгиланг"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Станцияларни қидириш…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Барча тиллар"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Тил бўйича саралаш"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Барча давлатлар"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Давлат бўйича саралаш"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Станциялар йўқ"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Юкланмоқда…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d станция"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Станциялар: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Станциялар юкланмоқда"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Натижалар йўқ"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Илтимос, кутинг…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Қидирувингизга мос станция топилмади"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Станцияларни юклаб бўлмади"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Станция"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Давлат"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Теглар"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Веб-сайт"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Кодек"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Битрейт"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "Оқим URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ижро этилмаяпти"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Станция танланг"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Буферланмоқда…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Ҳозир ижро этилмоқда"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Тўхтатилди"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Қайта уланмоқда…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "YouTube дан қидириш…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Қидирув муваффақиятсиз: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "YouTube натижалари топилмади"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Барча натижалар мавжуд эмас"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Юкланмоқда: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Бекор қилинди"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Юклаш муваффақиятсиз: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Сақланди: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Қўшиқни юклаб олиш"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Юклашни бекор қилиш"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Ҳали қўшиқлар йўқ"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Радио станцияларни тинглаганингизда қўшиқлар бу ерда кўринади"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ҳозиргина"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d дақиқа олдин"
 msgstr[1] "%d дақиқа олдин"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d соат олдин"
 msgstr[1] "%d соат олдин"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/vi.po
+++ b/po/vi.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver tiếp tục phát radio sau khi cửa sổ được đóng"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Lịch sử bài hát"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Tiếp tục phát ở chế độ nền"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "Giới thiệu Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Duyệt"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Yêu thích"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Thông tin đài"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Đã tải %d đài"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Lỗi: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Lỗi phát: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Đang phát: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Tiếp tục: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Hủy ủy quyền Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Ngắt kết nối Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Kết nối Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Đã hủy ủy quyền Last.fm"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Đã ngắt kết nối Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Đang kết nối Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Không thể kết nối Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Cấp quyền truy cập trong trình duyệt…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Ủy quyền Last.fm đã hết hạn"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Đã kết nối Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Khám phá hơn 30.000 đài phát thanh đã xác minh từ khắp nơi trên thế giới"
@@ -118,61 +126,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Đánh dấu sao các đài khi duyệt để thêm vào đây"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Tìm đài…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Tất cả ngôn ngữ"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Lọc theo ngôn ngữ"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tất cả quốc gia"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Lọc theo quốc gia"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Không có đài"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Đang tải…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d đài"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Đài: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Đang tải các đài"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Không có kết quả"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Vui lòng đợi…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Không có đài nào khớp với tìm kiếm của bạn"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Không thể tải các đài"
 
@@ -205,25 +213,29 @@ msgid "Stream URL"
 msgstr "URL luồng phát"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Không phát"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Chọn một đài"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Đang đệm…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Đang phát"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "Tạm dừng"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Đang kết nối lại…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Đang phát"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/vi.po
+++ b/po/vi.po
@@ -3,311 +3,309 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: vi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver tiếp tục phát radio sau khi cửa sổ được đóng"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Menu"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Lịch sử bài hát"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Tiếp tục phát ở chế độ nền"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "Giới thiệu Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Duyệt"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Yêu thích"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Thông tin đài"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "Đã tải %d đài"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Lỗi: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Lỗi phát: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Đang phát: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Tiếp tục: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Hủy ủy quyền Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Ngắt kết nối Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Kết nối Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Đã hủy ủy quyền Last.fm"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Đã ngắt kết nối Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Đang kết nối Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Không thể kết nối Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Cấp quyền truy cập trong trình duyệt…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Ủy quyền Last.fm đã hết hạn"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Đã kết nối Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr ""
 "Khám phá hơn 30.000 đài phát thanh đã xác minh từ khắp nơi trên thế giới"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Không có yêu thích"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Đánh dấu sao các đài khi duyệt để thêm vào đây"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Tìm đài…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Tất cả ngôn ngữ"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Lọc theo ngôn ngữ"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tất cả quốc gia"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Lọc theo quốc gia"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Không có đài"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Đang tải…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d đài"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Đài: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Đang tải các đài"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Không có kết quả"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Vui lòng đợi…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Không có đài nào khớp với tìm kiếm của bạn"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Không thể tải các đài"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Đài"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Quốc gia"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Thẻ"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Trang web"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Tốc độ bit"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL luồng phát"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Không phát"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Chọn một đài"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Đang đệm…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Đang phát"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "Tạm dừng"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Đang kết nối lại…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Đang tìm trên YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Tìm kiếm thất bại: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Không tìm thấy kết quả YouTube"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tất cả kết quả không khả dụng"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Đang tải: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Đã hủy"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Tải thất bại: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Đã lưu: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Tải bài hát"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Hủy tải"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Chưa có bài hát nào"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "Bài hát sẽ xuất hiện tại đây khi bạn nghe các đài phát thanh"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Vừa xong"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d phút trước"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d giờ trước"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/wa.po
+++ b/po/wa.po
@@ -3,313 +3,311 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: wa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver continouwe a djouwer li radio après ki l' purnea est sere"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "Mino"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "Istwere des tchansons"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "Continouwer a djouwer e fond"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "A prépo di Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "Foyter"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "Préferés"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "Informåcions del ståcion"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ståcions tcherdjîyes"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "Aroke: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "Aroke di djowaedje: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "Djowe asteure: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ricminçaedje: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "Discandjî l'ôtorisåcion di Last.fm"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "Si disconyî di Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "Si conyî a Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "L'ôtorisåcion di Last.fm a stî discandjêye"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "Discovî di Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "Conexion a Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "Nén polou si conyî a Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "Dunez l'accès dins vosse betchteu…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "L'ôtorisåcion di Last.fm a expîré"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "Covî a Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Discovroz pus di 30 000 ståcions di radio verifieyes del monde etire"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "Nén préferé"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "Metoz des steûles so lesståcions tot foyant po lès radjouter chal"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "Cweri des ståcions…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "Totes les lingaedjes"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "Filtrer pa lingaedje"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "Tos les payis"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "Filtrer pa payis"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "Nole ståcion"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "Tcherdjaedje…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u so %d ståcions"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "Ståcions: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "Tcherdjaedje des ståcions"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "Nol rezultat"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "Ratindez s' i vs plait…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "Nole ståcion n' corespond a vosse cweraedje"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "Dji n' a nén polou tcherdji les ståcions"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "Ståcion"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "Payis"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "Etiketes"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "Wèb"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "Codec"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "URL do flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "Ne djowe nén"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "Tchoezixhoz one ståcion"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "Tchedjant…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "Djowe asteure"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "A l' påze"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "Riconecsion…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "Cweraedje so YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "Li cweraedje a raté: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "Nol rezultat YouTube trovê"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "Tos les rezultats nén disponibes"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "Distcherdjaedje: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "Disfwait"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "Li distcherdjaedje a raté: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "Schapé: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "Distcherdji li tchanson"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "Disfé li distcherdjaedje"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "Nole tchanson pol moumint"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr ""
 "Les tchansons aparexhront vaici tins k'vos ascoutez des ståcions di radio"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "Ossu"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "i gn a %d min."
 msgstr[1] "i gn a %d min."
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "i gn a %d eure"
 msgstr[1] "i gn a %d eures"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/wa.po
+++ b/po/wa.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: wa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver continouwe a djouwer li radio après ki l' purnea est sere"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "Mino"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "Istwere des tchansons"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "Continouwer a djouwer e fond"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "A prépo di Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "Foyter"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "Préferés"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "Informåcions del ståcion"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d ståcions tcherdjîyes"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "Aroke: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "Aroke di djowaedje: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "Djowe asteure: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "Ricminçaedje: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "Discandjî l'ôtorisåcion di Last.fm"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "Si disconyî di Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "Si conyî a Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "L'ôtorisåcion di Last.fm a stî discandjêye"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "Discovî di Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "Conexion a Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "Nén polou si conyî a Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "Dunez l'accès dins vosse betchteu…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "L'ôtorisåcion di Last.fm a expîré"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "Covî a Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "Discovroz pus di 30 000 ståcions di radio verifieyes del monde etire"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "Metoz des steûles so lesståcions tot foyant po lès radjouter chal"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "Cweri des ståcions…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "Totes les lingaedjes"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "Filtrer pa lingaedje"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "Tos les payis"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "Filtrer pa payis"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "Nole ståcion"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "Tcherdjaedje…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u so %d ståcions"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "Ståcions: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "Tcherdjaedje des ståcions"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "Nol rezultat"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "Ratindez s' i vs plait…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "Nole ståcion n' corespond a vosse cweraedje"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "Dji n' a nén polou tcherdji les ståcions"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "URL do flux"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "Ne djowe nén"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "Tchoezixhoz one ståcion"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "Tchedjant…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "Djowe asteure"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "A l' påze"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "Riconecsion…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "Djowe asteure"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/yi.po
+++ b/po/yi.po
@@ -3,312 +3,310 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: yi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "Receiver שפּילט װײַטער ראַדיאָ נאָכן פֿאַרמאַכן דעם פֿענצטער"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "מעניו"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "ליד געשיכטע"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "שפּיל װײַטער אין הינטערגרונט"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "וועגן Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "בלעטערן"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "באליבטע"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "סטאנציע אינפארמאציע"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d סטאנציעס אַריינגעלאָדן"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "גרייז: %s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "שפּיל-גרייז: %s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "שפּילט איצט: %s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "פֿאָרזעצן: %s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "אנולירן Last.fm דערלויבעניש"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "אפּטרענען פֿון Last.fm"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "פֿאַרבינדן מיט Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm דערלויבעניש אנולירט"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "אפּגעטרענט פֿון Last.fm"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "פֿאַרבינדן מיט Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "קען נישט פֿאַרבינדן מיט Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "גיט צוטריט אין אייער בלעטערער…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm דערלויבעניש צייט אויסגעגאנגען"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "פֿאַרבונדן מיט Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "אנטדעקט מער ווי 30,000 באַשטעטיקטע ראַדיאָ סטאַנציעס פֿון אַרום דער וועלט"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "קיין באליבטע"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "שטערנט סטאנציעס בעת בלעטערן צו מוסיף זיין זיי דא"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "זוכן סטאנציעס…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "אַלע שפּראַכן"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "פֿילטער לויט שפּראַך"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "אלע לענדער"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "פילטער לויט לאנד"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "קיין סטאנציעס"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "לאָדן…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u פֿון %d סטאנציעס"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "סטאנציעס: %d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "לאָדן סטאנציעס"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "קיין רעזולטאַטן"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "ביטע וואַרט…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "קיין סטאנציעס פּאַסן צו אייער זוכן"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "קען נישט לאָדן סטאנציעס"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "סטאנציע"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "לאנד"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "טעגס"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "וועבזייטל"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "קאדעק"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "ביטרייט"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "סטרים URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "שפּילט נישט"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "קלייבט אַ סטאנציע"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "באַפערן…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "שפּילט איצט"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "געפּויזט"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "פֿאַרבינדן ווידער…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "זוכן אויף YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "זוכן דורכגעפֿאַלן: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "קיין YouTube-רעזולטאַטן געפֿונען"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "אַלע רעזולטאַטן נישט פֿאַראַנען"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "אַראָפּלאָדן: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "אָפּגעזאָגט"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "אַראָפּלאָדן דורכגעפֿאַלן: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "אָפּגעהיט: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "אַראָפּלאָדן ליד"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "אָפּזאָגן אַראָפּלאָדן"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "נאָך קיין לידער"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "לידער וועלן אויפטרעטן דאָ ווען איר הערט ראַדיאָ סטאַנציעס"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "אָט אָט"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d מינוט צוריק"
 msgstr[1] "%d מינוטן צוריק"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d שעה צוריק"
 msgstr[1] "%d שעות צוריק"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/yi.po
+++ b/po/yi.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: yi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "Receiver שפּילט װײַטער ראַדיאָ נאָכן פֿאַרמאַכן דעם פֿענצטער"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "מעניו"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "ליד געשיכטע"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "שפּיל װײַטער אין הינטערגרונט"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "וועגן Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "בלעטערן"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "באליבטע"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "סטאנציע אינפארמאציע"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "%d סטאנציעס אַריינגעלאָדן"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "גרייז: %s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "שפּיל-גרייז: %s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "שפּילט איצט: %s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "פֿאָרזעצן: %s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "אנולירן Last.fm דערלויבעניש"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "אפּטרענען פֿון Last.fm"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "פֿאַרבינדן מיט Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm דערלויבעניש אנולירט"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "אפּגעטרענט פֿון Last.fm"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "פֿאַרבינדן מיט Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "קען נישט פֿאַרבינדן מיט Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "גיט צוטריט אין אייער בלעטערער…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm דערלויבעניש צייט אויסגעגאנגען"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "פֿאַרבונדן מיט Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "אנטדעקט מער ווי 30,000 באַשטעטיקטע ראַדיאָ סטאַנציעס פֿון אַרום דער וועלט"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "שטערנט סטאנציעס בעת בלעטערן צו מוסיף זיין זיי דא"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "זוכן סטאנציעס…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "אַלע שפּראַכן"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "פֿילטער לויט שפּראַך"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "אלע לענדער"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "פילטער לויט לאנד"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "קיין סטאנציעס"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "לאָדן…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u פֿון %d סטאנציעס"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "סטאנציעס: %d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "לאָדן סטאנציעס"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "קיין רעזולטאַטן"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "ביטע וואַרט…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "קיין סטאנציעס פּאַסן צו אייער זוכן"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "קען נישט לאָדן סטאנציעס"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "סטרים URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "שפּילט נישט"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "קלייבט אַ סטאנציע"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "באַפערן…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "שפּילט איצט"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "געפּויזט"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "פֿאַרבינדן ווידער…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "שפּילט איצט"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "关闭窗口后 Receiver 仍会继续播放广播"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "菜单"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "歌曲历史"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "在后台继续播放"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "关于 Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "浏览"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "收藏"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "电台信息"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "已加载 %d 个电台"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "错误：%s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "播放错误：%s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "正在播放：%s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "恢复播放：%s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "取消 Last.fm 授权"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "断开 Last.fm 连接"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "连接到 Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 授权已取消"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "已断开 Last.fm 连接"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "正在连接 Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "无法连接到 Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "请在浏览器中授予访问权限…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 授权超时"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "已连接到 Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "发现来自世界各地的 30,000 多个经过验证的电台"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "无收藏"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "浏览时为电台加星标以添加到此处"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "搜索电台…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "所有语言"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "按语言筛选"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "所有国家"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "按国家筛选"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "无电台"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "正在加载…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 个电台"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "电台数：%d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "加载电台中"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "无结果"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "请稍候…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "未找到匹配的电台"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "无法加载电台"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "电台"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "国家"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "标签"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "网站"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "编解码器"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "比特率"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "流媒体 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "未播放"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "选择电台"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "正在缓冲…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "正在播放"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "正在重新连接…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "正在搜索 YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "搜索失败: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "未找到 YouTube 结果"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "所有结果均不可用"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "正在下载: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "已取消"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "下载失败: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "已保存: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "下载歌曲"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "取消下载"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "暂无歌曲"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "收听电台时，歌曲将显示在这里"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "刚刚"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d 分钟前"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d 小时前"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "关闭窗口后 Receiver 仍会继续播放广播"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "菜单"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "歌曲历史"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "在后台继续播放"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "关于 Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "浏览"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "收藏"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "电台信息"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "已加载 %d 个电台"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "错误：%s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "播放错误：%s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "正在播放：%s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "恢复播放：%s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "取消 Last.fm 授权"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "断开 Last.fm 连接"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "连接到 Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 授权已取消"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "已断开 Last.fm 连接"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "正在连接 Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "无法连接到 Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "请在浏览器中授予访问权限…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 授权超时"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "已连接到 Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "发现来自世界各地的 30,000 多个经过验证的电台"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "浏览时为电台加星标以添加到此处"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "搜索电台…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "所有语言"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "按语言筛选"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "所有国家"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "按国家筛选"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "无电台"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "正在加载…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 个电台"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "电台数：%d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "加载电台中"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "无结果"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "请稍候…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "未找到匹配的电台"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "无法加载电台"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "流媒体 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "未播放"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "选择电台"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "正在缓冲…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "正在播放"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "已暂停"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "正在重新连接…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "正在播放"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: zh_HK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "關閉視窗後 Receiver 仍會繼續播放電台"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "選單"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "歌曲歷史"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "在背景繼續播放"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "關於 Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "收藏"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "電台資訊"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "已載入 %d 個電台"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "錯誤：%s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "播放錯誤：%s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "正在播放：%s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "恢復中：%s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "取消 Last.fm 授權"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "連線至 Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 授權已取消"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "已中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "正在連線至 Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "無法連線至 Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "請在瀏覽器中授予存取權限…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 授權逾時"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "已連線至 Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "探索來自世界各地超過 30,000 個已驗證嘅電台"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "沒有收藏"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "瀏覽時為電台加星標以添加到此處"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "搜尋電台…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "所有語言"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "依語言篩選"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "所有國家"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "按國家篩選"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "無電台"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "載入中…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 個電台"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "電台數：%d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "載入電台中"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "無結果"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "請稍候…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "找不到符合的電台"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "無法載入電台"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "電台"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "國家"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "標籤"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "網站"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "編解碼器"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "位元率"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "串流 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "未播放"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "選擇電台"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "正在緩衝…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "正在播放"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "正在重新連線…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "正在搜尋 YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "搜尋失敗: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "未找到 YouTube 結果"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "所有結果均不可用"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "正在下載: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "已取消"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "下載失敗: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "已儲存: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "下載歌曲"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "取消下載"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "暫無歌曲"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "收聽電台時，歌曲將會顯示喺呢度"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "啱啱"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d 分鐘前"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d 小時前"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/po/zh_HK.po
+++ b/po/zh_HK.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: zh_HK\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "關閉視窗後 Receiver 仍會繼續播放電台"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "選單"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "歌曲歷史"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "在背景繼續播放"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "關於 Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "收藏"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "電台資訊"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "已載入 %d 個電台"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "錯誤：%s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "播放錯誤：%s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "正在播放：%s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "恢復中：%s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "取消 Last.fm 授權"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "連線至 Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 授權已取消"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "已中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "正在連線至 Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "無法連線至 Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "請在瀏覽器中授予存取權限…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 授權逾時"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "已連線至 Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "探索來自世界各地超過 30,000 個已驗證嘅電台"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "瀏覽時為電台加星標以添加到此處"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "搜尋電台…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "所有語言"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "依語言篩選"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "所有國家"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "按國家篩選"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "無電台"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "載入中…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 個電台"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "電台數：%d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "載入電台中"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "無結果"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "請稍候…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "找不到符合的電台"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "無法載入電台"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "串流 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "未播放"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "選擇電台"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "正在緩衝…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "正在播放"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "正在重新連線…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "正在播放"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3,108 +3,116 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-04-02 22:36+0200\n"
+"POT-Creation-Date: 2026-06-30 00:21+0200\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/widgets/window.vala:54
+#: src/application.vala:51
+msgid "Receiver keeps playing radio after the window is closed"
+msgstr "關閉視窗後 Receiver 仍會繼續播放電台"
+
+#: src/widgets/window.vala:65
 msgid "Menu"
 msgstr "選單"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:64 src/widgets/window.vala:120
+#: src/widgets/window.vala:75 src/widgets/window.vala:132
 #: src/widgets/history_page.vala:21
 msgid "Song History"
 msgstr "歌曲歷史"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala:76
+msgid "Keep Playing in Background"
+msgstr "在背景繼續播放"
+
+#: src/widgets/window.vala:77
 msgid "About Receiver"
 msgstr "關於 Receiver"
 
-#: src/widgets/window.vala:95
+#: src/widgets/window.vala:107
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/widgets/window.vala:99
+#: src/widgets/window.vala:111
 msgid "Favourites"
 msgstr "收藏"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:125 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
 msgid "Station Info"
 msgstr "電台資訊"
 
-#: src/widgets/window.vala:151
+#: src/widgets/window.vala:163
 #, c-format
 msgid "Loaded %d stations"
 msgstr "已載入 %d 個電台"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:156 src/services/song_downloader.vala:69
+#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
 #: src/services/song_downloader.vala:148
 #, c-format
 msgid "Error: %s"
 msgstr "錯誤：%s"
 
-#: src/widgets/window.vala:160
+#: src/widgets/window.vala:172
 #, c-format
 msgid "Playback error: %s"
 msgstr "播放錯誤：%s"
 
-#: src/widgets/window.vala:173
+#: src/widgets/window.vala:185
 #, c-format
 msgid "Now playing: %s"
 msgstr "正在播放：%s"
 
-#: src/widgets/window.vala:190
+#: src/widgets/window.vala:202
 #, c-format
 msgid "Resuming: %s"
 msgstr "恢復中：%s"
 
-#: src/widgets/window.vala:217
+#: src/widgets/window.vala:229
 msgid "Cancel Last.fm Authorization"
 msgstr "取消 Last.fm 授權"
 
-#: src/widgets/window.vala:219
+#: src/widgets/window.vala:231
 msgid "Disconnect from Last.fm"
 msgstr "中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:221
+#: src/widgets/window.vala:233
 msgid "Connect to Last.fm"
 msgstr "連線至 Last.fm"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala:241
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 授權已取消"
 
-#: src/widgets/window.vala:235
+#: src/widgets/window.vala:247
 msgid "Disconnected from Last.fm"
 msgstr "已中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:239
+#: src/widgets/window.vala:251
 msgid "Connecting to Last.fm…"
 msgstr "正在連線至 Last.fm…"
 
-#: src/widgets/window.vala:243
+#: src/widgets/window.vala:255
 msgid "Failed to connect to Last.fm"
 msgstr "無法連線至 Last.fm"
 
-#: src/widgets/window.vala:250
+#: src/widgets/window.vala:262
 msgid "Grant access in your browser…"
 msgstr "請在瀏覽器中授予存取權限…"
 
-#: src/widgets/window.vala:258
+#: src/widgets/window.vala:270
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 授權逾時"
 
-#: src/widgets/window.vala:266
+#: src/widgets/window.vala:278
 msgid "Connected to Last.fm"
 msgstr "已連線至 Last.fm"
 
-#: src/widgets/window.vala:287
+#: src/widgets/window.vala:299
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "探索來自世界各地超過 30,000 個已驗證的電台"
 
@@ -117,61 +125,61 @@ msgid "Star stations while browsing to add them here"
 msgstr "瀏覽時為電台加星標以新增至此"
 
 #. Search entry
-#: src/widgets/station_list.vala:44
+#: src/widgets/station_list.vala:46
 msgid "Search stations…"
 msgstr "搜尋電台…"
 
-#: src/widgets/station_list.vala:56 src/widgets/station_list.vala:228
+#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
 msgid "All Languages"
 msgstr "所有語言"
 
-#: src/widgets/station_list.vala:57
+#: src/widgets/station_list.vala:59
 msgid "Filter by language"
 msgstr "依語言篩選"
 
-#: src/widgets/station_list.vala:60 src/widgets/station_list.vala:241
+#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
 msgid "All Countries"
 msgstr "所有國家"
 
-#: src/widgets/station_list.vala:61
+#: src/widgets/station_list.vala:63
 msgid "Filter by country"
 msgstr "依國家篩選"
 
-#: src/widgets/station_list.vala:116 src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
 msgid "No Stations"
 msgstr "無電台"
 
-#: src/widgets/station_list.vala:189
+#: src/widgets/station_list.vala:203
 msgid "Loading…"
 msgstr "載入中…"
 
-#: src/widgets/station_list.vala:293
+#: src/widgets/station_list.vala:307
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 個電台"
 
-#: src/widgets/station_list.vala:294
+#: src/widgets/station_list.vala:308
 #, c-format
 msgid "Stations: %d"
 msgstr "電台數：%d"
 
-#: src/widgets/station_list.vala:306
+#: src/widgets/station_list.vala:320
 msgid "Loading Stations"
 msgstr "載入電台中"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala:321
 msgid "No Results"
 msgstr "無結果"
 
-#: src/widgets/station_list.vala:309
+#: src/widgets/station_list.vala:323
 msgid "Please wait…"
 msgstr "請稍候…"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "No stations match your search"
 msgstr "找不到符合的電台"
 
-#: src/widgets/station_list.vala:310
+#: src/widgets/station_list.vala:324
 msgid "Could not load stations"
 msgstr "無法載入電台"
 
@@ -204,25 +212,29 @@ msgid "Stream URL"
 msgstr "串流 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:209
+#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
 msgid "Not Playing"
 msgstr "未播放"
 
-#: src/widgets/player_bar.vala:138 src/widgets/player_bar.vala:212
+#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
 msgid "Select a station"
 msgstr "選擇電台"
 
-#: src/widgets/player_bar.vala:199
+#: src/widgets/player_bar.vala:179
+msgid "Buffering…"
+msgstr "正在緩衝…"
+
+#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+msgid "Now playing"
+msgstr "正在播放"
+
+#: src/widgets/player_bar.vala:210
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/widgets/player_bar.vala:204
+#: src/widgets/player_bar.vala:215
 msgid "Reconnecting…"
 msgstr "正在重新連線…"
-
-#: src/widgets/player_bar.vala:229
-msgid "Now playing"
-msgstr "正在播放"
 
 #. indeterminate while searching
 #: src/services/song_downloader.vala:28

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -3,310 +3,308 @@ msgid ""
 msgstr ""
 "Project-Id-Version: receiver\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-30 00:21+0200\n"
+"POT-Creation-Date: 2026-06-30 01:14+0200\n"
 "Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: src/application.vala:51
+#: src/application.vala
 msgid "Receiver keeps playing radio after the window is closed"
 msgstr "關閉視窗後 Receiver 仍會繼續播放電台"
 
-#: src/widgets/window.vala:65
+#: src/widgets/window.vala
 msgid "Menu"
 msgstr "選單"
 
 #. History page (pushed on demand)
-#: src/widgets/window.vala:75 src/widgets/window.vala:132
-#: src/widgets/history_page.vala:21
+#: src/widgets/window.vala src/widgets/history_page.vala
 msgid "Song History"
 msgstr "歌曲歷史"
 
-#: src/widgets/window.vala:76
+#: src/widgets/window.vala
 msgid "Keep Playing in Background"
 msgstr "在背景繼續播放"
 
-#: src/widgets/window.vala:77
+#: src/widgets/window.vala
 msgid "About Receiver"
 msgstr "關於 Receiver"
 
-#: src/widgets/window.vala:107
+#: src/widgets/window.vala
 msgid "Browse"
 msgstr "瀏覽"
 
-#: src/widgets/window.vala:111
+#: src/widgets/window.vala
 msgid "Favourites"
 msgstr "收藏"
 
 #. Station info page (pushed on demand)
-#: src/widgets/window.vala:137 src/widgets/station_info_page.vala:25
+#: src/widgets/window.vala src/widgets/station_info_page.vala
 msgid "Station Info"
 msgstr "電台資訊"
 
-#: src/widgets/window.vala:163
+#: src/widgets/window.vala
 #, c-format
 msgid "Loaded %d stations"
 msgstr "已載入 %d 個電台"
 
 #. User dismissed the dialog — no toast needed
-#: src/widgets/window.vala:168 src/services/song_downloader.vala:69
-#: src/services/song_downloader.vala:148
+#: src/widgets/window.vala src/services/song_downloader.vala
 #, c-format
 msgid "Error: %s"
 msgstr "錯誤：%s"
 
-#: src/widgets/window.vala:172
+#: src/widgets/window.vala
 #, c-format
 msgid "Playback error: %s"
 msgstr "播放錯誤：%s"
 
-#: src/widgets/window.vala:185
+#: src/widgets/window.vala
 #, c-format
 msgid "Now playing: %s"
 msgstr "正在播放：%s"
 
-#: src/widgets/window.vala:202
+#: src/widgets/window.vala
 #, c-format
 msgid "Resuming: %s"
 msgstr "恢復中：%s"
 
-#: src/widgets/window.vala:229
+#: src/widgets/window.vala
 msgid "Cancel Last.fm Authorization"
 msgstr "取消 Last.fm 授權"
 
-#: src/widgets/window.vala:231
+#: src/widgets/window.vala
 msgid "Disconnect from Last.fm"
 msgstr "中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:233
+#: src/widgets/window.vala
 msgid "Connect to Last.fm"
 msgstr "連線至 Last.fm"
 
-#: src/widgets/window.vala:241
+#: src/widgets/window.vala
 msgid "Last.fm authorization cancelled"
 msgstr "Last.fm 授權已取消"
 
-#: src/widgets/window.vala:247
+#: src/widgets/window.vala
 msgid "Disconnected from Last.fm"
 msgstr "已中斷 Last.fm 連線"
 
-#: src/widgets/window.vala:251
+#: src/widgets/window.vala
 msgid "Connecting to Last.fm…"
 msgstr "正在連線至 Last.fm…"
 
-#: src/widgets/window.vala:255
+#: src/widgets/window.vala
 msgid "Failed to connect to Last.fm"
 msgstr "無法連線至 Last.fm"
 
-#: src/widgets/window.vala:262
+#: src/widgets/window.vala
 msgid "Grant access in your browser…"
 msgstr "請在瀏覽器中授予存取權限…"
 
-#: src/widgets/window.vala:270
+#: src/widgets/window.vala
 msgid "Last.fm authorization timed out"
 msgstr "Last.fm 授權逾時"
 
-#: src/widgets/window.vala:278
+#: src/widgets/window.vala
 msgid "Connected to Last.fm"
 msgstr "已連線至 Last.fm"
 
-#: src/widgets/window.vala:299
+#: src/widgets/window.vala
 msgid "Discover 30,000+ verified radio stations from around the world"
 msgstr "探索來自世界各地超過 30,000 個已驗證的電台"
 
-#: src/widgets/favourites_page.vala:25
+#: src/widgets/favourites_page.vala
 msgid "No Favourites"
 msgstr "沒有收藏"
 
-#: src/widgets/favourites_page.vala:26
+#: src/widgets/favourites_page.vala
 msgid "Star stations while browsing to add them here"
 msgstr "瀏覽時為電台加星標以新增至此"
 
 #. Search entry
-#: src/widgets/station_list.vala:46
+#: src/widgets/station_list.vala
 msgid "Search stations…"
 msgstr "搜尋電台…"
 
-#: src/widgets/station_list.vala:58 src/widgets/station_list.vala:242
+#: src/widgets/station_list.vala
 msgid "All Languages"
 msgstr "所有語言"
 
-#: src/widgets/station_list.vala:59
+#: src/widgets/station_list.vala
 msgid "Filter by language"
 msgstr "依語言篩選"
 
-#: src/widgets/station_list.vala:62 src/widgets/station_list.vala:255
+#: src/widgets/station_list.vala
 msgid "All Countries"
 msgstr "所有國家"
 
-#: src/widgets/station_list.vala:63
+#: src/widgets/station_list.vala
 msgid "Filter by country"
 msgstr "依國家篩選"
 
-#: src/widgets/station_list.vala:130 src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Stations"
 msgstr "無電台"
 
-#: src/widgets/station_list.vala:203
+#: src/widgets/station_list.vala
 msgid "Loading…"
 msgstr "載入中…"
 
-#: src/widgets/station_list.vala:307
+#: src/widgets/station_list.vala
 #, c-format
 msgid "%u of %d stations"
 msgstr "%u / %d 個電台"
 
-#: src/widgets/station_list.vala:308
+#: src/widgets/station_list.vala
 #, c-format
 msgid "Stations: %d"
 msgstr "電台數：%d"
 
-#: src/widgets/station_list.vala:320
+#: src/widgets/station_list.vala
 msgid "Loading Stations"
 msgstr "載入電台中"
 
-#: src/widgets/station_list.vala:321
+#: src/widgets/station_list.vala
 msgid "No Results"
 msgstr "無結果"
 
-#: src/widgets/station_list.vala:323
+#: src/widgets/station_list.vala
 msgid "Please wait…"
 msgstr "請稍候…"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "No stations match your search"
 msgstr "找不到符合的電台"
 
-#: src/widgets/station_list.vala:324
+#: src/widgets/station_list.vala
 msgid "Could not load stations"
 msgstr "無法載入電台"
 
-#: src/widgets/station_info_page.vala:48
+#: src/widgets/station_info_page.vala
 msgid "Station"
 msgstr "電台"
 
-#: src/widgets/station_info_page.vala:52
+#: src/widgets/station_info_page.vala
 msgid "Country"
 msgstr "國家"
 
-#: src/widgets/station_info_page.vala:56
+#: src/widgets/station_info_page.vala
 msgid "Tags"
 msgstr "標籤"
 
-#: src/widgets/station_info_page.vala:61
+#: src/widgets/station_info_page.vala
 msgid "Website"
 msgstr "網站"
 
-#: src/widgets/station_info_page.vala:66
+#: src/widgets/station_info_page.vala
 msgid "Codec"
 msgstr "編解碼器"
 
-#: src/widgets/station_info_page.vala:70
+#: src/widgets/station_info_page.vala
 msgid "Bitrate"
 msgstr "位元率"
 
-#: src/widgets/station_info_page.vala:74
+#: src/widgets/station_info_page.vala
 msgid "Stream URL"
 msgstr "串流 URL"
 
 #. Controls row
-#: src/widgets/player_bar.vala:70 src/widgets/player_bar.vala:220
+#: src/widgets/player_bar.vala
 msgid "Not Playing"
 msgstr "未播放"
 
-#: src/widgets/player_bar.vala:139 src/widgets/player_bar.vala:223
+#: src/widgets/player_bar.vala
 msgid "Select a station"
 msgstr "選擇電台"
 
-#: src/widgets/player_bar.vala:179
+#: src/widgets/player_bar.vala
 msgid "Buffering…"
 msgstr "正在緩衝…"
 
-#: src/widgets/player_bar.vala:182 src/widgets/player_bar.vala:240
+#: src/widgets/player_bar.vala
 msgid "Now playing"
 msgstr "正在播放"
 
-#: src/widgets/player_bar.vala:210
+#: src/widgets/player_bar.vala
 msgid "Paused"
 msgstr "已暫停"
 
-#: src/widgets/player_bar.vala:215
+#: src/widgets/player_bar.vala
 msgid "Reconnecting…"
 msgstr "正在重新連線…"
 
 #. indeterminate while searching
-#: src/services/song_downloader.vala:28
+#: src/services/song_downloader.vala
 msgid "Searching YouTube…"
 msgstr "正在搜尋 YouTube…"
 
-#: src/services/song_downloader.vala:42
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Search failed: %s"
 msgstr "搜尋失敗: %s"
 
-#: src/services/song_downloader.vala:48
+#: src/services/song_downloader.vala
 msgid "No YouTube results found"
 msgstr "未找到 YouTube 結果"
 
-#: src/services/song_downloader.vala:62
+#: src/services/song_downloader.vala
 msgid "All results unavailable"
 msgstr "所有結果均不可用"
 
-#: src/services/song_downloader.vala:94
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Downloading: %s"
 msgstr "正在下載: %s"
 
 #. Clean up partial file
-#: src/services/song_downloader.vala:131
+#: src/services/song_downloader.vala
 msgid "Cancelled"
 msgstr "已取消"
 
-#: src/services/song_downloader.vala:140
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Download failed: %s"
 msgstr "下載失敗: %s"
 
-#: src/services/song_downloader.vala:142
+#: src/services/song_downloader.vala
 #, c-format
 msgid "Saved: %s"
 msgstr "已儲存: %s"
 
-#: src/widgets/download_button.vala:30
+#: src/widgets/download_button.vala
 msgid "Download song"
 msgstr "下載歌曲"
 
-#: src/widgets/download_button.vala:45
+#: src/widgets/download_button.vala
 msgid "Cancel download"
 msgstr "取消下載"
 
-#: src/widgets/history_page.vala:31
+#: src/widgets/history_page.vala
 msgid "No Songs Yet"
 msgstr "尚無歌曲"
 
-#: src/widgets/history_page.vala:32
+#: src/widgets/history_page.vala
 msgid "Songs will appear here as you listen to radio stations"
 msgstr "收聽電台時，歌曲將會顯示在這裡"
 
-#: src/widgets/history_page.vala:150
+#: src/widgets/history_page.vala
 msgid "Just now"
 msgstr "剛剛"
 
-#: src/widgets/history_page.vala:151
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d min ago"
 msgid_plural "%d min ago"
 msgstr[0] "%d 分鐘前"
 
-#: src/widgets/history_page.vala:152
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d hour ago"
 msgid_plural "%d hours ago"
 msgstr[0] "%d 小時前"
 
-#: src/widgets/history_page.vala:153
+#: src/widgets/history_page.vala
 #, c-format
 msgid "%d day ago"
 msgid_plural "%d days ago"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: receiver
 base: core24
-version: '0.5.0'
+version: '0.6.0'
 title: Receiver
 summary: 30,000+ verified radio stations
 description: |


### PR DESCRIPTION
Prepares the **v0.6.0** release.

## Version bump (4 files)
`meson.build`, `snap/snapcraft.yaml`, `debian/changelog`, `data/io.github.meehow.Receiver.metainfo.xml` → 0.6.0 (new changelog + metainfo `<release>` entries dated 2026-06-30).

## Release notes
- Add a terminal UI (`receiver-tui`): browse and play, Favourites and History, country/language filters, search, MPRIS media keys, mouse support.
- Keep playing in the background when the window is closed (optional; menu toggle).
- Fix missing favourite and tab icons on the .deb and AppImage (#17).
- Smoother playback of high-bitrate streams (pause while buffering).
- Consistent cubic volume curve + player-bar title alignment.
- Load artwork even when the list is too short to scroll.
- Reserve scrollbar height in the genre strip with classic scrollbars.

## Translations
Added `src/application.vala` to `po/POTFILES` and translated the new strings ("Keep Playing in Background", the background portal reason, "Buffering…") across all 126 catalogs. `ru.po` is left as the intentional symlink to `uk.po`. All catalogs are `msgfmt -c` clean with 0 untranslated / 0 fuzzy.

## Verified
- `appstreamcli validate` on the metainfo: success.
- Build clean; `0.6.0` baked into the binary.

## Notes / not in this PR
- `receiver-tui` ships in deb/flatpak/snap (the `tui` option defaults on) — intended, advertised above.
- Pre-existing `desktop-file-validate` warning: `Categories=Audio;…` should be paired with `AudioVideo` ("will be fatal in the future") — left as-is to avoid changing app categorization; worth a follow-up.

## Release sequence after merge
1. Merge `ci/appimage-icon-deps` first (installs the icon themes on the AppImage CI runner — completes the #17 fix for the released AppImage).
2. Merge this PR.
3. Tag `v0.6.0` on master and push the tag → CI builds the .deb + AppImage and creates the GitHub (pre)release.
