### PR TITLE
feat: launch receiver-tui from snap/AppImage + document it

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,17 @@ sudo apt install ./receiver_*.deb
 ### From source
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for build instructions and development setup.
+
+## Terminal UI
+
+Receiver also ships `receiver-tui`, an ncurses terminal client that shares the
+same station database and playback engine as the desktop app. How you launch it
+depends on how Receiver is installed:
+
+| Install method | Command |
+| --- | --- |
+| Flatpak | `flatpak run --command=receiver-tui io.github.meehow.Receiver` |
+| Snap | `receiver.receiver-tui` |
+| Debian / Ubuntu | `receiver-tui` |
+| AppImage | `./Receiver-*.AppImage --tui` |
+| From source | `make run-tui` |

--- a/data/appimage/receiver-env.sh
+++ b/data/appimage/receiver-env.sh
@@ -23,3 +23,10 @@ unset GDK_BACKEND
 # Unset GTK_THEME — Libadwaita manages its own stylesheet
 # Setting GTK_THEME conflicts with AdwStyleManager
 unset GTK_THEME
+
+# Launch the bundled terminal UI with `./Receiver-*.AppImage --tui`.
+# The receiver-tui binary ships in the same AppDir and reuses the env above.
+if [ "${1:-}" = "--tui" ]; then
+    shift
+    exec "${APPDIR}/usr/bin/receiver-tui" "$@"
+fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,14 @@ apps:
       - desktop
     slots:
       - receiver-mpris
+  receiver-tui:
+    command: usr/bin/receiver-tui
+    extensions: [gnome]
+    environment:
+      GIO_USE_PROXY_RESOLVER: gnome
+    plugs:
+      - network
+      - audio-playback
 
 layout:
   /usr/share/receiver:


### PR DESCRIPTION
Makes the terminal client reachable from every install method and documents it.

- **snap**: new `receiver-tui` app → `receiver.receiver-tui`
- **AppImage**: `./Receiver-*.AppImage --tui` runs the bundled `receiver-tui` (no separate AppImage; binary + deps already in the AppDir, via an AppRun hook dispatch)
- **README**: new Terminal UI section with the per-method launch command

Already worked before this PR: `flatpak run --command=receiver-tui …`, the deb's `receiver-tui`, and `make run-tui`.

Note: the AppImage `--tui` path and the snap app need a CI/store build to verify end-to-end.